### PR TITLE
trackingLST modifier to enable LST via cmsDriver

### DIFF
--- a/Configuration/ProcessModifiers/python/trackingIters01_cff.py
+++ b/Configuration/ProcessModifiers/python/trackingIters01_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+# This modifier sets the iterative tracking to use a minimal set of iterations, first two
+trackingIters01 = cms.Modifier()

--- a/Configuration/ProcessModifiers/python/trackingLST_cff.py
+++ b/Configuration/ProcessModifiers/python/trackingLST_cff.py
@@ -1,0 +1,5 @@
+import FWCore.ParameterSet.Config as cms
+
+# This modifier sets the LST (Phase-2 line segment tracking) used for track building
+trackingLST = cms.Modifier()
+

--- a/RecoTracker/ConversionSeedGenerators/python/ConversionStep_cff.py
+++ b/RecoTracker/ConversionSeedGenerators/python/ConversionStep_cff.py
@@ -33,6 +33,12 @@ trackingPhase2PU140.toReplaceWith(convClusters, _phase2trackClusterRemover.clone
     oldClusterRemovalInfo                    = 'detachedQuadStepClusters',
     overrideTrkQuals                         = 'detachedQuadStepSelector:detachedQuadStepTrk'
 ))
+from Configuration.ProcessModifiers.trackingIters01_cff import trackingIters01
+trackingIters01.toModify(convClusters,
+                         trajectories          = "highPtTripletStepTracks",
+                         oldClusterRemovalInfo = "highPtTripletStepClusters",
+                         overrideTrkQuals      = "highPtTripletStepSelector:highPtTripletStep"
+)
 
 _convLayerPairsStripOnlyLayers = ['TIB1+TID1_pos', 
                                  'TIB1+TID1_neg', 

--- a/RecoTracker/FinalTrackSelectors/python/MergeTrackCollections_cff.py
+++ b/RecoTracker/FinalTrackSelectors/python/MergeTrackCollections_cff.py
@@ -16,6 +16,8 @@ duplicateTrackCandidates = DuplicateTrackMerger.clone(
     ttrhBuilderName   = "WithAngleAndTemplate",
     chi2EstimatorName = "duplicateTrackCandidatesChi2Est"
 )
+from Configuration.ProcessModifiers.trackingIters01_cff import trackingIters01
+trackingIters01.toModify(duplicateTrackCandidates, source = "earlyGeneralTracks")
 
 import RecoTracker.TrackProducer.TrackProducer_cfi
 mergedDuplicateTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
@@ -42,6 +44,10 @@ generalTracks = DuplicateListMerger.clone(
     mergedMVAVals       = "duplicateTrackClassifier:MVAValues",
     candidateSource     = "duplicateTrackCandidates:candidates",
     candidateComponents = "duplicateTrackCandidates:candidateMap"
+)
+trackingIters01.toModify(generalTracks,
+                         originalSource = "earlyGeneralTracks",
+                         originalMVAVals = "earlyGeneralTracks:MVAValues"
 )
 
 generalTracksTask = cms.Task(

--- a/RecoTracker/FinalTrackSelectors/python/earlyGeneralTracks_cfi.py
+++ b/RecoTracker/FinalTrackSelectors/python/earlyGeneralTracks_cfi.py
@@ -107,6 +107,16 @@ trackingPhase2PU140.toReplaceWith(earlyGeneralTracks, _trackListMerger.clone(
     makeReKeyedSeeds = cms.untracked.bool(False)
     )
 )
+from Configuration.ProcessModifiers.trackingIters01_cff import trackingIters01
+trackingIters01.toModify(earlyGeneralTracks,
+                         TrackProducers = ['initialStepTracks', 'highPtTripletStepTracks'],
+                         hasSelector = [1,1],
+                         indivShareFrac = [1,0.16],
+                         selectedTrackQuals = ['initialStepSelector:initialStep',
+                                               'highPtTripletStepSelector:highPtTripletStep'
+                         ],
+                         setsToMerge = {0: dict(tLists = [0,1])}
+)
 from Configuration.ProcessModifiers.vectorHits_cff import vectorHits
 def _extend_pixelLess(x):
     x.TrackProducers += ['pixelLessStepTracks']

--- a/RecoTracker/FinalTrackSelectors/python/earlyGeneralTracks_cfi.py
+++ b/RecoTracker/FinalTrackSelectors/python/earlyGeneralTracks_cfi.py
@@ -116,3 +116,14 @@ def _extend_pixelLess(x):
     x.setsToMerge[0].tLists += [6]
 (trackingPhase2PU140 & vectorHits).toModify(earlyGeneralTracks, _extend_pixelLess)
 
+def _dropIter(mod, iteration):
+     mod.TrackProducers.pop(iteration)
+     mod.hasSelector.pop(iteration)
+     mod.indivShareFrac.pop(iteration)
+     mod.selectedTrackQuals.pop(iteration)
+     mod.setsToMerge[0].tLists.pop(iteration)
+
+from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
+# remove initialStep from earlyGeneralTracks inputs
+(trackingPhase2PU140 & trackingLST).toModify(earlyGeneralTracks, func=lambda x:_dropIter(x,0))
+(trackingPhase2PU140 & trackingLST).toModify(earlyGeneralTracks, indivShareFrac = {0:  1})

--- a/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
@@ -259,6 +259,10 @@ trackingPhase2PU140.toModify(highPtTripletStepTrackCandidates,
     phase2clustersToSkip = 'highPtTripletStepClusters'
 )
 
+from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
+from RecoTracker.LST.lstOutputConverter_cfi import lstOutputConverter as _lstOutputConverter
+(trackingPhase2PU140 & trackingLST).toReplaceWith(highPtTripletStepTrackCandidates, _lstOutputConverter.clone())
+
 #For FastSim phase1 tracking 
 import FastSimulation.Tracking.TrackCandidateProducer_cfi
 _fastSim_highPtTripletStepTrackCandidates = FastSimulation.Tracking.TrackCandidateProducer_cfi.trackCandidateProducer.clone(
@@ -375,6 +379,14 @@ _HighPtTripletStepTask_Phase2PU140 = HighPtTripletStepTask.copy()
 _HighPtTripletStepTask_Phase2PU140.replace(highPtTripletStep, highPtTripletStepSelector)
 _HighPtTripletStep_Phase2PU140 = cms.Sequence(_HighPtTripletStepTask_Phase2PU140)
 trackingPhase2PU140.toReplaceWith(HighPtTripletStepTask, _HighPtTripletStepTask_Phase2PU140)
+
+_HighPtTripletStepTask_LST = HighPtTripletStepTask.copy()
+from RecoLocalTracker.Phase2TrackerRecHits.Phase2TrackerRecHits_cfi import siPhase2RecHits
+from RecoTracker.LST.lstPixelSeedInputProducer_cfi import lstPixelSeedInputProducer
+from RecoTracker.LST.lstPhase2OTHitsInputProducer_cfi import lstPhase2OTHitsInputProducer
+from RecoTracker.LST.alpaka_cuda_asyncLSTProducer_cfi import alpaka_cuda_asyncLSTProducer as lstProducer
+_HighPtTripletStepTask_LST.add(siPhase2RecHits, lstPixelSeedInputProducer, lstPhase2OTHitsInputProducer, lstProducer)
+(trackingPhase2PU140 & trackingLST).toReplaceWith(HighPtTripletStepTask, _HighPtTripletStepTask_LST)
 
 # fast tracking mask producer 
 from FastSimulation.Tracking.FastTrackerRecHitMaskProducer_cfi import maskProducerFromClusterRemover

--- a/RecoTracker/IterativeTracking/python/LowPtQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtQuadStep_cff.py
@@ -14,6 +14,9 @@ lowPtQuadStepClusters = _cfg.clusterRemoverForIter('LowPtQuadStep')
 for _eraName, _postfix, _era in _cfg.nonDefaultEras():
     _era.toReplaceWith(lowPtQuadStepClusters, _cfg.clusterRemoverForIter('LowPtQuadStep', _eraName, _postfix))
 
+from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
+# with LST, this is the first iteration with proper cluster masking
+trackingLST.toModify(lowPtQuadStepClusters, oldClusterRemovalInfo = "")
 
 # SEEDING LAYERS
 import RecoTracker.TkSeedingLayers.PixelLayerQuadruplets_cfi

--- a/RecoTracker/IterativeTracking/python/iterativeTkConfig.py
+++ b/RecoTracker/IterativeTracking/python/iterativeTkConfig.py
@@ -53,25 +53,33 @@ displacedTracking.toModify(_iterations_trackingPhase1, func=lambda x: x.append('
 
 _iterations_trackingPhase1.append('JetCoreRegionalStep')
 
-_iterations_trackingPhase2PU140 = [
+_iterations_trackingPhase2PU140_VS = cms.PSet(names = cms.vstring(
     "InitialStep",
     "HighPtTripletStep",
     "LowPtQuadStep",
     "LowPtTripletStep",
     "DetachedQuadStep",
     "PixelPairStep",
-]
+))
 from Configuration.ProcessModifiers.vectorHits_cff import vectorHits
-vectorHits.toModify(_iterations_trackingPhase2PU140, func=lambda x: x.append('PixelLessStep'))
+vectorHits.toModify(_iterations_trackingPhase2PU140_VS.names, func=lambda x: x.append('PixelLessStep'))
+from Configuration.ProcessModifiers.trackingIters01_cff import trackingIters01
+trackingIters01.toModify(_iterations_trackingPhase2PU140_VS, names = ["InitialStep", "HighPtTripletStep"])
+# apply all procModifiers before this
+_iterations_trackingPhase2PU140 = _iterations_trackingPhase2PU140_VS.names.value()
+
 _iterations_muonSeeded = [
     "MuonSeededStepInOut",
     "MuonSeededStepOutIn",
 ]
 #Phase2
-_iterations_muonSeeded_trackingPhase2PU140 = [
+_iterations_muonSeeded_trackingPhase2PU140_VS = cms.PSet(names = cms.vstring(
     "MuonSeededStepInOut",
     "MuonSeededStepOutIn",
-]
+))
+trackingIters01.toModify(_iterations_muonSeeded_trackingPhase2PU140_VS, names = [])
+_iterations_muonSeeded_trackingPhase2PU140 = _iterations_muonSeeded_trackingPhase2PU140_VS.names.value()
+
 _multipleSeedProducers = {
     "MixedTripletStep": ["A", "B"],
     "TobTecStep": ["Pair", "Tripl"],

--- a/RecoTracker/LST/plugins/BuildFile.xml
+++ b/RecoTracker/LST/plugins/BuildFile.xml
@@ -1,7 +1,9 @@
 <!-- host-only plugins -->
 <library file="*.cc" name="RecoTrackerLSTPlugins">
   <use name="DataFormats/TrackCandidate"/>
+  <use name="DataFormats/TrackReco"/>
   <use name="DataFormats/TrackerRecHit2D"/>
+  <use name="DataFormats/TrajectorySeed"/>
   <use name="FWCore/Framework"/>
   <use name="FWCore/ParameterSet"/>
   <use name="FWCore/Utilities"/>


### PR DESCRIPTION
- `trackingLST` modifier and its initial use to enable LST as a replacement to the highPt triplet step building
    - the initialStep tracks are only virtual (not used in the generalTracks); the initialStep cluster masks are used only in highPtTriplet step seeding
    - eventually this setup can be combined/compared with pixel tracks from patatrack replacing seeding from the initial and highPtTriplet steps
- added `SeedStopInfo` output to the `LSTOutputConverter` mainly to keep DQM running; the info is currently dummy (an empty vector)

Can be tested with `--procModifiers gpu,trackingLST` combined with `trackingOnly` setup.

Here are some results with PU for `allTracks` (aka `generalTracks`) for 100 events in ttbar without PU
<img width="500" alt="image" src="https://user-images.githubusercontent.com/4676718/220371381-d039f263-8193-4b01-b805-27a0c5dddb37.png">
<img width="500" alt="image" src="https://user-images.githubusercontent.com/4676718/220371509-d7ad8844-271f-4333-a909-f9f891137032.png">
all plots are in http://uaf-10.t2.ucsd.edu/~slava77/figs/lst/CMSSW_13_0_0_pre4-lst12/mtv-oob-trackingLST-rmIS-mask-8c1d76e/

The comparisons are for:
- default phase-2 tracking (blue)
- LST replacing the highPtTriplet while initialStep tracks are still used (red)
    - the "to be virtualized" initialStep tracks contribute redundantly, efficiency is high
- as above, with initialStep tracks removed from merged generalTracks collection (black)
    - only LST is now covering for what was initialStep and highPtTriplet, BUT the cluster masks are still as if the initialStep was there; this does not allow the following iterations to recover
- LST replacing the highPtTriplet and initialStep including cluster masks (orange)
    - the efficiency now recovers to roughly the baseline
    - the fake rate is about the same
    - the duplicate rate goes up significantly, primarily in endcaps where the pixel (IT) part of LST is using only 3 or 4 layers out of more possibly available: these are found again by later iterations. 

TODO: 
- tune duplicate merging
- make a tracking configuration with just the initialStep and highPtTriplet iterations as a reference







