### PR TITLE
load T5 TCs and make seeds for them on the fly

### DIFF
--- a/RecoTracker/LST/plugins/BuildFile.xml
+++ b/RecoTracker/LST/plugins/BuildFile.xml
@@ -7,9 +7,14 @@
   <use name="FWCore/Framework"/>
   <use name="FWCore/ParameterSet"/>
   <use name="FWCore/Utilities"/>
+  <use name="Geometry/TrackerGeometryBuilder"/>
   <use name="MagneticField/Engine"/>
+  <use name="MagneticField/Records"/>
   <use name="RecoTracker/LST"/>
+  <use name="RecoTracker/TkSeedingLayers"/>
   <use name="RecoTracker/TkSeedGenerator"/>
+  <use name="TrackingTools/Records"/>
+  <use name="TrackingTools/GeomPropagators"/>
   <use name="TrackingTools/Records"/>
   <use name="TrackingTools/TrajectoryState"/>
   <use name="TrackingTools/TransientTrackingRecHit"/>

--- a/RecoTracker/LST/plugins/LSTOutputConverter.cc
+++ b/RecoTracker/LST/plugins/LSTOutputConverter.cc
@@ -157,7 +157,7 @@ void LSTOutputConverter::produce(edm::StreamID, edm::Event& iEvent, const edm::E
       int nHits = 0;
       for (auto const& hit : recHits) {
         auto hType = tracker.getDetectorType(hit.geographicalId());
-        if (hType != TrackerGeometry::ModuleType::Ph2PSP && nHits <= 2)
+        if (hType != TrackerGeometry::ModuleType::Ph2PSP && nHits < 2)
           continue; // the first two should be P
         hitsFromT5.emplace_back(dynamic_cast<Hit>(&hit));
         nHits++;


### PR DESCRIPTION
T5s are added 
- the seed (`TrajectorySeed`) is made using `SeedFromConsecutiveHitsCreator` (all 10 hits at this point); the seed state is defined on the last hit.
- the `TrackCandidate` state is just a propagation of the seed to the first hit
- most of the code was already there, it just needed a few relatively minor cleanups.

As of e2cff6df: on 100 events I observe that only about 96% of T5s are converted to `TrackCandidate`. Most of the inefficiency is due to failed seed making with a minor additional loss from fairly poor seed state parameters 

all preliminary plots (as of e2cff6df; **READ TO THE END** to see the final performance) are in http://uaf-10.t2.ucsd.edu/~slava77/figs/lst/CMSSW_13_0_0_pre4-lst12/mtv-oob-trackingLST-Iters01-T5-e2cff6d/plots_ootb.html
this is for ttbar WITHOUT PU (100 events)

<img width="797" alt="image" src="https://user-images.githubusercontent.com/4676718/220672801-26790a63-7abf-4d9f-aba1-c8df00bf51a8.png">
black -> orange is the impact of this PR on tracking with LST as of e2cff6df.

---
As of a16ef33: on 100 events all T5s are converted to `TrackCandidate` and the efficiency is up wrt e2cff6df by a couple %.
In this commit (33e94a6), the requirement that the first two hits are on P layers is added.
The `SeedFromConsecutiveHitsCreator` relies on the first two hits to make the initial kinematics estimate.

all plots are in http://uaf-10.t2.ucsd.edu/~slava77/figs/lst/CMSSW_13_0_0_pre4-lst12/mtv-oob-trackingLST-Iters01-T5-2P-a16ef33/
<img width="792" alt="image" src="https://user-images.githubusercontent.com/4676718/220887746-6121e9c0-b3c4-4d64-ab62-0ca109bcc5b0.png">
black -> orange is the impact of this PR on tracking with LST as of a16ef33 (the last commit).

