### PR TITLE
Sync with standalone developments and options for the LSTOutputConverter

### DIFF
--- a/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
@@ -382,12 +382,12 @@ trackingPhase2PU140.toReplaceWith(HighPtTripletStepTask, _HighPtTripletStepTask_
 
 _HighPtTripletStepTask_LST = HighPtTripletStepTask.copy()
 from RecoLocalTracker.Phase2TrackerRecHits.Phase2TrackerRecHits_cfi import siPhase2RecHits
-from RecoTracker.LST.lstSeedTracks_cfi import initialStepSeedTracks,highPtTripletStepSeedTracks
+from RecoTracker.LST.lstSeedTracks_cfi import lstInitialStepSeedTracks,lstHighPtTripletStepSeedTracks
 from RecoTracker.LST.lstPixelSeedInputProducer_cfi import lstPixelSeedInputProducer
 from RecoTracker.LST.lstPhase2OTHitsInputProducer_cfi import lstPhase2OTHitsInputProducer
 from RecoTracker.LST.alpaka_cuda_asyncLSTProducer_cfi import alpaka_cuda_asyncLSTProducer
 lstProducer = alpaka_cuda_asyncLSTProducer.clone()
-_HighPtTripletStepTask_LST.add(siPhase2RecHits, initialStepSeedTracks, highPtTripletStepSeedTracks, lstPixelSeedInputProducer, lstPhase2OTHitsInputProducer, lstProducer)
+_HighPtTripletStepTask_LST.add(siPhase2RecHits, lstInitialStepSeedTracks, lstHighPtTripletStepSeedTracks, lstPixelSeedInputProducer, lstPhase2OTHitsInputProducer, lstProducer)
 (trackingPhase2PU140 & trackingLST).toReplaceWith(HighPtTripletStepTask, _HighPtTripletStepTask_LST)
 
 # fast tracking mask producer 

--- a/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
@@ -382,11 +382,12 @@ trackingPhase2PU140.toReplaceWith(HighPtTripletStepTask, _HighPtTripletStepTask_
 
 _HighPtTripletStepTask_LST = HighPtTripletStepTask.copy()
 from RecoLocalTracker.Phase2TrackerRecHits.Phase2TrackerRecHits_cfi import siPhase2RecHits
+from RecoTracker.LST.lstSeedTracks_cfi import initialStepSeedTracks,highPtTripletStepSeedTracks
 from RecoTracker.LST.lstPixelSeedInputProducer_cfi import lstPixelSeedInputProducer
 from RecoTracker.LST.lstPhase2OTHitsInputProducer_cfi import lstPhase2OTHitsInputProducer
 from RecoTracker.LST.alpaka_cuda_asyncLSTProducer_cfi import alpaka_cuda_asyncLSTProducer
 lstProducer = alpaka_cuda_asyncLSTProducer.clone()
-_HighPtTripletStepTask_LST.add(siPhase2RecHits, lstPixelSeedInputProducer, lstPhase2OTHitsInputProducer, lstProducer)
+_HighPtTripletStepTask_LST.add(siPhase2RecHits, initialStepSeedTracks, highPtTripletStepSeedTracks, lstPixelSeedInputProducer, lstPhase2OTHitsInputProducer, lstProducer)
 (trackingPhase2PU140 & trackingLST).toReplaceWith(HighPtTripletStepTask, _HighPtTripletStepTask_LST)
 
 # fast tracking mask producer 

--- a/RecoTracker/LST/interface/LSTOutput.h
+++ b/RecoTracker/LST/interface/LSTOutput.h
@@ -4,6 +4,8 @@
 #include <memory>
 #include <vector>
 
+enum LSTTCType { T5=4, pT3=5, pT5=7, pLS=8 };
+
 class LSTOutput {
 public:
   LSTOutput() = default;

--- a/RecoTracker/LST/interface/LSTOutput.h
+++ b/RecoTracker/LST/interface/LSTOutput.h
@@ -4,12 +4,12 @@
 #include <memory>
 #include <vector>
 
-enum LSTTCType { T5=4, pT3=5, pT5=7, pLS=8 };
-
 class LSTOutput {
 public:
   LSTOutput() = default;
   ~LSTOutput() = default;
+
+  enum LSTTCType { T5 = 4, pT3 = 5, pT5 = 7, pLS = 8 };
 
   void setLSTOutputTraits(std::vector<std::vector<unsigned int>> hitIdx,
                           std::vector<unsigned int> len,
@@ -46,4 +46,3 @@ private:
 };
 
 #endif
-

--- a/RecoTracker/LST/interface/LSTPhase2OTHitsInput.h
+++ b/RecoTracker/LST/interface/LSTPhase2OTHitsInput.h
@@ -38,4 +38,3 @@ private:
 };
 
 #endif
-

--- a/RecoTracker/LST/interface/LSTPixelSeedInput.h
+++ b/RecoTracker/LST/interface/LSTPixelSeedInput.h
@@ -76,4 +76,3 @@ private:
 };
 
 #endif
-

--- a/RecoTracker/LST/interface/LSTPixelSeedInput.h
+++ b/RecoTracker/LST/interface/LSTPixelSeedInput.h
@@ -23,7 +23,6 @@ public:
                              std::vector<float> stateTrajGlbPy,
                              std::vector<float> stateTrajGlbPz,
                              std::vector<int> q,
-                             std::vector<unsigned int> algo,
                              std::vector<std::vector<int>> hitIdx) {
     px_ = px;
     py_ = py;
@@ -39,7 +38,6 @@ public:
     stateTrajGlbPy_ = stateTrajGlbPy;
     stateTrajGlbPz_ = stateTrajGlbPz;
     q_ = q;
-    algo_ = algo;
     hitIdx_ = hitIdx;
   }
 
@@ -57,7 +55,6 @@ public:
   std::vector<float> const& stateTrajGlbPy() const { return stateTrajGlbPy_; }
   std::vector<float> const& stateTrajGlbPz() const { return stateTrajGlbPz_; }
   std::vector<int> const& q() const { return q_; }
-  std::vector<unsigned int> const& algo() const { return algo_; }
   std::vector<std::vector<int>> const& hitIdx() const { return hitIdx_; }
 
 private:
@@ -75,7 +72,6 @@ private:
   std::vector<float> stateTrajGlbPy_;
   std::vector<float> stateTrajGlbPz_;
   std::vector<int> q_;
-  std::vector<unsigned int> algo_;
   std::vector<std::vector<int>> hitIdx_;
 };
 

--- a/RecoTracker/LST/plugins/BuildFile.xml
+++ b/RecoTracker/LST/plugins/BuildFile.xml
@@ -13,7 +13,6 @@
   <use name="RecoTracker/LST"/>
   <use name="RecoTracker/TkSeedingLayers"/>
   <use name="RecoTracker/TkSeedGenerator"/>
-  <use name="TrackingTools/Records"/>
   <use name="TrackingTools/GeomPropagators"/>
   <use name="TrackingTools/Records"/>
   <use name="TrackingTools/TrajectoryState"/>

--- a/RecoTracker/LST/plugins/LSTOutputConverter.cc
+++ b/RecoTracker/LST/plugins/LSTOutputConverter.cc
@@ -43,8 +43,8 @@ private:
   edm::ESGetToken<Propagator, TrackingComponentsRecord> propagatorAlongToken_;
   edm::ESGetToken<Propagator, TrackingComponentsRecord> propagatorOppositeToken_;
   const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> tGeomToken_;
-  //const edm::EDGetTokenT<reco::BeamSpot> beamSpotToken_;
   std::unique_ptr<SeedCreator> seedCreator_;
+  const edm::EDPutTokenT<TrajectorySeedCollection> trajectorySeedPutToken_;
   const edm::EDPutTokenT<TrackCandidateCollection> trackCandidatePutToken_;
   const edm::EDPutTokenT<std::vector<SeedStopInfo>> seedStopInfoPutToken_;
 };
@@ -56,9 +56,9 @@ LSTOutputConverter::LSTOutputConverter(edm::ParameterSet const& iConfig)
       mfToken_(esConsumes()),
       propagatorAlongToken_{esConsumes<Propagator, TrackingComponentsRecord>(iConfig.getParameter<edm::ESInputTag>("propagatorAlong"))},
       propagatorOppositeToken_{esConsumes<Propagator, TrackingComponentsRecord>(iConfig.getParameter<edm::ESInputTag>("propagatorOpposite"))},
-      //beamSpotToken_(consumes<reco::BeamSpot>(iConfig.getUntrackedParameter<edm::InputTag>("beamSpot"))),
       tGeomToken_(esConsumes()),
       seedCreator_(SeedCreatorFactory::get()->create("SeedFromConsecutiveHitsCreator", iConfig.getParameter<edm::ParameterSet>("SeedCreatorPSet"), consumesCollector())),
+      trajectorySeedPutToken_(produces<TrajectorySeedCollection>()),
       trackCandidatePutToken_(produces<TrackCandidateCollection>()),
       seedStopInfoPutToken_(produces<std::vector<SeedStopInfo>>()) {}
 
@@ -70,7 +70,6 @@ void LSTOutputConverter::fillDescriptions(edm::ConfigurationDescriptions& descri
   desc.addUntracked<edm::InputTag>("lstPixelSeeds", edm::InputTag("lstPixelSeedInputProducer"));
   desc.add("propagatorAlong", edm::ESInputTag{"", "PropagatorWithMaterial"});
   desc.add("propagatorOpposite", edm::ESInputTag{"", "PropagatorWithMaterialOpposite"});
-  //desc.addUntracked<edm::InputTag>("beamSpot", edm::InputTag("offlineBeamSpot"));
 
   edm::ParameterSetDescription psd0;
   psd0.add<std::string>("ComponentName", std::string("SeedFromConsecutiveHitsCreator"));
@@ -95,7 +94,6 @@ void LSTOutputConverter::produce(edm::StreamID, edm::Event& iEvent, const edm::E
   const auto& propAlo = iSetup.getData(propagatorAlongToken_);
   const auto& propOppo = iSetup.getData(propagatorOppositeToken_);
   const auto& tracker = iSetup.getData(tGeomToken_);
-  //auto const& bs = iEvent.get(beamSpotToken_);
 
   // Vector definitions
   std::vector<std::vector<unsigned int>> const& lstTC_hitIdx = lstOutput.hitIdx();
@@ -106,27 +104,27 @@ void LSTOutputConverter::produce(edm::StreamID, edm::Event& iEvent, const edm::E
   std::vector<int> const& lstTC_seedIdx = lstOutput.seedIdx();
   std::vector<short> const& lstTC_trackCandidateType = lstOutput.trackCandidateType();
 
-  TrackCandidateCollection output;
-  output.reserve(lstTC_len.size());
+  TrajectorySeedCollection outputTS;
+  outputTS.reserve(lstTC_len.size());
+  TrackCandidateCollection outputTC;
+  outputTC.reserve(lstTC_len.size());
 
   auto const& OTHits = phase2OTRecHits.hits();
 
-  //auto seedsFromT5 = std::make_unique<TrajectorySeedCollection>();
-  //GlobalPoint vtxOfBs(bs.x0(), bs.y0(), bs.z0()); 
   LogDebug("LSTOutputConverter")<<"lstTC size "<<lstTC_len.size();
   for (unsigned int i=0; i<lstTC_len.size(); i++) {
     LogDebug("LSTOutputConverter")<<" cand "<<i<<" "<<lstTC_len[i]<<" "<<lstTC_pt[i]<<" "<<lstTC_eta[i]<<" "<<lstTC_phi[i]<<" "<<lstTC_seedIdx[i];
     TrajectorySeed seed;
-    if (lstTC_seedIdx[i] != - 1)
+    if (lstTC_trackCandidateType[i] != LSTTCType::T5)
       seed = pixelSeeds[lstTC_seedIdx[i]];
 
     edm::OwnVector<TrackingRecHit> recHits;
-    if (lstTC_seedIdx[i] != - 1) {
+    if (lstTC_trackCandidateType[i] != LSTTCType::T5) {
       for (auto const& hit : seed.recHits())
         recHits.push_back(hit.clone());
     }
 
-    unsigned int const nPixelHits = lstTC_seedIdx[i] == -1 ? 0 : recHits.size();
+    unsigned int const nPixelHits = lstTC_trackCandidateType[i] == LSTTCType::T5 ? 0 : recHits.size();
     for (unsigned int j=nPixelHits; j<lstTC_hitIdx[i].size(); j++)
       recHits.push_back(OTHits[lstTC_hitIdx[i][j]]->clone());
 
@@ -150,33 +148,39 @@ void LSTOutputConverter::produce(edm::StreamID, edm::Event& iEvent, const edm::E
       }
     });
 
-    if (lstTC_seedIdx[i] == -1) { // T5
+    TrajectorySeedCollection seeds;
+    if (lstTC_trackCandidateType[i] != LSTTCType::pLS) {
       using Hit = SeedingHitSet::ConstRecHitPointer;
-      std::vector<Hit> hitsFromT5;
-      hitsFromT5.reserve(lstTC_len[i]);
+      std::vector<Hit> hitsForSeed;
+      hitsForSeed.reserve(lstTC_len.size());
       int nHits = 0;
       for (auto const& hit : recHits) {
-        auto hType = tracker.getDetectorType(hit.geographicalId());
-        if (hType != TrackerGeometry::ModuleType::Ph2PSP && nHits < 2)
-          continue; // the first two should be P
-        hitsFromT5.emplace_back(dynamic_cast<Hit>(&hit));
+        if (lstTC_trackCandidateType[i] == LSTTCType::T5) {
+          auto hType = tracker.getDetectorType(hit.geographicalId());
+          if (hType != TrackerGeometry::ModuleType::Ph2PSP && nHits < 2)
+            continue; // the first two should be P
+        }
+        hitsForSeed.emplace_back(dynamic_cast<Hit>(&hit));
         nHits++;
       }
 
-      TrajectorySeedCollection seeds;
       seedCreator_->init(GlobalTrackingRegion(), iSetup, nullptr);
-      seedCreator_->makeSeed(seeds, hitsFromT5);
+      seedCreator_->makeSeed(seeds, hitsForSeed);
       if (seeds.empty()) {
-        edm::LogInfo("LSTOutputConverter")<<"failed to convert a T5 to a seed"<<i<<" "<<lstTC_len[i]
+        edm::LogInfo("LSTOutputConverter")<<"failed to convert a LST object to a seed"<<i<<" "<<lstTC_len[i]
                                              <<" "<<lstTC_pt[i]<<" "<<lstTC_eta[i]<<" "<<lstTC_phi[i]<<" "<<lstTC_seedIdx[i];
-        continue;
+        if (lstTC_trackCandidateType[i] == LSTTCType::T5)
+          continue;
       }
-      seed = seeds[0];
-      auto const& ss = seed.startingState();
+      if (lstTC_trackCandidateType[i] == LSTTCType::T5)
+        seed = seeds[0];
+      outputTS.emplace_back(seeds[0]);
+      auto const& ss = seeds[0].startingState();
       LogDebug("LSTOutputConverter")<<"Created a seed with "<<seed.nHits()<<" "<<ss.detId()<<" "<<ss.pt()
                                            <<" "<<ss.parameters().vector()<<" "<<ss.error(0);
+    } else {
+      outputTS.emplace_back(seed);
     }
-
 
     TrajectoryStateOnSurface tsos = trajectoryStateTransform::transientState(seed.startingState(), (seed.recHits().end()-1)->surface(), &mf);
     auto tsosPair = propOppo.propagateWithPath(tsos, *recHits[0].surface());
@@ -187,7 +191,7 @@ void LSTOutputConverter::produce(edm::StreamID, edm::Event& iEvent, const edm::E
     if (tsosPair.first.isValid()) {
       PTrajectoryStateOnDet st = trajectoryStateTransform::persistentState(tsosPair.first, recHits[0].det()->geographicalId().rawId());
 
-      output.emplace_back(TrackCandidate(recHits,seed,st));
+      outputTC.emplace_back(TrackCandidate(recHits,seed,st));
     } else {
       edm::LogInfo("LSTOutputConverter")<<"Failed to make a candidate initial state. Seed state is "<<tsos
                                            <<" TC cand "<<i<<" "<<lstTC_len[i]
@@ -197,8 +201,9 @@ void LSTOutputConverter::produce(edm::StreamID, edm::Event& iEvent, const edm::E
     }
   }
 
-  LogDebug("LSTOutputConverter")<<"done with conversion: output size "<<output.size();
-  iEvent.emplace(trackCandidatePutToken_, std::move(output));
+  LogDebug("LSTOutputConverter")<<"done with conversion: Track candidate output size "<<outputTC.size();
+  iEvent.emplace(trajectorySeedPutToken_, std::move(outputTS));
+  iEvent.emplace(trackCandidatePutToken_, std::move(outputTC));
   iEvent.emplace(seedStopInfoPutToken_, 0U); //dummy stop info
 }
 

--- a/RecoTracker/LST/plugins/LSTPhase2OTHitsInputProducer.cc
+++ b/RecoTracker/LST/plugins/LSTPhase2OTHitsInputProducer.cc
@@ -21,7 +21,8 @@ private:
 };
 
 LSTPhase2OTHitsInputProducer::LSTPhase2OTHitsInputProducer(edm::ParameterSet const& iConfig)
-    : phase2OTRecHitToken_(consumes<Phase2TrackerRecHit1DCollectionNew>(iConfig.getUntrackedParameter<edm::InputTag>("phase2OTRecHits"))),
+    : phase2OTRecHitToken_(consumes<Phase2TrackerRecHit1DCollectionNew>(
+          iConfig.getUntrackedParameter<edm::InputTag>("phase2OTRecHits"))),
       lstPhase2OTHitsInputPutToken_(produces<LSTPhase2OTHitsInput>()) {}
 
 void LSTPhase2OTHitsInputProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/RecoTracker/LST/plugins/LSTPixelSeedInputProducer.cc
+++ b/RecoTracker/LST/plugins/LSTPixelSeedInputProducer.cc
@@ -44,7 +44,6 @@ LSTPixelSeedInputProducer::LSTPixelSeedInputProducer(edm::ParameterSet const& iC
       lstPixelSeedsPutToken_(produces<TrajectorySeedCollection>()) {
   seedTokens_ = edm::vector_transform(iConfig.getUntrackedParameter<std::vector<edm::InputTag>>("seedTracks"),
                                       [&](const edm::InputTag& tag) { return consumes<edm::View<reco::Track>>(tag); });
-
 }
 
 void LSTPixelSeedInputProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -52,13 +51,13 @@ void LSTPixelSeedInputProducer::fillDescriptions(edm::ConfigurationDescriptions&
 
   desc.addUntracked<edm::InputTag>("beamSpot", edm::InputTag("offlineBeamSpot"));
 
-  desc.addUntracked<std::vector<edm::InputTag>>("seedTracks",
-    std::vector<edm::InputTag>{edm::InputTag("initialStepSeedTracks"),
-                               edm::InputTag("highPtTripletStepSeedTracks")});
+  desc.addUntracked<std::vector<edm::InputTag>>(
+      "seedTracks",
+      std::vector<edm::InputTag>{edm::InputTag("lstInitialStepSeedTracks"),
+                                 edm::InputTag("lstHighPtTripletStepSeedTracks")});
 
   descriptions.addWithDefaultLabel(desc);
 }
-
 
 void LSTPixelSeedInputProducer::produce(edm::StreamID iID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
   // Setup
@@ -106,7 +105,6 @@ void LSTPixelSeedInputProducer::produce(edm::StreamID iID, edm::Event& iEvent, c
       const auto& seedRef = seedTrack.seedRef();
       const auto& seed = *seedRef;
 
-
       if (seedRef.id() != id)
         throw cms::Exception("LogicError")
             << "All tracks in 'TracksFromSeeds' collection should point to seeds in the same collection. Now the "
@@ -129,8 +127,7 @@ void LSTPixelSeedInputProducer::produce(edm::StreamID iID, edm::Event& iEvent, c
           const auto clusterKey = clusterRef.cluster_pixel().key();
           hitIdx.push_back(clusterKey);
         } else {
-          throw cms::Exception("LSTPixelSeedInputProducer")
-                << "Not pixel hits found!";
+          throw cms::Exception("LSTPixelSeedInputProducer") << "Not pixel hits found!";
         }
       }
 
@@ -154,7 +151,21 @@ void LSTPixelSeedInputProducer::produce(edm::StreamID iID, edm::Event& iEvent, c
     }
   }
 
-  pixelSeedInput.setLSTPixelSeedTraits(see_px, see_py, see_pz, see_dxy, see_dz, see_ptErr, see_etaErr, see_stateTrajGlbX, see_stateTrajGlbY, see_stateTrajGlbZ, see_stateTrajGlbPx, see_stateTrajGlbPy, see_stateTrajGlbPz, see_q, see_hitIdx);
+  pixelSeedInput.setLSTPixelSeedTraits(see_px,
+                                       see_py,
+                                       see_pz,
+                                       see_dxy,
+                                       see_dz,
+                                       see_ptErr,
+                                       see_etaErr,
+                                       see_stateTrajGlbX,
+                                       see_stateTrajGlbY,
+                                       see_stateTrajGlbZ,
+                                       see_stateTrajGlbPx,
+                                       see_stateTrajGlbPy,
+                                       see_stateTrajGlbPz,
+                                       see_q,
+                                       see_hitIdx);
   iEvent.emplace(lstPixelSeedInputPutToken_, std::move(pixelSeedInput));
   iEvent.emplace(lstPixelSeedsPutToken_, std::move(see_seeds));
 }

--- a/RecoTracker/LST/plugins/alpaka/LSTProducer.cc
+++ b/RecoTracker/LST/plugins/alpaka/LSTProducer.cc
@@ -29,6 +29,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     LSTProducer(edm::ParameterSet const& config)
         : lstPixelSeedInputToken_{consumes<LSTPixelSeedInput>(config.getParameter<edm::InputTag>("pixelSeedInput"))},
           lstPhase2OTHitsInputToken_{consumes<LSTPhase2OTHitsInput>(config.getParameter<edm::InputTag>("phase2OTHitsInput"))},
+          verbose_(config.getParameter<int>("verbose")),
           lstOutputToken_{produces<LSTOutput>()} {}
 
     void acquire(edm::Event const& event, edm::EventSetup const& setup, edm::WaitingTaskWithArenaHolder task) override {
@@ -42,6 +43,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
       lst_.eventSetup();
       lst_.run(ctx.queue().getNativeHandle(),
+               verbose_,
                pixelSeeds.px(),
                pixelSeeds.py(),
                pixelSeeds.pz(),
@@ -76,12 +78,14 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       edm::ParameterSetDescription desc;
       desc.add<edm::InputTag>("pixelSeedInput", edm::InputTag{"lstPixelSeedInputProducer"});
       desc.add<edm::InputTag>("phase2OTHitsInput", edm::InputTag{"lstPhase2OTHitsInputProducer"});
+      desc.add<int>("verbose", 0);
       descriptions.addWithDefaultLabel(desc);
     }
 
   private:
     edm::EDGetTokenT<LSTPixelSeedInput> lstPixelSeedInputToken_;
     edm::EDGetTokenT<LSTPhase2OTHitsInput> lstPhase2OTHitsInputToken_;
+    const int verbose_;
     edm::EDPutTokenT<LSTOutput> lstOutputToken_;
 
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED

--- a/RecoTracker/LST/plugins/alpaka/LSTProducer.cc
+++ b/RecoTracker/LST/plugins/alpaka/LSTProducer.cc
@@ -20,7 +20,7 @@
 
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 #include "SDL/LST.h"
-#endif // ALPAKA_ACC_GPU_CUDA_ENABLED
+#endif  // ALPAKA_ACC_GPU_CUDA_ENABLED
 
 namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
@@ -28,7 +28,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   public:
     LSTProducer(edm::ParameterSet const& config)
         : lstPixelSeedInputToken_{consumes<LSTPixelSeedInput>(config.getParameter<edm::InputTag>("pixelSeedInput"))},
-          lstPhase2OTHitsInputToken_{consumes<LSTPhase2OTHitsInput>(config.getParameter<edm::InputTag>("phase2OTHitsInput"))},
+          lstPhase2OTHitsInputToken_{
+              consumes<LSTPhase2OTHitsInput>(config.getParameter<edm::InputTag>("phase2OTHitsInput"))},
           verbose_(config.getParameter<int>("verbose")),
           lstOutputToken_{produces<LSTOutput>()} {}
 
@@ -63,14 +64,15 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                phase2OTHits.x(),
                phase2OTHits.y(),
                phase2OTHits.z());
-#endif // ALPAKA_ACC_GPU_CUDA_ENABLED
+#endif  // ALPAKA_ACC_GPU_CUDA_ENABLED
     }
 
     void produce(edm::Event& event, edm::EventSetup const&) override {
       // Output
       LSTOutput lstOutput;
-      lstOutput.setLSTOutputTraits(lst_.hits(), lst_.len(), lst_.pt(), lst_.eta(), lst_.phi(), lst_.seedIdx(), lst_.trackCandidateType());
- 
+      lstOutput.setLSTOutputTraits(
+          lst_.hits(), lst_.len(), lst_.pt(), lst_.eta(), lst_.phi(), lst_.seedIdx(), lst_.trackCandidateType());
+
       event.emplace(lstOutputToken_, std::move(lstOutput));
     }
 
@@ -90,7 +92,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
     SDL::LST lst_;
-#endif // ALPAKA_ACC_GPU_CUDA_ENABLED
+#endif  // ALPAKA_ACC_GPU_CUDA_ENABLED
   };
 
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE

--- a/RecoTracker/LST/plugins/alpaka/LSTProducer.cc
+++ b/RecoTracker/LST/plugins/alpaka/LSTProducer.cc
@@ -56,7 +56,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                pixelSeeds.stateTrajGlbPy(),
                pixelSeeds.stateTrajGlbPz(),
                pixelSeeds.q(),
-               pixelSeeds.algo(),
                pixelSeeds.hitIdx(),
                phase2OTHits.detId(),
                phase2OTHits.x(),

--- a/RecoTracker/LST/python/lstSeedTracks_cfi.py
+++ b/RecoTracker/LST/python/lstSeedTracks_cfi.py
@@ -1,13 +1,13 @@
 import FWCore.ParameterSet.Config as cms
 
-initialStepSeedTracks = cms.EDProducer(
+lstInitialStepSeedTracks = cms.EDProducer(
     "TrackFromSeedProducer",
     src = cms.InputTag("initialStepSeeds"),
     beamSpot = cms.InputTag("offlineBeamSpot"),
     TTRHBuilder = cms.string("WithoutRefit")
 )
 
-highPtTripletStepSeedTracks = cms.EDProducer(
+lstHighPtTripletStepSeedTracks = cms.EDProducer(
     "TrackFromSeedProducer",
     src = cms.InputTag("highPtTripletStepSeeds"),
     beamSpot = cms.InputTag("offlineBeamSpot"),

--- a/RecoTracker/LST/python/lstSeedTracks_cfi.py
+++ b/RecoTracker/LST/python/lstSeedTracks_cfi.py
@@ -1,0 +1,15 @@
+import FWCore.ParameterSet.Config as cms
+
+initialStepSeedTracks = cms.EDProducer(
+    "TrackFromSeedProducer",
+    src = cms.InputTag("initialStepSeeds"),
+    beamSpot = cms.InputTag("offlineBeamSpot"),
+    TTRHBuilder = cms.string("WithoutRefit")
+)
+
+highPtTripletStepSeedTracks = cms.EDProducer(
+    "TrackFromSeedProducer",
+    src = cms.InputTag("highPtTripletStepSeeds"),
+    beamSpot = cms.InputTag("offlineBeamSpot"),
+    TTRHBuilder = cms.string("WithoutRefit")
+)

--- a/RecoTracker/LST/python/lst_cff.py
+++ b/RecoTracker/LST/python/lst_cff.py
@@ -1,5 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
+from RecoTracker.LST.lstSeedTracks_cfi import *
 from RecoTracker.LST.lstPixelSeedInputProducer_cfi import *
 from RecoTracker.LST.lstPhase2OTHitsInputProducer_cfi import *
 from RecoTracker.LST.lstOutputConverter_cfi import *

--- a/RecoTracker/LST/test/LSTAlpakaTester.py
+++ b/RecoTracker/LST/test/LSTAlpakaTester.py
@@ -85,8 +85,7 @@ process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T21', ''
 
 # Tasks and Sequences for LST inputs
 process.load("RecoTracker.LST.lst_cff")
-process.load("Validation.RecoTrack.trackingNtuple_cff")
-lstInputTask = cms.Task(process.trackingNtupleSeedSelectors,process.siPhase2RecHits)
+lstInputTask = cms.Task(process.initialStepSeedTracks,process.highPtTripletStepSeedTracks,process.siPhase2RecHits)
 lstInputSequence = cms.Sequence(lstInputTask)
 
 # Main LST Producer

--- a/RecoTracker/LST/test/LSTAlpakaTester.py
+++ b/RecoTracker/LST/test/LSTAlpakaTester.py
@@ -85,7 +85,7 @@ process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T21', ''
 
 # Tasks and Sequences for LST inputs
 process.load("RecoTracker.LST.lst_cff")
-lstInputTask = cms.Task(process.initialStepSeedTracks,process.highPtTripletStepSeedTracks,process.siPhase2RecHits)
+lstInputTask = cms.Task(process.lstInitialStepSeedTracks,process.lstHighPtTripletStepSeedTracks,process.siPhase2RecHits)
 lstInputSequence = cms.Sequence(lstInputTask)
 
 # Main LST Producer


### PR DESCRIPTION
This PR includes the following developments:
- `BuildFile` clean-up
- Uses the TrackCandidate type to determine the LST objects in CMSSW.
- The option to create `TrajectorySeeds` as the output of the `LSTOutputConverter`.
- The option to (not) include T5s in the CMSSW TrackCandidate coming out of the `LSTOutputConverter`.
- Disentangles the LST reconstruction from validation modules.
- Synchronizes with the latest standalone master branch developments (SegmentLinking/TrackLooper@b5dfd9d9f97c882ac64ee1a1a52d1159114ce979) and simplifies the pixelSeed input logic by dropping the iteration algo information.

The PR has been tested by running the CMSSW configuration on a few events and verifying that the `TrackCandidates` are the same and that the `TrajectorySeed` variables make sense (are reasonably close to those of the corresponding `TrackCandidates`).

Coupled with SegmentLinking/TrackLooper#280.