### PR TITLE
module map ES producers

### DIFF
--- a/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
@@ -394,14 +394,25 @@ from HeterogeneousCore.CUDACore.SwitchProducerCUDA import SwitchProducerCUDA
 lstProducer = SwitchProducerCUDA(
     cpu  = alpaka_serial_syncLSTProducer.clone(),
 )
+gpu.toModify(lstProducer,cuda = alpaka_cuda_asyncLSTProducer.clone())
+
 from RecoTracker.LST.lstModuleConnectionMapESProducer_cfi import lstModuleConnectionMapESProducer as _mmapES
+dataLST = "RecoTracker/LST/data/"
 lstModuleConnectionMap = _mmapES.clone(
     ComponentName = "",
-    txt = "RecoTracker/LST/data/module_connection_tracing_CMSSW_12_2_0_pre2_merged.txt"
+    txt = dataLST+"module_connection_tracing_CMSSW_12_2_0_pre2_merged.txt"
 )
-gpu.toModify(lstProducer,cuda = alpaka_cuda_asyncLSTProducer.clone())
 _HighPtTripletStepTask_LST.add(siPhase2RecHits, lstInitialStepSeedTracks, lstHighPtTripletStepSeedTracks, lstPixelSeedInputProducer,
                                lstPhase2OTHitsInputProducer, lstProducer, lstModuleConnectionMap)
+mCM_pLS = ["_layer1_subdet5", "_layer2_subdet5", "_layer1_subdet4", "_layer2_subdet4"]
+for mCM in mCM_pLS:
+    for ec in ["", "_pos", "_neg"]:
+        locals()["lstModuleConnectionMap_pLS"+mCM+ec] = _mmapES.clone(
+            ComponentName = "pLS"+mCM+ec,
+            txt = dataLST+"pixelmaps_CMSSW_12_2_0_pre2_0p8minPt/pLS_map"+ec+mCM+".txt"
+        )
+        _HighPtTripletStepTask_LST.add(locals()["lstModuleConnectionMap_pLS"+mCM+ec])
+
 (trackingPhase2PU140 & trackingLST).toReplaceWith(HighPtTripletStepTask, _HighPtTripletStepTask_LST)
 
 # fast tracking mask producer 

--- a/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
@@ -394,8 +394,14 @@ from HeterogeneousCore.CUDACore.SwitchProducerCUDA import SwitchProducerCUDA
 lstProducer = SwitchProducerCUDA(
     cpu  = alpaka_serial_syncLSTProducer.clone(),
 )
+from RecoTracker.LST.lstModuleConnectionMapESProducer_cfi import lstModuleConnectionMapESProducer as _mmapES
+lstModuleConnectionMap = _mmapES.clone(
+    ComponentName = "",
+    txt = "RecoTracker/LST/data/module_connection_tracing_CMSSW_12_2_0_pre2_merged.txt"
+)
 gpu.toModify(lstProducer,cuda = alpaka_cuda_asyncLSTProducer.clone())
-_HighPtTripletStepTask_LST.add(siPhase2RecHits, lstInitialStepSeedTracks, lstHighPtTripletStepSeedTracks, lstPixelSeedInputProducer, lstPhase2OTHitsInputProducer, lstProducer)
+_HighPtTripletStepTask_LST.add(siPhase2RecHits, lstInitialStepSeedTracks, lstHighPtTripletStepSeedTracks, lstPixelSeedInputProducer,
+                               lstPhase2OTHitsInputProducer, lstProducer, lstModuleConnectionMap)
 (trackingPhase2PU140 & trackingLST).toReplaceWith(HighPtTripletStepTask, _HighPtTripletStepTask_LST)
 
 # fast tracking mask producer 

--- a/RecoTracker/LST/BuildFile.xml
+++ b/RecoTracker/LST/BuildFile.xml
@@ -1,4 +1,5 @@
 <use name="DataFormats/Common"/>
+<use name="lst"/>
 <use name="DataFormats/TrackerRecHit2D"/>
 <export>
   <lib name="RecoTrackerLST"/>

--- a/RecoTracker/LST/plugins/BuildFile.xml
+++ b/RecoTracker/LST/plugins/BuildFile.xml
@@ -1,10 +1,12 @@
 <!-- host-only plugins -->
 <library file="*.cc" name="RecoTrackerLSTPlugins">
+  <use name="lst"/>
   <use name="DataFormats/TrackCandidate"/>
   <use name="DataFormats/TrackReco"/>
   <use name="DataFormats/TrackerRecHit2D"/>
   <use name="DataFormats/TrajectorySeed"/>
   <use name="FWCore/Framework"/>
+  <use name="FWCore/MessageLogger"/>
   <use name="FWCore/ParameterSet"/>
   <use name="FWCore/Utilities"/>
   <use name="Geometry/TrackerGeometryBuilder"/>
@@ -13,6 +15,7 @@
   <use name="RecoTracker/LST"/>
   <use name="RecoTracker/TkSeedingLayers"/>
   <use name="RecoTracker/TkSeedGenerator"/>
+  <use name="RecoTracker/Record"/>
   <use name="TrackingTools/GeomPropagators"/>
   <use name="TrackingTools/Records"/>
   <use name="TrackingTools/TrajectoryState"/>
@@ -31,6 +34,7 @@
   <use name="HeterogeneousCore/AlpakaCore"/>
   <use name="HeterogeneousCore/AlpakaInterface"/>
   <use name="RecoTracker/LST"/>
+  <use name="RecoTracker/Record"/>
   <flags ALPAKA_BACKENDS="cuda serial"/>
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/RecoTracker/LST/plugins/LSTModuleConnectionMapESProducer.cc
+++ b/RecoTracker/LST/plugins/LSTModuleConnectionMapESProducer.cc
@@ -19,16 +19,14 @@ private:
 };
 
 LSTModuleConnectionMapESProducer::LSTModuleConnectionMapESProducer(const edm::ParameterSet &iConfig)
-  : txtFile_{iConfig.getParameter<edm::FileInPath>("txt").fullPath()}
-{
+    : txtFile_{iConfig.getParameter<edm::FileInPath>("txt").fullPath()} {
   setWhatProduced(this, iConfig.getParameter<std::string>("ComponentName"));
 }
 
 void LSTModuleConnectionMapESProducer::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<std::string>("ComponentName", "")->setComment("Product label");
-  desc.add<edm::FileInPath>("txt", edm::FileInPath())
-      ->setComment("Path to the txt file for the module map parameters");
+  desc.add<edm::FileInPath>("txt", edm::FileInPath())->setComment("Path to the txt file for the module map parameters");
   descriptions.addWithDefaultLabel(desc);
 }
 

--- a/RecoTracker/LST/plugins/LSTModuleConnectionMapESProducer.cc
+++ b/RecoTracker/LST/plugins/LSTModuleConnectionMapESProducer.cc
@@ -1,0 +1,40 @@
+#include "FWCore/Framework/interface/ModuleFactory.h"
+#include "FWCore/Framework/interface/ESProducer.h"
+
+#include "RecoTracker/Record/interface/TrackerRecoGeometryRecord.h"
+
+// LST includes
+#include "SDL/ModuleConnectionMap.h"
+
+class LSTModuleConnectionMapESProducer : public edm::ESProducer {
+public:
+  LSTModuleConnectionMapESProducer(const edm::ParameterSet &iConfig);
+
+  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
+
+  std::unique_ptr<SDL::ModuleConnectionMap> produce(const TrackerRecoGeometryRecord &iRecord);
+
+private:
+  const std::string txtFile_;
+};
+
+LSTModuleConnectionMapESProducer::LSTModuleConnectionMapESProducer(const edm::ParameterSet &iConfig)
+  : txtFile_{iConfig.getParameter<edm::FileInPath>("txt").fullPath()}
+{
+  setWhatProduced(this, iConfig.getParameter<std::string>("ComponentName"));
+}
+
+void LSTModuleConnectionMapESProducer::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<std::string>("ComponentName", "")->setComment("Product label");
+  desc.add<edm::FileInPath>("txt", edm::FileInPath())
+      ->setComment("Path to the txt file for the module map parameters");
+  descriptions.addWithDefaultLabel(desc);
+}
+
+std::unique_ptr<SDL::ModuleConnectionMap> LSTModuleConnectionMapESProducer::produce(
+    const TrackerRecoGeometryRecord &iRecord) {
+  return std::make_unique<SDL::ModuleConnectionMap>(txtFile_);
+}
+
+DEFINE_FWK_EVENTSETUP_MODULE(LSTModuleConnectionMapESProducer);

--- a/RecoTracker/LST/plugins/alpaka/LSTProducer.cc
+++ b/RecoTracker/LST/plugins/alpaka/LSTProducer.cc
@@ -5,6 +5,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Utilities/interface/transform.h"
 
 #include "HeterogeneousCore/AlpakaCore/interface/alpaka/EDGetToken.h"
 #include "HeterogeneousCore/AlpakaCore/interface/alpaka/EDPutToken.h"
@@ -30,19 +31,38 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         : lstPixelSeedInputToken_{consumes<LSTPixelSeedInput>(config.getParameter<edm::InputTag>("pixelSeedInput"))},
           lstPhase2OTHitsInputToken_{
               consumes<LSTPhase2OTHitsInput>(config.getParameter<edm::InputTag>("phase2OTHitsInput"))},
-          mmapToken_{esConsumes()},
+          mmapToken_(esConsumes(config.getParameter<edm::ESInputTag>("mmap"))),
           verbose_(config.getParameter<int>("verbose")),
-          lstOutputToken_{produces()} {}
+          lstOutputToken_{produces()} {
+      mmap_pLSTokens_ = edm::vector_transform(
+          config.getUntrackedParameter<std::vector<edm::ESInputTag>>("mmap_pLS"), [&](const edm::ESInputTag& tag) {
+            return (edm::ESGetToken<SDL::ModuleConnectionMap, TrackerRecoGeometryRecord>)esConsumes(tag);
+          });
+      mmap_pLS_posTokens_ = edm::vector_transform(
+          config.getUntrackedParameter<std::vector<edm::ESInputTag>>("mmap_pLS_pos"), [&](const edm::ESInputTag& tag) {
+            return (edm::ESGetToken<SDL::ModuleConnectionMap, TrackerRecoGeometryRecord>)esConsumes(tag);
+          });
+      mmap_pLS_negTokens_ = edm::vector_transform(
+          config.getUntrackedParameter<std::vector<edm::ESInputTag>>("mmap_pLS_neg"), [&](const edm::ESInputTag& tag) {
+            return (edm::ESGetToken<SDL::ModuleConnectionMap, TrackerRecoGeometryRecord>)esConsumes(tag);
+          });
+    }
 
     void acquire(device::Event const& event, device::EventSetup const& setup) override {
-
       // Inputs
       auto const& pixelSeeds = event.get(lstPixelSeedInputToken_);
       auto const& phase2OTHits = event.get(lstPhase2OTHitsInputToken_);
 
       auto const& mmap = setup.getData(mmapToken_);
-      edm::LogWarning("MYDEBUG")<<mmap.size();
-      lst_.eventSetup();
+      std::vector<SDL::ModuleConnectionMap> moduleConnectionMap_pLStoLayer, moduleConnectionMap_pLStoLayer_pos,
+          moduleConnectionMap_pLStoLayer_neg;
+      for (size_t iMCM = 0; iMCM < mmap_pLSTokens_.size(); ++iMCM) {
+        moduleConnectionMap_pLStoLayer.push_back(setup.getData(mmap_pLSTokens_[iMCM]));
+        moduleConnectionMap_pLStoLayer_pos.push_back(setup.getData(mmap_pLS_posTokens_[iMCM]));
+        moduleConnectionMap_pLStoLayer_neg.push_back(setup.getData(mmap_pLS_negTokens_[iMCM]));
+      }
+      lst_.eventSetup(
+          mmap, moduleConnectionMap_pLStoLayer, moduleConnectionMap_pLStoLayer_pos, moduleConnectionMap_pLStoLayer_neg);
       lst_.run(event.queue(),
                verbose_,
                pixelSeeds.px(),
@@ -67,7 +87,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     }
 
     void produce(device::Event& event, device::EventSetup const&) override {
-
       // Output
       LSTOutput lstOutput;
       lstOutput.setLSTOutputTraits(lst_.hits(), lst_.len(), lst_.seedIdx(), lst_.trackCandidateType());
@@ -79,6 +98,25 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       edm::ParameterSetDescription desc;
       desc.add<edm::InputTag>("pixelSeedInput", edm::InputTag{"lstPixelSeedInputProducer"});
       desc.add<edm::InputTag>("phase2OTHitsInput", edm::InputTag{"lstPhase2OTHitsInputProducer"});
+      desc.add<edm::ESInputTag>("mmap", edm::ESInputTag("", ""));
+      desc.addUntracked<std::vector<edm::ESInputTag>>(
+          "mmap_pLS",
+          std::vector<edm::ESInputTag>{edm::ESInputTag("", "pLS_layer1_subdet5"),
+                                       edm::ESInputTag("", "pLS_layer2_subdet5"),
+                                       edm::ESInputTag("", "pLS_layer1_subdet4"),
+                                       edm::ESInputTag("", "pLS_layer2_subdet4")});
+      desc.addUntracked<std::vector<edm::ESInputTag>>(
+          "mmap_pLS_pos",
+          std::vector<edm::ESInputTag>{edm::ESInputTag("", "pLS_layer1_subdet5_pos"),
+                                       edm::ESInputTag("", "pLS_layer2_subdet5_pos"),
+                                       edm::ESInputTag("", "pLS_layer1_subdet4_pos"),
+                                       edm::ESInputTag("", "pLS_layer2_subdet4_pos")});
+      desc.addUntracked<std::vector<edm::ESInputTag>>(
+          "mmap_pLS_neg",
+          std::vector<edm::ESInputTag>{edm::ESInputTag("", "pLS_layer1_subdet5_neg"),
+                                       edm::ESInputTag("", "pLS_layer2_subdet5_neg"),
+                                       edm::ESInputTag("", "pLS_layer1_subdet4_neg"),
+                                       edm::ESInputTag("", "pLS_layer2_subdet4_neg")});
       desc.add<int>("verbose", 0);
       descriptions.addWithDefaultLabel(desc);
     }
@@ -87,6 +125,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     edm::EDGetTokenT<LSTPixelSeedInput> lstPixelSeedInputToken_;
     edm::EDGetTokenT<LSTPhase2OTHitsInput> lstPhase2OTHitsInputToken_;
     const edm::ESGetToken<SDL::ModuleConnectionMap, TrackerRecoGeometryRecord> mmapToken_;
+    std::vector<edm::ESGetToken<SDL::ModuleConnectionMap, TrackerRecoGeometryRecord>> mmap_pLSTokens_,
+        mmap_pLS_posTokens_, mmap_pLS_negTokens_;
     const int verbose_;
     edm::EDPutTokenT<LSTOutput> lstOutputToken_;
 

--- a/RecoTracker/LST/plugins/alpaka/LSTProducer.cc
+++ b/RecoTracker/LST/plugins/alpaka/LSTProducer.cc
@@ -1,5 +1,6 @@
 #include <alpaka/alpaka.hpp>
 
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
@@ -16,7 +17,10 @@
 #include "RecoTracker/LST/interface/LSTPhase2OTHitsInput.h"
 #include "RecoTracker/LST/interface/LSTPixelSeedInput.h"
 
+#include "RecoTracker/Record/interface/TrackerRecoGeometryRecord.h"
+
 #include "SDL/LST.h"
+#include "SDL/ModuleConnectionMap.h"
 
 namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
@@ -26,6 +30,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         : lstPixelSeedInputToken_{consumes<LSTPixelSeedInput>(config.getParameter<edm::InputTag>("pixelSeedInput"))},
           lstPhase2OTHitsInputToken_{
               consumes<LSTPhase2OTHitsInput>(config.getParameter<edm::InputTag>("phase2OTHitsInput"))},
+          mmapToken_{esConsumes()},
           verbose_(config.getParameter<int>("verbose")),
           lstOutputToken_{produces()} {}
 
@@ -35,6 +40,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       auto const& pixelSeeds = event.get(lstPixelSeedInputToken_);
       auto const& phase2OTHits = event.get(lstPhase2OTHitsInputToken_);
 
+      auto const& mmap = setup.getData(mmapToken_);
+      edm::LogWarning("MYDEBUG")<<mmap.size();
       lst_.eventSetup();
       lst_.run(event.queue(),
                verbose_,
@@ -79,6 +86,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   private:
     edm::EDGetTokenT<LSTPixelSeedInput> lstPixelSeedInputToken_;
     edm::EDGetTokenT<LSTPhase2OTHitsInput> lstPhase2OTHitsInputToken_;
+    const edm::ESGetToken<SDL::ModuleConnectionMap, TrackerRecoGeometryRecord> mmapToken_;
     const int verbose_;
     edm::EDPutTokenT<LSTOutput> lstOutputToken_;
 

--- a/RecoTracker/LST/src/ES_ModuleConnectionMap.cc
+++ b/RecoTracker/LST/src/ES_ModuleConnectionMap.cc
@@ -1,0 +1,3 @@
+#include "SDL/ModuleConnectionMap.h"
+#include "FWCore/Utilities/interface/typelookup.h"
+TYPELOOKUP_DATA_REG(SDL::ModuleConnectionMap);


### PR DESCRIPTION
this is a concept PR at this point: I start with making ES products for module maps in the host space.
For a start it seemed easier to convert just one module map load.
Since most other maps are the same and are independent they could as well be populated with the same ES producer clones.

To run this one also needs a data area known to CMSSW : 
```
dataD=$CMSSW_BASE/external/$SCRAM_ARCH/data/RecoTracker/LST
mkdir -p $dataD
cd $dataD
ln -s $LST_BASE/data
```

Ultimately, it would be good to create and fill data (almost) directly usable by `modulesBuf->moduleMap_buf` and `nConnectedModules_buf` as ES products in the device space.