### PR TITLE
Switch between CPU and CUDA backends without need to recompile the standalone

### DIFF
--- a/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
@@ -387,14 +387,13 @@ from RecoLocalTracker.Phase2TrackerRecHits.Phase2TrackerRecHits_cfi import siPha
 from RecoTracker.LST.lstSeedTracks_cfi import lstInitialStepSeedTracks,lstHighPtTripletStepSeedTracks
 from RecoTracker.LST.lstPixelSeedInputProducer_cfi import lstPixelSeedInputProducer
 from RecoTracker.LST.lstPhase2OTHitsInputProducer_cfi import lstPhase2OTHitsInputProducer
-from RecoTracker.LST.alpaka_cuda_asyncLSTProducer_cfi import alpaka_cuda_asyncLSTProducer
-from RecoTracker.LST.alpaka_serial_syncLSTProducer_cfi import alpaka_serial_syncLSTProducer
-from Configuration.ProcessModifiers.gpu_cff import gpu
-from HeterogeneousCore.CUDACore.SwitchProducerCUDA import SwitchProducerCUDA
-lstProducer = SwitchProducerCUDA(
-    cpu  = alpaka_serial_syncLSTProducer.clone(),
+from RecoTracker.LST.lstProducer_cfi import lstProducer as _lstProducer
+# Define lstProducer like this to be able to run the serial version explicitly
+lstProducer = _lstProducer.clone(
+  alpaka = cms.untracked.PSet(backend = cms.untracked.string('serial_sync'))
 )
-gpu.toModify(lstProducer,cuda = alpaka_cuda_asyncLSTProducer.clone())
+from Configuration.ProcessModifiers.gpu_cff import gpu
+gpu.toReplaceWith(lstProducer,_lstProducer.clone())
 _HighPtTripletStepTask_LST.add(siPhase2RecHits, lstInitialStepSeedTracks, lstHighPtTripletStepSeedTracks, lstPixelSeedInputProducer, lstPhase2OTHitsInputProducer, lstProducer)
 (trackingPhase2PU140 & trackingLST).toReplaceWith(HighPtTripletStepTask, _HighPtTripletStepTask_LST)
 

--- a/RecoTracker/LST/plugins/BuildFile.xml
+++ b/RecoTracker/LST/plugins/BuildFile.xml
@@ -22,15 +22,28 @@
 </library>
 
 <!-- alpaka-based portable plugins -->
-<library file="alpaka/*.cc" name="RecoTrackerLSTPluginsPortable">
+<library file="alpaka/*.cc" name="RecoTrackerLSTPluginsPortableCpu">
   <use name="alpaka"/>
-  <use name="lst"/>
+  <use name="lst_cpu"/>
   <use name="FWCore/Framework"/>
   <use name="FWCore/ParameterSet"/>
   <use name="FWCore/Utilities"/>
   <use name="HeterogeneousCore/AlpakaCore"/>
   <use name="HeterogeneousCore/AlpakaInterface"/>
   <use name="RecoTracker/LST"/>
-  <flags ALPAKA_BACKENDS="cuda serial"/>
+  <flags ALPAKA_BACKENDS="serial"/>
+  <flags EDM_PLUGIN="1"/>
+</library>
+
+<library file="alpaka/*.cc" name="RecoTrackerLSTPluginsPortableGpu">
+  <use name="alpaka"/>
+  <use name="lst_gpu"/>
+  <use name="FWCore/Framework"/>
+  <use name="FWCore/ParameterSet"/>
+  <use name="FWCore/Utilities"/>
+  <use name="HeterogeneousCore/AlpakaCore"/>
+  <use name="HeterogeneousCore/AlpakaInterface"/>
+  <use name="RecoTracker/LST"/>
+  <flags ALPAKA_BACKENDS="cuda"/>
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/RecoTracker/LST/test/LSTAlpakaTester.py
+++ b/RecoTracker/LST/test/LSTAlpakaTester.py
@@ -90,16 +90,9 @@ lstInputSequence = cms.Sequence(lstInputTask)
 
 # Main LST Producer
 process.load('Configuration.StandardSequences.Accelerators_cff')
-process.load('RecoTracker.LST.alpaka_cuda_asyncLSTProducer_cfi')
-process.load('RecoTracker.LST.alpaka_serial_syncLSTProducer_cfi')
-### Enable alpaka-based heterogeneous modules
-process.AlpakaServiceCudaAsync = cms.Service('AlpakaServiceCudaAsync')
-process.AlpakaServiceSerialSync = cms.Service('AlpakaServiceSerialSync')
-from HeterogeneousCore.CUDACore.SwitchProducerCUDA import SwitchProducerCUDA
-process.lstProducer = SwitchProducerCUDA(
-        cpu = process.alpaka_serial_syncLSTProducer.clone(),
-        cuda = process.alpaka_cuda_asyncLSTProducer.clone()
-)
+process.load("HeterogeneousCore.AlpakaCore.ProcessAcceleratorAlpaka_cfi")
+from RecoTracker.LST.lstProducer_cfi import lstProducer as _lstProducer
+process.lstProducer = _lstProducer.clone()
 
 # Track Fitting
 import RecoTracker.TrackProducer.TrackProducer_cfi


### PR DESCRIPTION
Updates to make the lstProducer use the appropriate LST library based on the backend in use. It should be merged together with  SegmentLinking/TrackLooper#341 that creates both CPU and CUDA libraries with one command, with the proper naming.

Also small updates to use the latest CMSSW alpaka interface.