### PR TITLE
updates to match updates in TrackLooper#377

### DIFF
--- a/RecoTracker/LST/plugins/alpaka/LSTModulesDevESProducer.cc
+++ b/RecoTracker/LST/plugins/alpaka/LSTModulesDevESProducer.cc
@@ -48,7 +48,7 @@ void LSTModulesDevESProducer::fillDescriptions(edm::ConfigurationDescriptions &d
   std::optional<SDL::modulesBuffer<alpaka_common::DevHost>> LSTModulesDevESProducer::produce(const TrackerRecoGeometryRecord &iRecord) {
     SDL::modulesBuffer<alpaka_common::DevHost> modules(cms::alpakatools::host());
     alpaka::QueueCpuBlocking queue(cms::alpakatools::host());
-    SDL::LST::loadAndFillES(queue, &modules);
+    SDL::LST<SDL::Acc>::loadAndFillES(queue, &modules);
     return modules;
 }
 

--- a/RecoTracker/LST/plugins/alpaka/LSTProducer.cc
+++ b/RecoTracker/LST/plugins/alpaka/LSTProducer.cc
@@ -40,8 +40,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       auto const& phase2OTHits = event.get(lstPhase2OTHitsInputToken_);
 
       auto const& modulesData = setup.getData(modulesESToken_);
-      SDL::modulesBuffersES = &modulesData;
-      SDL::modulesInGPU->setData(modulesData);
+      SDL::globals::modulesBuffersES = &modulesData;
       lst_.run(event.queue(),
                verbose_,
                pixelSeeds.px(),

--- a/RecoTracker/LST/plugins/alpaka/LSTProducer.cc
+++ b/RecoTracker/LST/plugins/alpaka/LSTProducer.cc
@@ -40,8 +40,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       auto const& phase2OTHits = event.get(lstPhase2OTHitsInputToken_);
 
       auto const& modulesData = setup.getData(modulesESToken_);
-      SDL::globals::modulesBuffersES = &modulesData;
       lst_.run(event.queue(),
+               &modulesData,
                verbose_,
                pixelSeeds.px(),
                pixelSeeds.py(),

--- a/RecoTracker/LST/plugins/alpaka/LSTProducer.cc
+++ b/RecoTracker/LST/plugins/alpaka/LSTProducer.cc
@@ -88,7 +88,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     const int verbose_;
     edm::EDPutTokenT<LSTOutput> lstOutputToken_;
 
-    SDL::LST lst_;
+    SDL::LST<SDL::Acc> lst_;
   };
 
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE


### PR DESCRIPTION
LST has a template parameter in https://github.com/SegmentLinking/TrackLooper/pull/377: `SDL::LST<SDL::Acc>`

the reference branch is still 13_3_X, but it should be OK for 14_1

(will make non-draft after I actually test in 14_1)