### PR TITLE
Fix LSTCore compatibility

### DIFF
--- a/RecoTracker/LST/BuildFile.xml
+++ b/RecoTracker/LST/BuildFile.xml
@@ -3,6 +3,7 @@
 <use name="lst_headers"/>
 <use name="DataFormats/TrackerRecHit2D"/>
 <use name="HeterogeneousCore/AlpakaInterface"/>
+<flags CXXFLAGS="-DLST_STANDALONE"/>
 <flags ALPAKA_BACKENDS="cuda serial"/>
 <export>
   <lib name="1"/>

--- a/RecoTracker/LST/plugins/BuildFile.xml
+++ b/RecoTracker/LST/plugins/BuildFile.xml
@@ -34,6 +34,7 @@
   <use name="HeterogeneousCore/AlpakaInterface"/>
   <use name="RecoTracker/LST"/>
   <use name="RecoTracker/Record"/>
+  <flags CXXFLAGS="-DLST_STANDALONE"/>
   <flags ALPAKA_BACKENDS="serial"/>
   <flags EDM_PLUGIN="1"/>
 </library>
@@ -48,6 +49,7 @@
   <use name="HeterogeneousCore/AlpakaInterface"/>
   <use name="RecoTracker/LST"/>
   <use name="RecoTracker/Record"/>
+  <flags CXXFLAGS="-DLST_STANDALONE"/>
   <flags ALPAKA_BACKENDS="cuda"/>
   <flags EDM_PLUGIN="1"/>
 </library>


### PR DESCRIPTION
This is a companion PR to https://github.com/SegmentLinking/TrackLooper/pull/395. In that other PR I made some changes so that the master branch is compatible with LSTCore. However, since the LST package uses some of the headers, we need to set `LST_STANDALONE` when using it as an external so that headers are included properly.