### PR TITLE
Fix handling empty TrajectorySeedCollection in LSTOutputConverter

### DIFF
--- a/RecoTracker/LST/plugins/LSTOutputConverter.cc
+++ b/RecoTracker/LST/plugins/LSTOutputConverter.cc
@@ -179,8 +179,8 @@ void LSTOutputConverter::produce(edm::StreamID, edm::Event& iEvent, const edm::E
       }
       if (lstTC_trackCandidateType[i] == LSTOutput::LSTTCType::T5)
         seed = seeds[0];
-      outputTS.emplace_back(seeds[0]);
-      auto const& ss = seeds[0].startingState();
+      outputTS.emplace_back(seed);
+      auto const& ss = seed.startingState();
       LogDebug("LSTOutputConverter") << "Created a seed with " << seed.nHits() << " " << ss.detId() << " " << ss.pt()
                                      << " " << ss.parameters().vector() << " " << ss.error(0);
     } else {


### PR DESCRIPTION
On https://github.com/SegmentLinking/TrackLooper/pull/397 the CI ran into a problem when using the 0.6 GeV maps with CMSSW.

The issue is in this part of the code.

https://github.com/SegmentLinking/cmssw/blob/f9e0bcf7dc1af26f6d86843f43a023d303379317/RecoTracker/LST/plugins/LSTOutputConverter.cc#L174-L183

What happens is that if `seeds` is empty and the TC is not a T5, then it still tries to access `seeds` at index 0 on line 182 and 183.

There are two reasonable solutions to this, which is why I made this a draft PR. From the way it is set up, it seems like the intention was to only skip this when the TC is a T5 and save a seed in an invalid state otherwise, which is what I did. The other option is to simply remove the if statement on line 177.

Regardless, it seems like there might be a deeper issue for why `seeds` was not successfully constructed.