### PR TITLE
Usage of split TrackCandidate collections for LST objects and fixes/improvements for TrajectorySeed collections

### DIFF
--- a/RecoTracker/ConversionSeedGenerators/python/ConversionStep_cff.py
+++ b/RecoTracker/ConversionSeedGenerators/python/ConversionStep_cff.py
@@ -41,8 +41,6 @@ trackingIters01.toModify(convClusters,
 )
 from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
 (trackingIters01 & trackingPhase2PU140 & trackingLST).toModify(convClusters,
-                         trajectories          = "highPtTripletStepTracks",
-                         oldClusterRemovalInfo = "highPtTripletStepClusters",
                          overrideTrkQuals      = ""
 )
 

--- a/RecoTracker/ConversionSeedGenerators/python/ConversionStep_cff.py
+++ b/RecoTracker/ConversionSeedGenerators/python/ConversionStep_cff.py
@@ -39,6 +39,12 @@ trackingIters01.toModify(convClusters,
                          oldClusterRemovalInfo = "highPtTripletStepClusters",
                          overrideTrkQuals      = "highPtTripletStepSelector:highPtTripletStep"
 )
+from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
+(trackingIters01 & trackingPhase2PU140 & trackingLST).toModify(convClusters,
+                         trajectories          = "highPtTripletStepTracks",
+                         oldClusterRemovalInfo = "highPtTripletStepClusters",
+                         overrideTrkQuals      = ""
+)
 
 _convLayerPairsStripOnlyLayers = ['TIB1+TID1_pos', 
                                  'TIB1+TID1_neg', 

--- a/RecoTracker/FinalTrackSelectors/plugins/TrackListMerger.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackListMerger.cc
@@ -487,7 +487,7 @@ void TrackListMerger::produce(edm::Event& e, const edm::EventSetup& es) {
   }
 
   //DL here
-  if LIKELY (ngood > 1 && collsSize > 1)
+  if LIKELY (ngood > 0 && collsSize > 0)
     for (unsigned int ltm = 0; ltm < listsToMerge_.size(); ltm++) {
       int saveSelected[rSize];
       bool notActive[collsSize];

--- a/RecoTracker/FinalTrackSelectors/python/earlyGeneralTracks_cfi.py
+++ b/RecoTracker/FinalTrackSelectors/python/earlyGeneralTracks_cfi.py
@@ -126,14 +126,13 @@ def _extend_pixelLess(x):
     x.setsToMerge[0].tLists += [6]
 (trackingPhase2PU140 & vectorHits).toModify(earlyGeneralTracks, _extend_pixelLess)
 
-def _dropIter(mod, iteration):
-     mod.TrackProducers.pop(iteration)
-     mod.hasSelector.pop(iteration)
-     mod.indivShareFrac.pop(iteration)
-     mod.selectedTrackQuals.pop(iteration)
-     mod.setsToMerge[0].tLists.pop(iteration)
-
 from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
-# remove initialStep from earlyGeneralTracks inputs
-(trackingPhase2PU140 & trackingLST).toModify(earlyGeneralTracks, func=lambda x:_dropIter(x,0))
-(trackingPhase2PU140 & trackingLST).toModify(earlyGeneralTracks, indivShareFrac = {0:  1})
+(trackingPhase2PU140 & trackingLST).toModify(earlyGeneralTracks,
+                         TrackProducers = ['highPtTripletStepLSTpTracks', 'highPtTripletStepLSTT5Tracks'],
+                         hasSelector = [1,0],
+                         indivShareFrac = [0.1,0.1],
+                         selectedTrackQuals = ['highPtTripletStepSelector:highPtTripletStep',
+                                               'highPtTripletStepSelectorLSTT5:highPtTripletStepLSTT5'
+                         ],
+                         setsToMerge = {0: dict(tLists = [0,1])}
+)

--- a/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
@@ -294,11 +294,11 @@ _highPtTripletStepTracks_LST = RecoTracker.FinalTrackSelectors.trackListMerger_c
     TrackProducers     = ['highPtTripletStepLSTpTracks',
                           'highPtTripletStepLSTT5Tracks'],
     hasSelector        = [1,0],
-    indivShareFrac = cms.vdouble(0.1,0.1),
+    indivShareFrac     = [0.1,0.1],
     selectedTrackQuals = ['highPtTripletStepSelector:highPtTripletStep',
                           'highPtTripletStepSelectorLSTT5:highPtTripletStepLSTT5'],
-    copyExtras = cms.untracked.bool(True),
-    copyMVA = cms.bool(False),
+    copyExtras         = True,
+    copyMVA            = False,
     setsToMerge        = [cms.PSet( tLists=cms.vint32(0,1), pQual=cms.bool(True) )]
 )
 (trackingPhase2PU140 & trackingLST).toReplaceWith(highPtTripletStepTracks, _highPtTripletStepTracks_LST)

--- a/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
@@ -284,6 +284,25 @@ fastSim.toModify(highPtTripletStepTracks,TTRHBuilder = 'WithoutRefit')
 from Configuration.Eras.Modifier_phase2_timing_layer_cff import phase2_timing_layer
 phase2_timing_layer.toModify(highPtTripletStepTracks, TrajectoryInEvent = True)
 
+highPtTripletStepLSTpTracks = highPtTripletStepTracks.clone(
+     src           = 'highPtTripletStepTrackCandidates:pTCsLST'
+)
+highPtTripletStepLSTT5Tracks = highPtTripletStepTracks.clone(
+     src           = 'highPtTripletStepTrackCandidates:t5TCsLST'
+)
+_highPtTripletStepTracks_LST = RecoTracker.FinalTrackSelectors.trackListMerger_cfi.trackListMerger.clone(
+    TrackProducers     = ['highPtTripletStepLSTpTracks',
+                          'highPtTripletStepLSTT5Tracks'],
+    hasSelector        = [1,0],
+    indivShareFrac = cms.vdouble(0.1,0.1),
+    selectedTrackQuals = ['highPtTripletStepSelector:highPtTripletStep',
+                          'highPtTripletStepSelectorLSTT5:highPtTripletStepLSTT5'],
+    copyExtras = cms.untracked.bool(True),
+    copyMVA = cms.bool(False),
+    setsToMerge        = [cms.PSet( tLists=cms.vint32(0,1), pQual=cms.bool(True) )]
+)
+(trackingPhase2PU140 & trackingLST).toReplaceWith(highPtTripletStepTracks, _highPtTripletStepTracks_LST)
+
 # Final selection
 from RecoTracker.FinalTrackSelectors.TrackMVAClassifierPrompt_cfi import *
 highPtTripletStep = TrackMVAClassifierPrompt.clone(
@@ -361,6 +380,28 @@ highPtTripletStepSelector = RecoTracker.FinalTrackSelectors.multiTrackSelector_c
 from Configuration.ProcessModifiers.vectorHits_cff import vectorHits
 vectorHits.toModify(highPtTripletStepSelector.trackSelectors[2], minNumberLayers = 3, minNumber3DLayers = 3, d0_par1 = ( 0.5, 4.0 ), dz_par1 = ( 0.6, 4.0 ))
 
+(trackingPhase2PU140 & trackingLST).toModify(highPtTripletStepSelector, src = 'highPtTripletStepLSTpTracks')
+# Passthrough selector to satisfy the TrackListMerger requirement for selector values
+highPtTripletStepSelectorLSTT5 = RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.multiTrackSelector.clone(
+    src = 'highPtTripletStepLSTT5Tracks',
+    trackSelectors = [
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
+            name = 'highPtTripletStepLSTT5Loose',
+            minHitsToBypassChecks = 0
+            ), #end of pset
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.tightMTS.clone(
+            name = 'highPtTripletStepLSTT5Tight',
+            preFilterName = 'highPtTripletStepLSTT5Loose',
+            minHitsToBypassChecks = 0
+            ),
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.highpurityMTS.clone(
+            name = 'highPtTripletStepLSTT5',
+            preFilterName = 'highPtTripletStepLSTT5Tight',
+            minHitsToBypassChecks = 0
+            ),
+    ] #end of vpset
+) #end of clone
+
 # Final sequence
 HighPtTripletStepTask = cms.Task(highPtTripletStepClusters,
                                  highPtTripletStepSeedLayers,
@@ -388,8 +429,9 @@ from RecoTracker.LST.lstSeedTracks_cfi import lstInitialStepSeedTracks,lstHighPt
 from RecoTracker.LST.lstPixelSeedInputProducer_cfi import lstPixelSeedInputProducer
 from RecoTracker.LST.lstPhase2OTHitsInputProducer_cfi import lstPhase2OTHitsInputProducer
 from RecoTracker.LST.lstProducer_cff import *
+
 _HighPtTripletStepTask_LST.add(siPhase2RecHits, lstInitialStepSeedTracks, lstHighPtTripletStepSeedTracks, lstPixelSeedInputProducer, lstPhase2OTHitsInputProducer,
-                               lstProducer, lstModulesDevESProducer)
+                               lstProducer, lstModulesDevESProducer, highPtTripletStepLSTpTracks, highPtTripletStepLSTT5Tracks, highPtTripletStepSelectorLSTT5)
 (trackingPhase2PU140 & trackingLST).toReplaceWith(HighPtTripletStepTask, _HighPtTripletStepTask_LST)
 
 # fast tracking mask producer 

--- a/RecoTracker/LST/plugins/LSTOutputConverter.cc
+++ b/RecoTracker/LST/plugins/LSTOutputConverter.cc
@@ -255,9 +255,8 @@ void LSTOutputConverter::produce(edm::StreamID, edm::Event& iEvent, const edm::E
     }
   }
 
-  LogDebug("LSTOutputConverter") << "done with conversion: Track candidate output size = "
-                                 << outputpTC.size() << " (p* objects) + "
-                                 <<  outputT5TC.size() << " (T5 objects)";
+  LogDebug("LSTOutputConverter") << "done with conversion: Track candidate output size = " << outputpTC.size()
+                                 << " (p* objects) + " << outputT5TC.size() << " (T5 objects)";
   iEvent.emplace(trajectorySeedPutToken_, std::move(outputTS));
   iEvent.emplace(trajectorySeedpLSPutToken_, std::move(outputpLSTS));
   iEvent.emplace(trackCandidatePutToken_, std::move(outputTC));

--- a/RecoTracker/LST/plugins/LSTOutputConverter.cc
+++ b/RecoTracker/LST/plugins/LSTOutputConverter.cc
@@ -73,6 +73,12 @@ LSTOutputConverter::LSTOutputConverter(edm::ParameterSet const& iConfig)
       seedCreator_(SeedCreatorFactory::get()->create("SeedFromConsecutiveHitsCreator",
                                                      iConfig.getParameter<edm::ParameterSet>("SeedCreatorPSet"),
                                                      consumesCollector())),
+      // FIXME: need to make creation configurable:
+      // - A toggle to not produce TSs at all could be useful to save memory;
+      //   it won't affect speed though
+      // - The minimal set for TCs is t5TCsLST, pTTCsLST and pLSTCsLST.
+      //   That would complicate the handling of collections though,
+      //   so it is deferred to when we have a clearer picture of what's needed.
       trajectorySeedPutToken_(produces<TrajectorySeedCollection>("")),
       trajectorySeedpLSPutToken_(produces<TrajectorySeedCollection>("pLSTSsLST")),
       trackCandidatePutToken_(produces<TrackCandidateCollection>("")),
@@ -231,20 +237,20 @@ void LSTOutputConverter::produce(edm::StreamID, edm::Event& iEvent, const edm::E
         if (!includeT5s_) {
           continue;
         } else {
-          auto TC = TrackCandidate(recHits, seed, st);
-          outputTC.emplace_back(TC);
-          outputT5TC.emplace_back(TC);
-          outputNopLSTC.emplace_back(TC);
+          auto tc = TrackCandidate(recHits, seed, st);
+          outputTC.emplace_back(tc);
+          outputT5TC.emplace_back(tc);
+          outputNopLSTC.emplace_back(tc);
         }
       } else {
-        auto TC = TrackCandidate(recHits, seed, st);
-        outputTC.emplace_back(TC);
-        outputpTC.emplace_back(TC);
+        auto tc = TrackCandidate(recHits, seed, st);
+        outputTC.emplace_back(tc);
+        outputpTC.emplace_back(tc);
         if (lstTC_trackCandidateType[i] != LSTOutput::LSTTCType::pLS) {
-          outputNopLSTC.emplace_back(TC);
-          outputpTTC.emplace_back(TC);
+          outputNopLSTC.emplace_back(tc);
+          outputpTTC.emplace_back(tc);
         } else {
-          outputpLSTC.emplace_back(TC);
+          outputpLSTC.emplace_back(tc);
         }
       }
     } else {

--- a/RecoTracker/LST/plugins/LSTOutputConverter.cc
+++ b/RecoTracker/LST/plugins/LSTOutputConverter.cc
@@ -39,13 +39,20 @@ private:
   const edm::EDGetTokenT<LSTPhase2OTHitsInput> lstPhase2OTHitsInputToken_;
   const edm::EDGetTokenT<TrajectorySeedCollection> lstPixelSeedToken_;
   const bool includeT5s_;
+  const bool includeNonpLSTSs_;
   const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> mfToken_;
   edm::ESGetToken<Propagator, TrackingComponentsRecord> propagatorAlongToken_;
   edm::ESGetToken<Propagator, TrackingComponentsRecord> propagatorOppositeToken_;
   const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> tGeomToken_;
   std::unique_ptr<SeedCreator> seedCreator_;
   const edm::EDPutTokenT<TrajectorySeedCollection> trajectorySeedPutToken_;
+  const edm::EDPutTokenT<TrajectorySeedCollection> trajectorySeedpLSPutToken_;
   const edm::EDPutTokenT<TrackCandidateCollection> trackCandidatePutToken_;
+  const edm::EDPutTokenT<TrackCandidateCollection> trackCandidatepTCPutToken_;
+  const edm::EDPutTokenT<TrackCandidateCollection> trackCandidateT5TCPutToken_;
+  const edm::EDPutTokenT<TrackCandidateCollection> trackCandidateNopLSTCPutToken_;
+  const edm::EDPutTokenT<TrackCandidateCollection> trackCandidatepTTCPutToken_;
+  const edm::EDPutTokenT<TrackCandidateCollection> trackCandidatepLSTCPutToken_;
   const edm::EDPutTokenT<std::vector<SeedStopInfo>> seedStopInfoPutToken_;
 };
 
@@ -56,6 +63,7 @@ LSTOutputConverter::LSTOutputConverter(edm::ParameterSet const& iConfig)
       lstPixelSeedToken_{
           consumes<TrajectorySeedCollection>(iConfig.getUntrackedParameter<edm::InputTag>("lstPixelSeeds"))},
       includeT5s_(iConfig.getParameter<bool>("includeT5s")),
+      includeNonpLSTSs_(iConfig.getParameter<bool>("includeNonpLSTSs")),
       mfToken_(esConsumes()),
       propagatorAlongToken_{
           esConsumes<Propagator, TrackingComponentsRecord>(iConfig.getParameter<edm::ESInputTag>("propagatorAlong"))},
@@ -65,8 +73,14 @@ LSTOutputConverter::LSTOutputConverter(edm::ParameterSet const& iConfig)
       seedCreator_(SeedCreatorFactory::get()->create("SeedFromConsecutiveHitsCreator",
                                                      iConfig.getParameter<edm::ParameterSet>("SeedCreatorPSet"),
                                                      consumesCollector())),
-      trajectorySeedPutToken_(produces<TrajectorySeedCollection>()),
-      trackCandidatePutToken_(produces<TrackCandidateCollection>()),
+      trajectorySeedPutToken_(produces<TrajectorySeedCollection>("")),
+      trajectorySeedpLSPutToken_(produces<TrajectorySeedCollection>("pLSTSsLST")),
+      trackCandidatePutToken_(produces<TrackCandidateCollection>("")),
+      trackCandidatepTCPutToken_(produces<TrackCandidateCollection>("pTCsLST")),
+      trackCandidateT5TCPutToken_(produces<TrackCandidateCollection>("t5TCsLST")),
+      trackCandidateNopLSTCPutToken_(produces<TrackCandidateCollection>("nopLSTCsLST")),
+      trackCandidatepTTCPutToken_(produces<TrackCandidateCollection>("pTTCsLST")),
+      trackCandidatepLSTCPutToken_(produces<TrackCandidateCollection>("pLSTCsLST")),
       seedStopInfoPutToken_(produces<std::vector<SeedStopInfo>>()) {}
 
 void LSTOutputConverter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -76,6 +90,7 @@ void LSTOutputConverter::fillDescriptions(edm::ConfigurationDescriptions& descri
   desc.addUntracked<edm::InputTag>("phase2OTHits", edm::InputTag("lstPhase2OTHitsInputProducer"));
   desc.addUntracked<edm::InputTag>("lstPixelSeeds", edm::InputTag("lstPixelSeedInputProducer"));
   desc.add<bool>("includeT5s", true);
+  desc.add<bool>("includeNonpLSTSs", false);
   desc.add("propagatorAlong", edm::ESInputTag{"", "PropagatorWithMaterial"});
   desc.add("propagatorOpposite", edm::ESInputTag{"", "PropagatorWithMaterialOpposite"});
 
@@ -109,10 +124,16 @@ void LSTOutputConverter::produce(edm::StreamID, edm::Event& iEvent, const edm::E
   std::vector<int> const& lstTC_seedIdx = lstOutput.seedIdx();
   std::vector<short> const& lstTC_trackCandidateType = lstOutput.trackCandidateType();
 
-  TrajectorySeedCollection outputTS;
+  TrajectorySeedCollection outputTS, outputpLSTS;
   outputTS.reserve(lstTC_len.size());
-  TrackCandidateCollection outputTC;
+  outputpLSTS.reserve(lstTC_len.size());
+  TrackCandidateCollection outputTC, outputpTC, outputT5TC, outputNopLSTC, outputpTTC, outputpLSTC;
   outputTC.reserve(lstTC_len.size());
+  outputpTC.reserve(lstTC_len.size());
+  outputT5TC.reserve(lstTC_len.size());
+  outputNopLSTC.reserve(lstTC_len.size());
+  outputpTTC.reserve(lstTC_len.size());
+  outputpLSTC.reserve(lstTC_len.size());
 
   auto const& OTHits = phase2OTRecHits.hits();
 
@@ -155,40 +176,48 @@ void LSTOutputConverter::produce(edm::StreamID, edm::Event& iEvent, const edm::E
 
     TrajectorySeedCollection seeds;
     if (lstTC_trackCandidateType[i] != LSTOutput::LSTTCType::pLS) {
-      using Hit = SeedingHitSet::ConstRecHitPointer;
-      std::vector<Hit> hitsForSeed;
-      hitsForSeed.reserve(lstTC_len.size());
-      int nHits = 0;
-      for (auto const& hit : recHits) {
-        if (lstTC_trackCandidateType[i] == LSTOutput::LSTTCType::T5) {
-          auto hType = tracker.getDetectorType(hit.geographicalId());
-          if (hType != TrackerGeometry::ModuleType::Ph2PSP && nHits < 2)
-            continue;  // the first two should be P
+      // Construct a full-length TrajectorySeed always for T5s,
+      // only when required by a flag for other pT objects.
+      if (includeNonpLSTSs_ || lstTC_trackCandidateType[i] == LSTOutput::LSTTCType::T5) {
+        using Hit = SeedingHitSet::ConstRecHitPointer;
+        std::vector<Hit> hitsForSeed;
+        hitsForSeed.reserve(lstTC_len[i]);
+        int nHits = 0;
+        for (auto const& hit : recHits) {
+          if (lstTC_trackCandidateType[i] == LSTOutput::LSTTCType::T5) {
+            auto hType = tracker.getDetectorType(hit.geographicalId());
+            if (hType != TrackerGeometry::ModuleType::Ph2PSP && nHits < 2)
+              continue;  // the first two should be P
+          }
+          hitsForSeed.emplace_back(dynamic_cast<Hit>(&hit));
+          nHits++;
         }
-        hitsForSeed.emplace_back(dynamic_cast<Hit>(&hit));
-        nHits++;
-      }
 
-      seedCreator_->init(GlobalTrackingRegion(), iSetup, nullptr);
-      seedCreator_->makeSeed(seeds, hitsForSeed);
-      if (seeds.empty()) {
-        edm::LogInfo("LSTOutputConverter")
-            << "failed to convert a LST object to a seed" << i << " " << lstTC_len[i] << " " << lstTC_seedIdx[i];
+        seedCreator_->init(GlobalTrackingRegion(), iSetup, nullptr);
+        seedCreator_->makeSeed(seeds, hitsForSeed);
+        if (seeds.empty()) {
+          edm::LogInfo("LSTOutputConverter")
+              << "failed to convert a LST object to a seed" << i << " " << lstTC_len[i] << " " << lstTC_seedIdx[i];
+          if (lstTC_trackCandidateType[i] == LSTOutput::LSTTCType::T5)
+            continue;
+        }
         if (lstTC_trackCandidateType[i] == LSTOutput::LSTTCType::T5)
-          continue;
+          seed = seeds[0];
+
+        auto trajectorySeed = (seeds.empty() ? seed : seeds[0]);
+        outputTS.emplace_back(trajectorySeed);
+        auto const& ss = trajectorySeed.startingState();
+        LogDebug("LSTOutputConverter") << "Created a seed with " << seed.nHits() << " " << ss.detId() << " " << ss.pt()
+                                       << " " << ss.parameters().vector() << " " << ss.error(0);
       }
-      if (lstTC_trackCandidateType[i] == LSTOutput::LSTTCType::T5)
-        seed = seeds[0];
-      outputTS.emplace_back(seeds[0]);
-      auto const& ss = seeds[0].startingState();
-      LogDebug("LSTOutputConverter") << "Created a seed with " << seed.nHits() << " " << ss.detId() << " " << ss.pt()
-                                     << " " << ss.parameters().vector() << " " << ss.error(0);
     } else {
       outputTS.emplace_back(seed);
+      outputpLSTS.emplace_back(seed);
     }
 
     TrajectoryStateOnSurface tsos =
         trajectoryStateTransform::transientState(seed.startingState(), (seed.recHits().end() - 1)->surface(), &mf);
+    tsos.rescaleError(100.);
     auto tsosPair = propOppo.propagateWithPath(tsos, *recHits[0].surface());
     if (!tsosPair.first.isValid()) {
       LogDebug("LSTOutputConverter") << "Propagating to startingState opposite to momentum failed, trying along next";
@@ -198,10 +227,25 @@ void LSTOutputConverter::produce(edm::StreamID, edm::Event& iEvent, const edm::E
       PTrajectoryStateOnDet st =
           trajectoryStateTransform::persistentState(tsosPair.first, recHits[0].det()->geographicalId().rawId());
 
-      if (lstTC_trackCandidateType[i] == LSTOutput::LSTTCType::T5 && !includeT5s_) {
-        continue;
+      if (lstTC_trackCandidateType[i] == LSTOutput::LSTTCType::T5) {
+        if (!includeT5s_) {
+          continue;
+        } else {
+          auto TC = TrackCandidate(recHits, seed, st);
+          outputTC.emplace_back(TC);
+          outputT5TC.emplace_back(TC);
+          outputNopLSTC.emplace_back(TC);
+        }
       } else {
-        outputTC.emplace_back(TrackCandidate(recHits, seed, st));
+        auto TC = TrackCandidate(recHits, seed, st);
+        outputTC.emplace_back(TC);
+        outputpTC.emplace_back(TC);
+        if (lstTC_trackCandidateType[i] != LSTOutput::LSTTCType::pLS) {
+          outputNopLSTC.emplace_back(TC);
+          outputpTTC.emplace_back(TC);
+        } else {
+          outputpLSTC.emplace_back(TC);
+        }
       }
     } else {
       edm::LogInfo("LSTOutputConverter") << "Failed to make a candidate initial state. Seed state is " << tsos
@@ -211,9 +255,17 @@ void LSTOutputConverter::produce(edm::StreamID, edm::Event& iEvent, const edm::E
     }
   }
 
-  LogDebug("LSTOutputConverter") << "done with conversion: Track candidate output size " << outputTC.size();
+  LogDebug("LSTOutputConverter") << "done with conversion: Track candidate output size = "
+                                 << outputpTC.size() << " (p* objects) + "
+                                 <<  outputT5TC.size() << " (T5 objects)";
   iEvent.emplace(trajectorySeedPutToken_, std::move(outputTS));
+  iEvent.emplace(trajectorySeedpLSPutToken_, std::move(outputpLSTS));
   iEvent.emplace(trackCandidatePutToken_, std::move(outputTC));
+  iEvent.emplace(trackCandidatepTCPutToken_, std::move(outputpTC));
+  iEvent.emplace(trackCandidateT5TCPutToken_, std::move(outputT5TC));
+  iEvent.emplace(trackCandidateNopLSTCPutToken_, std::move(outputNopLSTC));
+  iEvent.emplace(trackCandidatepTTCPutToken_, std::move(outputpTTC));
+  iEvent.emplace(trackCandidatepLSTCPutToken_, std::move(outputpLSTC));
   iEvent.emplace(seedStopInfoPutToken_, 0U);  //dummy stop info
 }
 

--- a/RecoTracker/LST/plugins/alpaka/LSTModulesDevESProducer.cc
+++ b/RecoTracker/LST/plugins/alpaka/LSTModulesDevESProducer.cc
@@ -14,34 +14,32 @@
 
 namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
-class LSTModulesDevESProducer : public ESProducer {
-public:
-  LSTModulesDevESProducer(const edm::ParameterSet &iConfig);
+  class LSTModulesDevESProducer : public ESProducer {
+  public:
+    LSTModulesDevESProducer(const edm::ParameterSet &iConfig);
 
-  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
+    static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
 
-  std::optional<SDL::modulesBuffer<SDL::Dev>> produce(device::Record<TrackerRecoGeometryRecord> const& iRecord);
+    std::optional<SDL::modulesBuffer<SDL::Dev>> produce(device::Record<TrackerRecoGeometryRecord> const &iRecord);
+  };
 
-};
+  LSTModulesDevESProducer::LSTModulesDevESProducer(const edm::ParameterSet &iConfig) : ESProducer(iConfig) {
+    setWhatProduced(this, iConfig.getParameter<std::string>("ComponentName"));
+  }
 
-LSTModulesDevESProducer::LSTModulesDevESProducer(const edm::ParameterSet &iConfig)
-  : ESProducer(iConfig)
-{
-  setWhatProduced(this, iConfig.getParameter<std::string>("ComponentName"));
-}
+  void LSTModulesDevESProducer::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
+    edm::ParameterSetDescription desc;
+    desc.add<std::string>("ComponentName", "")->setComment("Product label");
+    descriptions.addWithDefaultLabel(desc);
+  }
 
-void LSTModulesDevESProducer::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
-  edm::ParameterSetDescription desc;
-  desc.add<std::string>("ComponentName", "")->setComment("Product label");
-  descriptions.addWithDefaultLabel(desc);
-}
-
-  std::optional<SDL::modulesBuffer<SDL::Dev>> LSTModulesDevESProducer::produce(device::Record<TrackerRecoGeometryRecord> const& iRecord) {
-    SDL::QueueAcc& queue = iRecord.queue();
+  std::optional<SDL::modulesBuffer<SDL::Dev>> LSTModulesDevESProducer::produce(
+      device::Record<TrackerRecoGeometryRecord> const &iRecord) {
+    SDL::QueueAcc &queue = iRecord.queue();
     SDL::modulesBuffer<SDL::Dev> modules(alpaka::getDev(queue));
     SDL::LST<SDL::Acc>::loadAndFillES(queue, &modules);
     return modules;
-}
+  }
 
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE
 

--- a/RecoTracker/LST/plugins/alpaka/LSTProducer.cc
+++ b/RecoTracker/LST/plugins/alpaka/LSTProducer.cc
@@ -34,7 +34,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
           lstOutputToken_{produces()} {}
 
     void acquire(device::Event const& event, device::EventSetup const& setup) override {
-
       // Inputs
       auto const& pixelSeeds = event.get(lstPixelSeedInputToken_);
       auto const& phase2OTHits = event.get(lstPhase2OTHitsInputToken_);
@@ -65,7 +64,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     }
 
     void produce(device::Event& event, device::EventSetup const&) override {
-
       // Output
       LSTOutput lstOutput;
       lstOutput.setLSTOutputTraits(lst_.hits(), lst_.len(), lst_.seedIdx(), lst_.trackCandidateType());


### PR DESCRIPTION
Same as https://github.com/SegmentLinking/cmssw/pull/27 but without the LSTCore package in the mix. Copying a summary of the description here (and more detailed comments can be found in the other PR):

This PR transfers the machinery for the improvements introduced in Phase 2 HLT for LST and partially transfers these improvements. More specifically, the pT LST objects and the T5 LST objects are now used to create separate TrackCandidate collections, so that a different tracking ID can be applied to each one of them: The default tracking ID for highPtTripletStep for Phase 2 is applied to the pT LST objects and not tracking ID is applied to the T5 LST objects.
What can also be tested and applied in a future PR is the utilization of the LST seeds as inputs to a following CKF/mkFit "iteration".

Apart from the above, there are a few fixes/improvements for the TrajectorySeeds collection of LST objects (see PR https://github.com/SegmentLinking/cmssw/pull/24 and the discussion that took place there about the proper length for the hitsForSeed vector and the addition of a toggle to construct non-pLS TrajectorySeeds).

The plots for the two-iteration setup with CKF vs. LST vs. LST after this PR can be found here:
https://uaf-10.t2.ucsd.edu/~evourlio/SDL/CMSSWPR25/CKF_LST_LSTAfterAllUpdates/