### PR TITLE
Add two-iteration, tracking-only LST workflow, both on CPU and GPU

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_2026.py
+++ b/Configuration/PyReleaseValidation/python/relval_2026.py
@@ -26,6 +26,7 @@ numWFIB.extend([24434.0]) #2026D97
 numWFIB.extend([24834.0,24834.911,24834.103]) #2026D98 DDD XML, DD4hep XML, aging
 numWFIB.extend([25061.97]) #2026D98 premixing stage1 (NuGun+PU)
 numWFIB.extend([24834.702]) #2026D98 mkFit tracking (initialStep)
+numWFIB.extend([24834.703,24834.704]) #2026D98 LST tracking (initialStep+HighPtTripletStep only): CPU, GPU
 numWFIB.extend([24834.5,24834.9]) #2026D98 pixelTrackingOnly, vector hits
 numWFIB.extend([24834.501,24834.502]) #2026D98 Patatrack local reconstruction on CPU, Patatrack local reconstruction on GPU
 numWFIB.extend([25034.99,25034.999]) #2026D98 premixing combined stage1+stage2 (ttbar+PU200, ttbar+PU50 for PR test)

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -485,6 +485,70 @@ upgradeWFs['trackingMkFitPhase2'].step3 = {
     '--procModifiers': 'trackingMkFitCommon,trackingMkFitInitialStep'
 }
 
+# LST on CPU, initialStep+highPtTripletStep-only tracking-only
+class UpgradeWorkflow_lstOnCPUIters01TrackingOnly(UpgradeWorkflowTracking):
+    def setup__(self, step, stepName, stepDict, k, properties):
+        if 'Reco' in step: stepDict[stepName][k] = merge([self.step3, stepDict[step][k]])
+        elif 'HARVEST' in step: stepDict[stepName][k] = merge([{'-s': 'HARVESTING:@trackingOnlyValidation+@trackingOnlyDQM'}, stepDict[step][k]])
+        elif 'ALCA' in step: stepDict[stepName][k] = None
+    def condition_(self, fragment, stepList, key, hasHarvest):
+        return ('2026' in key)
+upgradeWFs['lstOnCPUIters01TrackingOnly'] = UpgradeWorkflow_lstOnCPUIters01TrackingOnly(
+    steps = [
+        'Reco',
+        'RecoFakeHLT',
+        'HARVEST',
+        'HARVESTFakeHLT',
+        'RecoGlobal',
+        'HARVESTGlobal',
+        'RecoNano',
+        'RecoNanoFakeHLT',
+        'HARVESTNano',
+        'HARVESTNanoFakeHLT',
+        # Add ALCA steps explicitly, so that they can be properly removed
+        'ALCA',
+        'ALCAPhase2'
+    ],
+    PU = [],
+    suffix = '_lstOnCPUIters01TrackingOnly',
+    offset = 0.703,
+)
+upgradeWFs['lstOnCPUIters01TrackingOnly'].step3 = upgradeWFs['trackingOnly'].step3 | {
+    '--procModifiers': 'trackingIters01,trackingLST'
+}
+
+# LST on GPU, initialStep+highPtTripletStep-only tracking-only
+class UpgradeWorkflow_lstOnGPUIters01TrackingOnly(UpgradeWorkflowTracking):
+    def setup__(self, step, stepName, stepDict, k, properties):
+        if 'Reco' in step: stepDict[stepName][k] = merge([self.step3, stepDict[step][k]])
+        elif 'HARVEST' in step: stepDict[stepName][k] = merge([{'-s': 'HARVESTING:@trackingOnlyValidation+@trackingOnlyDQM'}, stepDict[step][k]])
+        elif 'ALCA' in step: stepDict[stepName][k] = None
+    def condition_(self, fragment, stepList, key, hasHarvest):
+        return ('2026' in key)
+upgradeWFs['lstOnGPUIters01TrackingOnly'] = UpgradeWorkflow_lstOnGPUIters01TrackingOnly(
+    steps = [
+        'Reco',
+        'RecoFakeHLT',
+        'HARVEST',
+        'HARVESTFakeHLT',
+        'RecoGlobal',
+        'HARVESTGlobal',
+        'RecoNano',
+        'RecoNanoFakeHLT',
+        'HARVESTNano',
+        'HARVESTNanoFakeHLT',
+        # Add ALCA steps explicitly, so that they can be properly removed
+        'ALCA',
+        'ALCAPhase2'
+    ],
+    PU = [],
+    suffix = '_lstOnGPUIters01TrackingOnly',
+    offset = 0.704,
+)
+upgradeWFs['lstOnGPUIters01TrackingOnly'].step3 = upgradeWFs['trackingOnly'].step3 | {
+    '--procModifiers': 'gpu,trackingIters01,trackingLST'
+}
+
 #DeepCore seeding for JetCore iteration workflow
 class UpgradeWorkflow_seedingDeepCore(UpgradeWorkflow):
     def setup_(self, step, stepName, stepDict, k, properties):


### PR DESCRIPTION
As per title. Tested and works properly (after putting LST data in the proper place, which is still not fully fixed in the code).

Full reconstruction workflows do not currently work, due to problems with electrons, hence the trackingOnly one, which should be fine for now. I didn't investigate much further at this stage.

The workflows are without PU, not sure if we want ones with PU at this stage (at least mkFit doesn't have those).

Barring comments, this could go in as is.