### PR TITLE
Standalone fixes

### DIFF
--- a/RecoTracker/LSTCore/standalone/Makefile
+++ b/RecoTracker/LSTCore/standalone/Makefile
@@ -10,7 +10,7 @@ OBJECTS=$(OBJECTS_CPU) $(OBJECTS_CUDA) $(OBJECTS_ROCM)
 
 CXX         = g++
 CXXFLAGS    = -g -O2 -Wall -fPIC -Wshadow -Woverloaded-virtual -Wno-unused-function -fno-var-tracking -std=c++17 -DLST_IS_CMSSW_PACKAGE
-INCLUDEFLAGS= -ISDL -I$(shell pwd) -Icode -Icode/core -I${ALPAKA_ROOT}/include -I/${BOOST_ROOT}/include $(shell rooutil-config --include) -I$(shell root-config --incdir) -I${CMSSW_BASE}/src -I../interface/alpaka/ -I../src/alpaka/
+INCLUDEFLAGS= -ISDL -I$(shell pwd) -Icode -Icode/core -I${ALPAKA_ROOT}/include -I/${BOOST_ROOT}/include $(shell rooutil-config --include) -I$(shell root-config --incdir) -I${TRACKLOOPERDIR}/../../../ -I${CMSSW_BASE}/src -I../interface/alpaka/ -I../src/alpaka/
 ifdef CMSSW_RELEASE_BASE
 INCLUDEFLAGS:= ${INCLUDEFLAGS} -I${CMSSW_RELEASE_BASE}/src
 endif

--- a/RecoTracker/LSTCore/standalone/SDL/Makefile
+++ b/RecoTracker/LSTCore/standalone/SDL/Makefile
@@ -46,7 +46,7 @@ CXX                  = g++
 CXXFLAGS_CPU         = -march=native -mtune=native -Ofast -fno-reciprocal-math -fopenmp-simd -g -Wall -Wshadow -Woverloaded-virtual -fPIC -fopenmp -I..
 CXXFLAGS_CUDA        = -O3 -g --compiler-options -Wall --compiler-options -Wshadow --compiler-options -Woverloaded-virtual --compiler-options -fPIC --compiler-options -fopenmp -dc -lineinfo --ptxas-options=-v --cudart shared $(GENCODE_CUDA) --use_fast_math --default-stream per-thread -I..
 CXXFLAGS_ROCM        = -O3 -g -Wall -Wshadow -Woverloaded-virtual -fPIC -I${ROCM_ROOT}/include -I..
-CMSSWINCLUDE        := -I${CMSSW_BASE}/src -DLST_IS_CMSSW_PACKAGE
+CMSSWINCLUDE        := -I${TRACKLOOPERDIR}/../../../ -I${CMSSW_BASE}/src -DLST_IS_CMSSW_PACKAGE
 ifdef CMSSW_RELEASE_BASE
 CMSSWINCLUDE        := ${CMSSWINCLUDE} -I${CMSSW_RELEASE_BASE}/src
 endif

--- a/RecoTracker/LSTCore/standalone/code/core/trkCore.cc
+++ b/RecoTracker/LSTCore/standalone/code/core/trkCore.cc
@@ -1079,11 +1079,8 @@ void writeMetaData() {
   gSystem->Exec(
       TString::Format("(cd $TRACKLOOPERDIR && git  --no-pager status && (cd - > /dev/null)) >> %s.gitversion.txt",
                       ana.output_tfile->GetName()));
-  gSystem->Exec(TString::Format("(cd $TRACKLOOPERDIR && echo 'git log -n5' && (cd - > /dev/null)) >> %s.gitversion.txt",
+  gSystem->Exec(TString::Format("(cd $TRACKLOOPERDIR && echo 'git --no-pager log -n 100' && (cd - > /dev/null)) >> %s.gitversion.txt",
                                 ana.output_tfile->GetName()));
-  gSystem->Exec(
-      TString::Format("(cd $TRACKLOOPERDIR && git --no-pager log  && (cd - > /dev/null)) >> %s.gitversion.txt",
-                      ana.output_tfile->GetName()));
   gSystem->Exec(TString::Format("(cd $TRACKLOOPERDIR && echo 'git diff' && (cd - > /dev/null)) >> %s.gitversion.txt",
                                 ana.output_tfile->GetName()));
   gSystem->Exec(

--- a/RecoTracker/LSTCore/standalone/setup.sh
+++ b/RecoTracker/LSTCore/standalone/setup.sh
@@ -55,7 +55,3 @@ fi
 export LATEST_CPU_BENCHMARK_EFF_MUONGUN="/data2/segmentlinking/muonGun_cpu_efficiencies.root"
 export LATEST_CPU_BENCHMARK_EFF_PU200="/data2/segmentlinking/pu200_cpu_efficiencies.root"
 #eof
-
-eval `scramv1 runtime -sh`
-# this needs to be last because it gets overwritten by cmsenv
-export LD_LIBRARY_PATH=$DIR/SDL:$DIR:$LD_LIBRARY_PATH

--- a/RecoTracker/LSTCore/standalone/setup_hpg.sh
+++ b/RecoTracker/LSTCore/standalone/setup_hpg.sh
@@ -47,8 +47,3 @@ export LSTPERFORMANCEWEBDIR=/home/users/phchang/public_html/LSTPerformanceWeb
 export LATEST_CPU_BENCHMARK_EFF_MUONGUN=
 export LATEST_CPU_BENCHMARK_EFF_PU200=
 #eof
-
-eval `scramv1 runtime -sh`
-# this needs to be last because it gets overwritten by cmsenv
-export LD_LIBRARY_PATH=$DIR/SDL:$DIR:$LD_LIBRARY_PATH
-


### PR DESCRIPTION
This PR fixes a couple of things on the standalone version. It fixes the setup script and makefiles so that it can be built in standalone mode without any extra steps. It also fixes an issue with the ROOT file that the standalone version creates since it saves the git logs, but the logs of the CMSSW repo are too large now, so they are now truncated to the 100 latest commits.