### PR TITLE
add a (dummy) task containing lstModulesDevESProducer

### DIFF
--- a/RecoTracker/LST/python/lstProducer_cff.py
+++ b/RecoTracker/LST/python/lstProducer_cff.py
@@ -7,3 +7,6 @@ from Configuration.ProcessModifiers.gpu_cff import gpu
 
 from RecoTracker.LST.lstModulesDevESProducer_cfi import lstModulesDevESProducer
 (~gpu).toModify(lstModulesDevESProducer.alpaka, backend = 'serial_sync')
+
+# not scheduled task to get the framework to hide the producer
+dummyLSTModulesDevESProducerTask = cms.Task(lstModulesDevESProducer)


### PR DESCRIPTION
~import `Accelerators_cff`~
add a task containing `lstModulesDevESProducer` in RecoTracker/LST/python/lstProducer_cff.py

this seems to fix the unit tests by virtue of getting the framework to not construct the module
