### PR TITLE
Remove LST_IS_CMSSW_PACKAGE flag

### DIFF
--- a/RecoTracker/LSTCore/BuildFile.xml
+++ b/RecoTracker/LSTCore/BuildFile.xml
@@ -2,7 +2,7 @@
 <use name="boost_header"/>
 <use name="root"/>
 <use name="HeterogeneousCore/AlpakaInterface"/>
-<flags CXXFLAGS="-DLST_IS_CMSSW_PACKAGE -DCACHE_ALLOC -DT4FromT3 -DUSE_RZCHI2 -DUSE_T5_DNN -DPT_CUT=0.8 -DDUP_pLS -DDUP_T5 -DDUP_pT5 -DDUP_pT3 -DCrossclean_T5 -DCrossclean_pT3 -Wshadow"/>
+<flags CXXFLAGS="-DCACHE_ALLOC -DT4FromT3 -DUSE_RZCHI2 -DUSE_T5_DNN -DPT_CUT=0.8 -DDUP_pLS -DDUP_T5 -DDUP_pT5 -DDUP_pT3 -DCrossclean_T5 -DCrossclean_pT3 -Wshadow"/>
 <flags ALPAKA_BACKENDS="1"/>
 <export>
   <lib name="1"/>

--- a/RecoTracker/LSTCore/interface/alpaka/LST.h
+++ b/RecoTracker/LSTCore/interface/alpaka/LST.h
@@ -1,13 +1,8 @@
 #ifndef LST_H
 #define LST_H
 
-#ifdef LST_IS_CMSSW_PACKAGE
 #include "RecoTracker/LSTCore/interface/alpaka/Constants.h"
 #include "RecoTracker/LSTCore/interface/alpaka/LSTESData.h"
-#else
-#include "Constants.h"
-#include "LSTESData.h"
-#endif
 
 #include <cstdlib>
 #include <numeric>

--- a/RecoTracker/LSTCore/interface/alpaka/LSTESData.h
+++ b/RecoTracker/LSTCore/interface/alpaka/LSTESData.h
@@ -1,11 +1,7 @@
 #ifndef LSTESData_H
 #define LSTESData_H
 
-#ifdef LST_IS_CMSSW_PACKAGE
 #include "RecoTracker/LSTCore/interface/alpaka/Constants.h"
-#else
-#include "Constants.h"
-#endif
 
 #include "HeterogeneousCore/AlpakaInterface/interface/CopyToDevice.h"
 

--- a/RecoTracker/LSTCore/interface/alpaka/Module.h
+++ b/RecoTracker/LSTCore/interface/alpaka/Module.h
@@ -3,11 +3,7 @@
 
 #include <alpaka/alpaka.hpp>
 
-#ifdef LST_IS_CMSSW_PACKAGE
 #include "RecoTracker/LSTCore/interface/alpaka/Constants.h"
-#else
-#include "Constants.h"
-#endif
 
 namespace SDL {
   enum SubDet { InnerPixel = 0, Barrel = 5, Endcap = 4 };

--- a/RecoTracker/LSTCore/src/alpaka/EndcapGeometry.h
+++ b/RecoTracker/LSTCore/src/alpaka/EndcapGeometry.h
@@ -9,11 +9,7 @@
 #include <vector>
 #include <stdexcept>
 
-#ifdef LST_IS_CMSSW_PACKAGE
 #include "RecoTracker/LSTCore/interface/alpaka/Constants.h"
-#else
-#include "Constants.h"
-#endif
 
 #include "HeterogeneousCore/AlpakaInterface/interface/host.h"
 

--- a/RecoTracker/LSTCore/src/alpaka/Event.h
+++ b/RecoTracker/LSTCore/src/alpaka/Event.h
@@ -1,15 +1,9 @@
 #ifndef Event_cuh
 #define Event_cuh
 
-#ifdef LST_IS_CMSSW_PACKAGE
 #include "RecoTracker/LSTCore/interface/alpaka/Constants.h"
 #include "RecoTracker/LSTCore/interface/alpaka/Module.h"
 #include "RecoTracker/LSTCore/interface/alpaka/LST.h"
-#else
-#include "Constants.h"
-#include "Module.h"
-#include "LST.h"
-#endif
 
 #include "Hit.h"
 #include "ModuleMethods.h"

--- a/RecoTracker/LSTCore/src/alpaka/Hit.h
+++ b/RecoTracker/LSTCore/src/alpaka/Hit.h
@@ -1,13 +1,8 @@
 #ifndef Hit_cuh
 #define Hit_cuh
 
-#ifdef LST_IS_CMSSW_PACKAGE
 #include "RecoTracker/LSTCore/interface/alpaka/Constants.h"
 #include "RecoTracker/LSTCore/interface/alpaka/Module.h"
-#else
-#include "Constants.h"
-#include "Module.h"
-#endif
 
 namespace SDL {
   struct hits {

--- a/RecoTracker/LSTCore/src/alpaka/Kernels.h
+++ b/RecoTracker/LSTCore/src/alpaka/Kernels.h
@@ -1,13 +1,8 @@
 #ifndef Kernels_cuh
 #define Kernels_cuh
 
-#ifdef LST_IS_CMSSW_PACKAGE
 #include "RecoTracker/LSTCore/interface/alpaka/Constants.h"
 #include "RecoTracker/LSTCore/interface/alpaka/Module.h"
-#else
-#include "Constants.h"
-#include "Module.h"
-#endif
 
 #include "Hit.h"
 #include "MiniDoublet.h"

--- a/RecoTracker/LSTCore/src/alpaka/LST.dev.cc
+++ b/RecoTracker/LSTCore/src/alpaka/LST.dev.cc
@@ -1,8 +1,4 @@
-#ifdef LST_IS_CMSSW_PACKAGE
 #include "RecoTracker/LSTCore/interface/alpaka/LST.h"
-#else
-#include "LST.h"
-#endif
 
 #include "Event.h"
 

--- a/RecoTracker/LSTCore/src/alpaka/LSTESData.dev.cc
+++ b/RecoTracker/LSTCore/src/alpaka/LSTESData.dev.cc
@@ -1,8 +1,4 @@
-#ifdef LST_IS_CMSSW_PACKAGE
 #include "RecoTracker/LSTCore/interface/alpaka/LSTESData.h"
-#else
-#include "LSTESData.h"
-#endif
 
 #include "EndcapGeometry.h"
 #include "ModuleConnectionMap.h"

--- a/RecoTracker/LSTCore/src/alpaka/MiniDoublet.h
+++ b/RecoTracker/LSTCore/src/alpaka/MiniDoublet.h
@@ -1,13 +1,8 @@
 #ifndef MiniDoublet_cuh
 #define MiniDoublet_cuh
 
-#ifdef LST_IS_CMSSW_PACKAGE
 #include "RecoTracker/LSTCore/interface/alpaka/Constants.h"
 #include "RecoTracker/LSTCore/interface/alpaka/Module.h"
-#else
-#include "Constants.h"
-#include "Module.h"
-#endif
 
 #include "EndcapGeometry.h"
 #include "Hit.h"

--- a/RecoTracker/LSTCore/src/alpaka/ModuleConnectionMap.h
+++ b/RecoTracker/LSTCore/src/alpaka/ModuleConnectionMap.h
@@ -8,11 +8,7 @@
 #include <sstream>
 #include <algorithm>
 
-#ifdef LST_IS_CMSSW_PACKAGE
 #include "RecoTracker/LSTCore/interface/alpaka/Constants.h"
-#else
-#include "Constants.h"
-#endif
 
 namespace SDL {
   //FIXME: move to non-alpaka single arch build

--- a/RecoTracker/LSTCore/src/alpaka/ModuleMethods.h
+++ b/RecoTracker/LSTCore/src/alpaka/ModuleMethods.h
@@ -4,13 +4,8 @@
 #include <map>
 #include <iostream>
 
-#ifdef LST_IS_CMSSW_PACKAGE
 #include "RecoTracker/LSTCore/interface/alpaka/Constants.h"
 #include "RecoTracker/LSTCore/interface/alpaka/Module.h"
-#else
-#include "Constants.h"
-#include "Module.h"
-#endif
 
 #include "TiltedGeometry.h"
 #include "EndcapGeometry.h"

--- a/RecoTracker/LSTCore/src/alpaka/NeuralNetwork.h
+++ b/RecoTracker/LSTCore/src/alpaka/NeuralNetwork.h
@@ -1,13 +1,8 @@
 #ifndef NeuralNetwork_cuh
 #define NeuralNetwork_cuh
 
-#ifdef LST_IS_CMSSW_PACKAGE
 #include "RecoTracker/LSTCore/interface/alpaka/Constants.h"
 #include "RecoTracker/LSTCore/interface/alpaka/Module.h"
-#else
-#include "Constants.h"
-#include "Module.h"
-#endif
 
 #include "NeuralNetworkWeights.h"
 #include "Segment.h"

--- a/RecoTracker/LSTCore/src/alpaka/PixelMap.h
+++ b/RecoTracker/LSTCore/src/alpaka/PixelMap.h
@@ -4,11 +4,7 @@
 #include <vector>
 #include <cstdint>
 
-#ifdef LST_IS_CMSSW_PACKAGE
 #include "RecoTracker/LSTCore/interface/alpaka/Constants.h"
-#else
-#include "Constants.h"
-#endif
 
 namespace SDL {
   // PixelMap is never allocated on the device.

--- a/RecoTracker/LSTCore/src/alpaka/PixelTriplet.h
+++ b/RecoTracker/LSTCore/src/alpaka/PixelTriplet.h
@@ -1,13 +1,8 @@
 #ifndef PixelTriplet_cuh
 #define PixelTriplet_cuh
 
-#ifdef LST_IS_CMSSW_PACKAGE
 #include "RecoTracker/LSTCore/interface/alpaka/Constants.h"
 #include "RecoTracker/LSTCore/interface/alpaka/Module.h"
-#else
-#include "Constants.h"
-#include "Module.h"
-#endif
 
 #include "Triplet.h"
 #include "Segment.h"
@@ -1852,13 +1847,8 @@ namespace SDL {
 #ifndef PixelQuintuplet_cuh
 #define PixelQuintuplet_cuh
 
-#ifdef LST_IS_CMSSW_PACKAGE
 #include "RecoTracker/LSTCore/interface/alpaka/Constants.h"
 #include "RecoTracker/LSTCore/interface/alpaka/Module.h"
-#else
-#include "Constants.h"
-#include "Module.h"
-#endif
 
 #include "Segment.h"
 #include "MiniDoublet.h"

--- a/RecoTracker/LSTCore/src/alpaka/Quintuplet.h
+++ b/RecoTracker/LSTCore/src/alpaka/Quintuplet.h
@@ -1,13 +1,8 @@
 #ifndef Quintuplet_cuh
 #define Quintuplet_cuh
 
-#ifdef LST_IS_CMSSW_PACKAGE
 #include "RecoTracker/LSTCore/interface/alpaka/Constants.h"
 #include "RecoTracker/LSTCore/interface/alpaka/Module.h"
-#else
-#include "Constants.h"
-#include "Module.h"
-#endif
 
 #include "NeuralNetwork.h"
 #include "EndcapGeometry.h"

--- a/RecoTracker/LSTCore/src/alpaka/Segment.h
+++ b/RecoTracker/LSTCore/src/alpaka/Segment.h
@@ -1,13 +1,8 @@
 #ifndef Segment_cuh
 #define Segment_cuh
 
-#ifdef LST_IS_CMSSW_PACKAGE
 #include "RecoTracker/LSTCore/interface/alpaka/Constants.h"
 #include "RecoTracker/LSTCore/interface/alpaka/Module.h"
-#else
-#include "Constants.h"
-#include "Module.h"
-#endif
 
 #include "EndcapGeometry.h"
 #include "MiniDoublet.h"

--- a/RecoTracker/LSTCore/src/alpaka/TiltedGeometry.h
+++ b/RecoTracker/LSTCore/src/alpaka/TiltedGeometry.h
@@ -9,11 +9,7 @@
 #include <string>
 #include <stdexcept>
 
-#ifdef LST_IS_CMSSW_PACKAGE
 #include "RecoTracker/LSTCore/interface/alpaka/Constants.h"
-#else
-#include "Constants.h"
-#endif
 
 namespace SDL {
   template <typename>

--- a/RecoTracker/LSTCore/src/alpaka/TrackCandidate.h
+++ b/RecoTracker/LSTCore/src/alpaka/TrackCandidate.h
@@ -1,13 +1,8 @@
 #ifndef TrackCandidate_cuh
 #define TrackCandidate_cuh
 
-#ifdef LST_IS_CMSSW_PACKAGE
 #include "RecoTracker/LSTCore/interface/alpaka/Constants.h"
 #include "RecoTracker/LSTCore/interface/alpaka/Module.h"
-#else
-#include "Constants.h"
-#include "Module.h"
-#endif
 
 #include "Triplet.h"
 #include "Segment.h"

--- a/RecoTracker/LSTCore/src/alpaka/Triplet.h
+++ b/RecoTracker/LSTCore/src/alpaka/Triplet.h
@@ -1,13 +1,8 @@
 #ifndef Triplet_cuh
 #define Triplet_cuh
 
-#ifdef LST_IS_CMSSW_PACKAGE
 #include "RecoTracker/LSTCore/interface/alpaka/Constants.h"
 #include "RecoTracker/LSTCore/interface/alpaka/Module.h"
-#else
-#include "Constants.h"
-#include "Module.h"
-#endif
 
 #include "Segment.h"
 #include "MiniDoublet.h"

--- a/RecoTracker/LSTCore/standalone/Makefile
+++ b/RecoTracker/LSTCore/standalone/Makefile
@@ -9,7 +9,7 @@ OBJECTS_ROCM=$(SOURCES:.cc=_rocm.o)
 OBJECTS=$(OBJECTS_CPU) $(OBJECTS_CUDA) $(OBJECTS_ROCM)
 
 CXX         = g++
-CXXFLAGS    = -g -O2 -Wall -fPIC -Wshadow -Woverloaded-virtual -Wno-unused-function -fno-var-tracking -std=c++17 -DLST_IS_CMSSW_PACKAGE
+CXXFLAGS    = -g -O2 -Wall -fPIC -Wshadow -Woverloaded-virtual -Wno-unused-function -fno-var-tracking -std=c++17
 INCLUDEFLAGS= -ISDL -I$(shell pwd) -Icode -Icode/core -I${ALPAKA_ROOT}/include -I/${BOOST_ROOT}/include $(shell rooutil-config --include) -I$(shell root-config --incdir) -I${TRACKLOOPERDIR}/../../../ -I${CMSSW_BASE}/src -I../interface/alpaka/ -I../src/alpaka/
 ifdef CMSSW_RELEASE_BASE
 INCLUDEFLAGS:= ${INCLUDEFLAGS} -I${CMSSW_RELEASE_BASE}/src

--- a/RecoTracker/LSTCore/standalone/SDL/Makefile
+++ b/RecoTracker/LSTCore/standalone/SDL/Makefile
@@ -46,7 +46,7 @@ CXX                  = g++
 CXXFLAGS_CPU         = -march=native -mtune=native -Ofast -fno-reciprocal-math -fopenmp-simd -g -Wall -Wshadow -Woverloaded-virtual -fPIC -fopenmp -I..
 CXXFLAGS_CUDA        = -O3 -g --compiler-options -Wall --compiler-options -Wshadow --compiler-options -Woverloaded-virtual --compiler-options -fPIC --compiler-options -fopenmp -dc -lineinfo --ptxas-options=-v --cudart shared $(GENCODE_CUDA) --use_fast_math --default-stream per-thread -I..
 CXXFLAGS_ROCM        = -O3 -g -Wall -Wshadow -Woverloaded-virtual -fPIC -I${ROCM_ROOT}/include -I..
-CMSSWINCLUDE        := -I${TRACKLOOPERDIR}/../../../ -I${CMSSW_BASE}/src -DLST_IS_CMSSW_PACKAGE
+CMSSWINCLUDE        := -I${TRACKLOOPERDIR}/../../../ -I${CMSSW_BASE}/src
 ifdef CMSSW_RELEASE_BASE
 CMSSWINCLUDE        := ${CMSSWINCLUDE} -I${CMSSW_RELEASE_BASE}/src
 endif


### PR DESCRIPTION
Now that we fully moved development to the CMSSW repo there's no need to keep the `LST_IS_CMSSW_PACKAGE` flag since it was meant for cross-compatibility with the original structure.