### PR TITLE
remove inheritance of buffers on underlying SoAs

### DIFF
--- a/RecoTracker/LSTCore/interface/EndcapGeometryBuffer.h
+++ b/RecoTracker/LSTCore/interface/EndcapGeometryBuffer.h
@@ -18,21 +18,22 @@ namespace SDL {
     const float* geoMapPhi;
 
     template <typename TBuff>
-    void setData(const TBuff& endcapgeombuf) {
-      geoMapDetId = alpaka::getPtrNative(endcapgeombuf.geoMapDetId_buf);
-      geoMapPhi = alpaka::getPtrNative(endcapgeombuf.geoMapPhi_buf);
+    void setData(const TBuff& buf) {
+      geoMapDetId = alpaka::getPtrNative(buf.geoMapDetId_buf);
+      geoMapPhi = alpaka::getPtrNative(buf.geoMapPhi_buf);
     }
   };
 
   template <typename TDev>
-  struct EndcapGeometryBuffer : EndcapGeometryDev {
+  struct EndcapGeometryBuffer {
     Buf<TDev, unsigned int> geoMapDetId_buf;
     Buf<TDev, float> geoMapPhi_buf;
+    EndcapGeometryDev data_;
 
     EndcapGeometryBuffer(TDev const& dev, unsigned int nEndCapMap)
         : geoMapDetId_buf(allocBufWrapper<unsigned int>(dev, nEndCapMap)),
           geoMapPhi_buf(allocBufWrapper<float>(dev, nEndCapMap)) {
-      setData(*this);
+      data_.setData(*this);
     }
 
     template <typename TQueue, typename TDevSrc>
@@ -47,7 +48,7 @@ namespace SDL {
       copyFromSrc(queue, src);
     }
 
-    inline EndcapGeometryDev const* data() const { return this; }
+    inline EndcapGeometryDev const* data() const { return &data_; }
   };
 
 }  // namespace SDL

--- a/RecoTracker/LSTCore/interface/LSTESData.h
+++ b/RecoTracker/LSTCore/interface/LSTESData.h
@@ -19,7 +19,7 @@ namespace SDL {
     uint16_t nLowerModules;
     unsigned int nPixels;
     unsigned int nEndCapMap;
-    std::shared_ptr<const modulesBuffer<TDev>> modulesBuffers;
+    std::shared_ptr<const ModulesBuffer<TDev>> modulesBuffers;
     std::shared_ptr<const EndcapGeometryBuffer<TDev>> endcapGeometryBuffers;
     std::shared_ptr<const pixelMap> pixelMapping;
 
@@ -27,7 +27,7 @@ namespace SDL {
               uint16_t const& nLowerModulesIn,
               unsigned int const& nPixelsIn,
               unsigned int const& nEndCapMapIn,
-              std::shared_ptr<const modulesBuffer<TDev>> const& modulesBuffersIn,
+              std::shared_ptr<const ModulesBuffer<TDev>> const& modulesBuffersIn,
               std::shared_ptr<const EndcapGeometryBuffer<TDev>> const& endcapGeometryBuffersIn,
               std::shared_ptr<const pixelMap> const& pixelMappingIn)
         : nModules(nModulesIn),
@@ -49,7 +49,7 @@ namespace cms::alpakatools {
     template <typename TQueue>
     static SDL::LSTESData<alpaka::Dev<TQueue>> copyAsync(TQueue& queue,
                                                          SDL::LSTESData<alpaka_common::DevHost> const& srcData) {
-      auto deviceModulesBuffers = std::make_shared<SDL::modulesBuffer<alpaka::Dev<TQueue>>>(
+      auto deviceModulesBuffers = std::make_shared<SDL::ModulesBuffer<alpaka::Dev<TQueue>>>(
           alpaka::getDev(queue), srcData.nModules, srcData.nPixels);
       deviceModulesBuffers->copyFromSrc(queue, *srcData.modulesBuffers);
       auto deviceEndcapGeometryBuffers =

--- a/RecoTracker/LSTCore/interface/Module.h
+++ b/RecoTracker/LSTCore/interface/Module.h
@@ -12,147 +12,7 @@ namespace SDL {
 
   enum ModuleLayerType { Pixel, Strip, InnerPixelLayer };
 
-  struct objectRanges {
-    int* hitRanges;
-    int* hitRangesLower;
-    int* hitRangesUpper;
-    int8_t* hitRangesnLower;
-    int8_t* hitRangesnUpper;
-    int* mdRanges;
-    int* segmentRanges;
-    int* trackletRanges;
-    int* tripletRanges;
-    int* trackCandidateRanges;
-    // Others will be added later
-    int* quintupletRanges;
-
-    // This number is just nEligibleModules - 1, but still we want this to be independent of the TC kernel
-    uint16_t* nEligibleT5Modules;
-    // Will be allocated in createQuintuplets kernel!
-    uint16_t* indicesOfEligibleT5Modules;
-    // To store different starting points for variable occupancy stuff
-    int* quintupletModuleIndices;
-    int* quintupletModuleOccupancy;
-    int* miniDoubletModuleIndices;
-    int* miniDoubletModuleOccupancy;
-    int* segmentModuleIndices;
-    int* segmentModuleOccupancy;
-    int* tripletModuleIndices;
-    int* tripletModuleOccupancy;
-
-    unsigned int* device_nTotalMDs;
-    unsigned int* device_nTotalSegs;
-    unsigned int* device_nTotalTrips;
-    unsigned int* device_nTotalQuints;
-
-    template <typename TBuff>
-    void setData(TBuff& objectRangesbuf) {
-      hitRanges = alpaka::getPtrNative(objectRangesbuf.hitRanges_buf);
-      hitRangesLower = alpaka::getPtrNative(objectRangesbuf.hitRangesLower_buf);
-      hitRangesUpper = alpaka::getPtrNative(objectRangesbuf.hitRangesUpper_buf);
-      hitRangesnLower = alpaka::getPtrNative(objectRangesbuf.hitRangesnLower_buf);
-      hitRangesnUpper = alpaka::getPtrNative(objectRangesbuf.hitRangesnUpper_buf);
-      mdRanges = alpaka::getPtrNative(objectRangesbuf.mdRanges_buf);
-      segmentRanges = alpaka::getPtrNative(objectRangesbuf.segmentRanges_buf);
-      trackletRanges = alpaka::getPtrNative(objectRangesbuf.trackletRanges_buf);
-      tripletRanges = alpaka::getPtrNative(objectRangesbuf.tripletRanges_buf);
-      trackCandidateRanges = alpaka::getPtrNative(objectRangesbuf.trackCandidateRanges_buf);
-      quintupletRanges = alpaka::getPtrNative(objectRangesbuf.quintupletRanges_buf);
-
-      nEligibleT5Modules = alpaka::getPtrNative(objectRangesbuf.nEligibleT5Modules_buf);
-      indicesOfEligibleT5Modules = alpaka::getPtrNative(objectRangesbuf.indicesOfEligibleT5Modules_buf);
-
-      quintupletModuleIndices = alpaka::getPtrNative(objectRangesbuf.quintupletModuleIndices_buf);
-      quintupletModuleOccupancy = alpaka::getPtrNative(objectRangesbuf.quintupletModuleOccupancy_buf);
-      miniDoubletModuleIndices = alpaka::getPtrNative(objectRangesbuf.miniDoubletModuleIndices_buf);
-      miniDoubletModuleOccupancy = alpaka::getPtrNative(objectRangesbuf.miniDoubletModuleOccupancy_buf);
-      segmentModuleIndices = alpaka::getPtrNative(objectRangesbuf.segmentModuleIndices_buf);
-      segmentModuleOccupancy = alpaka::getPtrNative(objectRangesbuf.segmentModuleOccupancy_buf);
-      tripletModuleIndices = alpaka::getPtrNative(objectRangesbuf.tripletModuleIndices_buf);
-      tripletModuleOccupancy = alpaka::getPtrNative(objectRangesbuf.tripletModuleOccupancy_buf);
-
-      device_nTotalMDs = alpaka::getPtrNative(objectRangesbuf.device_nTotalMDs_buf);
-      device_nTotalSegs = alpaka::getPtrNative(objectRangesbuf.device_nTotalSegs_buf);
-      device_nTotalTrips = alpaka::getPtrNative(objectRangesbuf.device_nTotalTrips_buf);
-      device_nTotalQuints = alpaka::getPtrNative(objectRangesbuf.device_nTotalQuints_buf);
-    }
-  };
-
-  template <typename TDev>
-  struct objectRangesBuffer : objectRanges {
-    Buf<TDev, int> hitRanges_buf;
-    Buf<TDev, int> hitRangesLower_buf;
-    Buf<TDev, int> hitRangesUpper_buf;
-    Buf<TDev, int8_t> hitRangesnLower_buf;
-    Buf<TDev, int8_t> hitRangesnUpper_buf;
-    Buf<TDev, int> mdRanges_buf;
-    Buf<TDev, int> segmentRanges_buf;
-    Buf<TDev, int> trackletRanges_buf;
-    Buf<TDev, int> tripletRanges_buf;
-    Buf<TDev, int> trackCandidateRanges_buf;
-    Buf<TDev, int> quintupletRanges_buf;
-
-    Buf<TDev, uint16_t> nEligibleT5Modules_buf;
-    Buf<TDev, uint16_t> indicesOfEligibleT5Modules_buf;
-
-    Buf<TDev, int> quintupletModuleIndices_buf;
-    Buf<TDev, int> quintupletModuleOccupancy_buf;
-    Buf<TDev, int> miniDoubletModuleIndices_buf;
-    Buf<TDev, int> miniDoubletModuleOccupancy_buf;
-    Buf<TDev, int> segmentModuleIndices_buf;
-    Buf<TDev, int> segmentModuleOccupancy_buf;
-    Buf<TDev, int> tripletModuleIndices_buf;
-    Buf<TDev, int> tripletModuleOccupancy_buf;
-
-    Buf<TDev, unsigned int> device_nTotalMDs_buf;
-    Buf<TDev, unsigned int> device_nTotalSegs_buf;
-    Buf<TDev, unsigned int> device_nTotalTrips_buf;
-    Buf<TDev, unsigned int> device_nTotalQuints_buf;
-
-    template <typename TQueue, typename TDevAcc>
-    objectRangesBuffer(unsigned int nMod, unsigned int nLowerMod, TDevAcc const& devAccIn, TQueue& queue)
-        : hitRanges_buf(allocBufWrapper<int>(devAccIn, nMod * 2, queue)),
-          hitRangesLower_buf(allocBufWrapper<int>(devAccIn, nMod, queue)),
-          hitRangesUpper_buf(allocBufWrapper<int>(devAccIn, nMod, queue)),
-          hitRangesnLower_buf(allocBufWrapper<int8_t>(devAccIn, nMod, queue)),
-          hitRangesnUpper_buf(allocBufWrapper<int8_t>(devAccIn, nMod, queue)),
-          mdRanges_buf(allocBufWrapper<int>(devAccIn, nMod * 2, queue)),
-          segmentRanges_buf(allocBufWrapper<int>(devAccIn, nMod * 2, queue)),
-          trackletRanges_buf(allocBufWrapper<int>(devAccIn, nMod * 2, queue)),
-          tripletRanges_buf(allocBufWrapper<int>(devAccIn, nMod * 2, queue)),
-          trackCandidateRanges_buf(allocBufWrapper<int>(devAccIn, nMod * 2, queue)),
-          quintupletRanges_buf(allocBufWrapper<int>(devAccIn, nMod * 2, queue)),
-          nEligibleT5Modules_buf(allocBufWrapper<uint16_t>(devAccIn, 1, queue)),
-          indicesOfEligibleT5Modules_buf(allocBufWrapper<uint16_t>(devAccIn, nLowerMod, queue)),
-          quintupletModuleIndices_buf(allocBufWrapper<int>(devAccIn, nLowerMod, queue)),
-          quintupletModuleOccupancy_buf(allocBufWrapper<int>(devAccIn, nLowerMod, queue)),
-          miniDoubletModuleIndices_buf(allocBufWrapper<int>(devAccIn, nLowerMod + 1, queue)),
-          miniDoubletModuleOccupancy_buf(allocBufWrapper<int>(devAccIn, nLowerMod + 1, queue)),
-          segmentModuleIndices_buf(allocBufWrapper<int>(devAccIn, nLowerMod + 1, queue)),
-          segmentModuleOccupancy_buf(allocBufWrapper<int>(devAccIn, nLowerMod + 1, queue)),
-          tripletModuleIndices_buf(allocBufWrapper<int>(devAccIn, nLowerMod, queue)),
-          tripletModuleOccupancy_buf(allocBufWrapper<int>(devAccIn, nLowerMod, queue)),
-          device_nTotalMDs_buf(allocBufWrapper<unsigned int>(devAccIn, 1, queue)),
-          device_nTotalSegs_buf(allocBufWrapper<unsigned int>(devAccIn, 1, queue)),
-          device_nTotalTrips_buf(allocBufWrapper<unsigned int>(devAccIn, 1, queue)),
-          device_nTotalQuints_buf(allocBufWrapper<unsigned int>(devAccIn, 1, queue)) {
-      alpaka::memset(queue, hitRanges_buf, 0xff);
-      alpaka::memset(queue, hitRangesLower_buf, 0xff);
-      alpaka::memset(queue, hitRangesUpper_buf, 0xff);
-      alpaka::memset(queue, hitRangesnLower_buf, 0xff);
-      alpaka::memset(queue, hitRangesnUpper_buf, 0xff);
-      alpaka::memset(queue, mdRanges_buf, 0xff);
-      alpaka::memset(queue, segmentRanges_buf, 0xff);
-      alpaka::memset(queue, trackletRanges_buf, 0xff);
-      alpaka::memset(queue, tripletRanges_buf, 0xff);
-      alpaka::memset(queue, trackCandidateRanges_buf, 0xff);
-      alpaka::memset(queue, quintupletRanges_buf, 0xff);
-      alpaka::memset(queue, quintupletModuleIndices_buf, 0xff);
-      alpaka::wait(queue);
-    }
-  };
-
-  struct modules {
+  struct Modules {
     const unsigned int* detIds;
     const uint16_t* moduleMap;
     const unsigned int* mapdetId;
@@ -223,38 +83,38 @@ namespace SDL {
     };
 
     template <typename TBuff>
-    void setData(const TBuff& modulesbuf) {
-      detIds = alpaka::getPtrNative(modulesbuf.detIds_buf);
-      moduleMap = alpaka::getPtrNative(modulesbuf.moduleMap_buf);
-      mapdetId = alpaka::getPtrNative(modulesbuf.mapdetId_buf);
-      mapIdx = alpaka::getPtrNative(modulesbuf.mapIdx_buf);
-      nConnectedModules = alpaka::getPtrNative(modulesbuf.nConnectedModules_buf);
-      drdzs = alpaka::getPtrNative(modulesbuf.drdzs_buf);
-      dxdys = alpaka::getPtrNative(modulesbuf.dxdys_buf);
-      nModules = alpaka::getPtrNative(modulesbuf.nModules_buf);
-      nLowerModules = alpaka::getPtrNative(modulesbuf.nLowerModules_buf);
-      partnerModuleIndices = alpaka::getPtrNative(modulesbuf.partnerModuleIndices_buf);
+    void setData(const TBuff& buf) {
+      detIds = alpaka::getPtrNative(buf.detIds_buf);
+      moduleMap = alpaka::getPtrNative(buf.moduleMap_buf);
+      mapdetId = alpaka::getPtrNative(buf.mapdetId_buf);
+      mapIdx = alpaka::getPtrNative(buf.mapIdx_buf);
+      nConnectedModules = alpaka::getPtrNative(buf.nConnectedModules_buf);
+      drdzs = alpaka::getPtrNative(buf.drdzs_buf);
+      dxdys = alpaka::getPtrNative(buf.dxdys_buf);
+      nModules = alpaka::getPtrNative(buf.nModules_buf);
+      nLowerModules = alpaka::getPtrNative(buf.nLowerModules_buf);
+      partnerModuleIndices = alpaka::getPtrNative(buf.partnerModuleIndices_buf);
 
-      layers = alpaka::getPtrNative(modulesbuf.layers_buf);
-      rings = alpaka::getPtrNative(modulesbuf.rings_buf);
-      modules = alpaka::getPtrNative(modulesbuf.modules_buf);
-      rods = alpaka::getPtrNative(modulesbuf.rods_buf);
-      subdets = alpaka::getPtrNative(modulesbuf.subdets_buf);
-      sides = alpaka::getPtrNative(modulesbuf.sides_buf);
-      eta = alpaka::getPtrNative(modulesbuf.eta_buf);
-      r = alpaka::getPtrNative(modulesbuf.r_buf);
-      isInverted = alpaka::getPtrNative(modulesbuf.isInverted_buf);
-      isLower = alpaka::getPtrNative(modulesbuf.isLower_buf);
-      isAnchor = alpaka::getPtrNative(modulesbuf.isAnchor_buf);
-      moduleType = alpaka::getPtrNative(modulesbuf.moduleType_buf);
-      moduleLayerType = alpaka::getPtrNative(modulesbuf.moduleLayerType_buf);
-      sdlLayers = alpaka::getPtrNative(modulesbuf.sdlLayers_buf);
-      connectedPixels = alpaka::getPtrNative(modulesbuf.connectedPixels_buf);
+      layers = alpaka::getPtrNative(buf.layers_buf);
+      rings = alpaka::getPtrNative(buf.rings_buf);
+      modules = alpaka::getPtrNative(buf.modules_buf);
+      rods = alpaka::getPtrNative(buf.rods_buf);
+      subdets = alpaka::getPtrNative(buf.subdets_buf);
+      sides = alpaka::getPtrNative(buf.sides_buf);
+      eta = alpaka::getPtrNative(buf.eta_buf);
+      r = alpaka::getPtrNative(buf.r_buf);
+      isInverted = alpaka::getPtrNative(buf.isInverted_buf);
+      isLower = alpaka::getPtrNative(buf.isLower_buf);
+      isAnchor = alpaka::getPtrNative(buf.isAnchor_buf);
+      moduleType = alpaka::getPtrNative(buf.moduleType_buf);
+      moduleLayerType = alpaka::getPtrNative(buf.moduleLayerType_buf);
+      sdlLayers = alpaka::getPtrNative(buf.sdlLayers_buf);
+      connectedPixels = alpaka::getPtrNative(buf.connectedPixels_buf);
     }
   };
 
   template <typename TDev>
-  struct modulesBuffer : modules {
+  struct ModulesBuffer {
     Buf<TDev, unsigned int> detIds_buf;
     Buf<TDev, uint16_t> moduleMap_buf;
     Buf<TDev, unsigned int> mapdetId_buf;
@@ -282,7 +142,9 @@ namespace SDL {
     Buf<TDev, int> sdlLayers_buf;
     Buf<TDev, unsigned int> connectedPixels_buf;
 
-    modulesBuffer(TDev const& dev, unsigned int nMod, unsigned int nPixs)
+    Modules data_;
+
+    ModulesBuffer(TDev const& dev, unsigned int nMod, unsigned int nPixs)
         : detIds_buf(allocBufWrapper<unsigned int>(dev, nMod)),
           moduleMap_buf(allocBufWrapper<uint16_t>(dev, nMod * MAX_CONNECTED_MODULES)),
           mapdetId_buf(allocBufWrapper<unsigned int>(dev, nMod)),
@@ -309,11 +171,11 @@ namespace SDL {
           moduleLayerType_buf(allocBufWrapper<ModuleLayerType>(dev, nMod)),
           sdlLayers_buf(allocBufWrapper<int>(dev, nMod)),
           connectedPixels_buf(allocBufWrapper<unsigned int>(dev, nPixs)) {
-      setData(*this);
+      data_.setData(*this);
     }
 
     template <typename TQueue, typename TDevSrc>
-    inline void copyFromSrc(TQueue queue, const modulesBuffer<TDevSrc>& src, bool isFull = true) {
+    inline void copyFromSrc(TQueue queue, const ModulesBuffer<TDevSrc>& src, bool isFull = true) {
       alpaka::memcpy(queue, detIds_buf, src.detIds_buf);
       if (isFull) {
         alpaka::memcpy(queue, moduleMap_buf, src.moduleMap_buf);
@@ -354,12 +216,12 @@ namespace SDL {
     }
 
     template <typename TQueue, typename TDevSrc>
-    modulesBuffer(TQueue queue, const modulesBuffer<TDevSrc>& src, unsigned int nMod, unsigned int nPixs)
-        : modulesBuffer(alpaka::getDev(queue), nMod, nPixs) {
+    ModulesBuffer(TQueue queue, const ModulesBuffer<TDevSrc>& src, unsigned int nMod, unsigned int nPixs)
+        : ModulesBuffer(alpaka::getDev(queue), nMod, nPixs) {
       copyFromSrc(queue, src);
     }
 
-    inline SDL::modules const* data() const { return this; }
+    inline Modules const* data() const { return &data_; }
   };
 
 }  // namespace SDL

--- a/RecoTracker/LSTCore/src/LSTESData.cc
+++ b/RecoTracker/LSTCore/src/LSTESData.cc
@@ -81,7 +81,7 @@ std::unique_ptr<SDL::LSTESData<alpaka_common::DevHost>> SDL::loadAndFillESHost()
   uint16_t nModules;
   uint16_t nLowerModules;
   unsigned int nPixels;
-  std::shared_ptr<SDL::modulesBuffer<alpaka_common::DevHost>> modulesBuffers = nullptr;
+  std::shared_ptr<SDL::ModulesBuffer<alpaka_common::DevHost>> modulesBuffers = nullptr;
   auto pLStoLayer = std::make_shared<MapPLStoLayer>();
   auto endcapGeometry = std::make_shared<EndcapGeometry>();
   auto tiltedGeometry = std::make_shared<TiltedGeometry>();

--- a/RecoTracker/LSTCore/src/ModuleMethods.h
+++ b/RecoTracker/LSTCore/src/ModuleMethods.h
@@ -24,7 +24,7 @@ namespace SDL {
   };
 
   template <typename TQueue>
-  inline void fillPixelMap(std::shared_ptr<modulesBuffer<alpaka_common::DevHost>>& modulesBuf,
+  inline void fillPixelMap(std::shared_ptr<ModulesBuffer<alpaka_common::DevHost>>& modulesBuf,
                            uint16_t nModules,
                            unsigned int& nPixels,
                            pixelMap& pixelMapping,
@@ -84,7 +84,7 @@ namespace SDL {
     // Now we can initialize modulesBuf
     alpaka_common::DevHost const& devHost = cms::alpakatools::host();
     if (modulesBuf == nullptr) {
-      modulesBuf = std::make_shared<modulesBuffer<alpaka_common::DevHost>>(devHost, nModules, nPixels);
+      modulesBuf = std::make_shared<ModulesBuffer<alpaka_common::DevHost>>(devHost, nModules, nPixels);
     }
 
     auto connectedPixels_buf = allocBufWrapper<unsigned int>(devHost, connectedPix_size);
@@ -105,7 +105,7 @@ namespace SDL {
   };
 
   template <typename TQueue, typename TDev>
-  inline void fillConnectedModuleArrayExplicit(struct modulesBuffer<TDev>* modulesBuf,
+  inline void fillConnectedModuleArrayExplicit(struct ModulesBuffer<TDev>* modulesBuf,
                                                unsigned int nMod,
                                                TQueue queue,
                                                struct ModuleMetaData& mmd,
@@ -133,7 +133,7 @@ namespace SDL {
   };
 
   template <typename TQueue, typename TDev>
-  inline void fillMapArraysExplicit(struct modulesBuffer<TDev>* modulesBuf,
+  inline void fillMapArraysExplicit(struct ModulesBuffer<TDev>* modulesBuf,
                                     unsigned int nMod,
                                     TQueue queue,
                                     struct ModuleMetaData& mmd) {
@@ -223,7 +223,7 @@ namespace SDL {
                                   uint16_t& nModules,
                                   uint16_t& nLowerModules,
                                   unsigned int& nPixels,
-                                  std::shared_ptr<modulesBuffer<alpaka_common::DevHost>>& modulesBuf,
+                                  std::shared_ptr<ModulesBuffer<alpaka_common::DevHost>>& modulesBuf,
                                   pixelMap* pixelMapping,
                                   const EndcapGeometry* endcapGeometry,
                                   const TiltedGeometry* tiltedGeometry,
@@ -302,8 +302,8 @@ namespace SDL {
         r = 0;
       } else {
         setDerivedQuantities(detId, layer, ring, rod, module, subdet, side, m_x, m_y, m_z, eta, r);
-        isInverted = SDL::modules::parseIsInverted(subdet, side, module, layer);
-        isLower = SDL::modules::parseIsLower(isInverted, detId);
+        isInverted = SDL::Modules::parseIsInverted(subdet, side, module, layer);
+        isLower = SDL::Modules::parseIsLower(isInverted, detId);
       }
       if (isLower) {
         index = lowerModuleCounter;
@@ -361,7 +361,7 @@ namespace SDL {
       auto& index = it->second;
       if (detId != 1) {
         host_partnerModuleIndices[index] =
-            mmd.detIdToIndex[SDL::modules::parsePartnerModuleId(detId, host_isLower[index], host_isInverted[index])];
+            mmd.detIdToIndex[SDL::Modules::parsePartnerModuleId(detId, host_isLower[index], host_isInverted[index])];
         //add drdz and slope importing stuff here!
         if (host_drdzs[index] == 0) {
           host_drdzs[index] = host_drdzs[host_partnerModuleIndices[index]];

--- a/RecoTracker/LSTCore/src/alpaka/Event.dev.cc
+++ b/RecoTracker/LSTCore/src/alpaka/Event.dev.cc
@@ -160,14 +160,14 @@ void SDL::Event<Acc3D>::addHitToEvent(std::vector<float> x,
 
   // Initialize space on device/host for next event.
   if (hitsInGPU == nullptr) {
-    hitsInGPU = new SDL::hits();
-    hitsBuffers = new SDL::hitsBuffer<Device>(nModules_, nHits, devAcc, queue);
+    hitsInGPU = new SDL::Hits();
+    hitsBuffers = new SDL::HitsBuffer<Device>(nModules_, nHits, devAcc, queue);
     hitsInGPU->setData(*hitsBuffers);
   }
 
   if (rangesInGPU == nullptr) {
-    rangesInGPU = new SDL::objectRanges();
-    rangesBuffers = new SDL::objectRangesBuffer<Device>(nModules_, nLowerModules_, devAcc, queue);
+    rangesInGPU = new SDL::ObjectRanges();
+    rangesBuffers = new SDL::ObjectRangesBuffer<Device>(nModules_, nLowerModules_, devAcc, queue);
     rangesInGPU->setData(*rangesBuffers);
   }
 
@@ -281,8 +281,8 @@ void SDL::Event<Acc3D>::addPixelSegmentToEvent(std::vector<unsigned int> hitIndi
 
     nTotalMDs += N_MAX_PIXEL_MD_PER_MODULES;
 
-    mdsInGPU = new SDL::miniDoublets();
-    miniDoubletsBuffers = new SDL::miniDoubletsBuffer<Device>(nTotalMDs, nLowerModules_, devAcc, queue);
+    mdsInGPU = new SDL::MiniDoublets();
+    miniDoubletsBuffers = new SDL::MiniDoubletsBuffer<Device>(nTotalMDs, nLowerModules_, devAcc, queue);
     mdsInGPU->setData(*miniDoubletsBuffers);
 
     alpaka::memcpy(queue, miniDoubletsBuffers->nMemoryLocations_buf, nTotalMDs_view);
@@ -314,9 +314,9 @@ void SDL::Event<Acc3D>::addPixelSegmentToEvent(std::vector<unsigned int> hitIndi
 
     nTotalSegments += N_MAX_PIXEL_SEGMENTS_PER_MODULE;
 
-    segmentsInGPU = new SDL::segments();
+    segmentsInGPU = new SDL::Segments();
     segmentsBuffers =
-        new SDL::segmentsBuffer<Device>(nTotalSegments, nLowerModules_, N_MAX_PIXEL_SEGMENTS_PER_MODULE, devAcc, queue);
+        new SDL::SegmentsBuffer<Device>(nTotalSegments, nLowerModules_, N_MAX_PIXEL_SEGMENTS_PER_MODULE, devAcc, queue);
     segmentsInGPU->setData(*segmentsBuffers);
 
     alpaka::memcpy(queue, segmentsBuffers->nMemoryLocations_buf, nTotalSegments_view);
@@ -427,8 +427,8 @@ void SDL::Event<Acc3D>::createMiniDoublets() {
   nTotalMDs += N_MAX_PIXEL_MD_PER_MODULES;
 
   if (mdsInGPU == nullptr) {
-    mdsInGPU = new SDL::miniDoublets();
-    miniDoubletsBuffers = new SDL::miniDoubletsBuffer<Device>(nTotalMDs, nLowerModules_, devAcc, queue);
+    mdsInGPU = new SDL::MiniDoublets();
+    miniDoubletsBuffers = new SDL::MiniDoubletsBuffer<Device>(nTotalMDs, nLowerModules_, devAcc, queue);
     mdsInGPU->setData(*miniDoubletsBuffers);
   }
 
@@ -471,9 +471,9 @@ void SDL::Event<Acc3D>::createMiniDoublets() {
 
 void SDL::Event<Acc3D>::createSegmentsWithModuleMap() {
   if (segmentsInGPU == nullptr) {
-    segmentsInGPU = new SDL::segments();
+    segmentsInGPU = new SDL::Segments();
     segmentsBuffers =
-        new SDL::segmentsBuffer<Device>(nTotalSegments, nLowerModules_, N_MAX_PIXEL_SEGMENTS_PER_MODULE, devAcc, queue);
+        new SDL::SegmentsBuffer<Device>(nTotalSegments, nLowerModules_, N_MAX_PIXEL_SEGMENTS_PER_MODULE, devAcc, queue);
     segmentsInGPU->setData(*segmentsBuffers);
   }
 
@@ -536,9 +536,9 @@ void SDL::Event<Acc3D>::createTriplets() {
     alpaka::memcpy(queue, maxTriplets_buf, rangesBuffers->device_nTotalTrips_buf);
     alpaka::wait(queue);
 
-    tripletsInGPU = new SDL::triplets();
+    tripletsInGPU = new SDL::Triplets();
     tripletsBuffers =
-        new SDL::tripletsBuffer<Device>(*alpaka::getPtrNative(maxTriplets_buf), nLowerModules_, devAcc, queue);
+        new SDL::TripletsBuffer<Device>(*alpaka::getPtrNative(maxTriplets_buf), nLowerModules_, devAcc, queue);
     tripletsInGPU->setData(*tripletsBuffers);
 
     alpaka::memcpy(queue, tripletsBuffers->nMemoryLocations_buf, maxTriplets_buf);
@@ -624,8 +624,8 @@ void SDL::Event<Acc3D>::createTriplets() {
 
 void SDL::Event<Acc3D>::createTrackCandidates(bool no_pls_dupclean, bool tc_pls_triplets) {
   if (trackCandidatesInGPU == nullptr) {
-    trackCandidatesInGPU = new SDL::trackCandidates();
-    trackCandidatesBuffers = new SDL::trackCandidatesBuffer<Device>(
+    trackCandidatesInGPU = new SDL::TrackCandidates();
+    trackCandidatesBuffers = new SDL::TrackCandidatesBuffer<Device>(
         N_MAX_NONPIXEL_TRACK_CANDIDATES + N_MAX_PIXEL_TRACK_CANDIDATES, devAcc, queue);
     trackCandidatesInGPU->setData(*trackCandidatesBuffers);
   }
@@ -789,8 +789,8 @@ void SDL::Event<Acc3D>::createTrackCandidates(bool no_pls_dupclean, bool tc_pls_
 
 void SDL::Event<Acc3D>::createPixelTriplets() {
   if (pixelTripletsInGPU == nullptr) {
-    pixelTripletsInGPU = new SDL::pixelTriplets();
-    pixelTripletsBuffers = new SDL::pixelTripletsBuffer<Device>(N_MAX_PIXEL_TRIPLETS, devAcc, queue);
+    pixelTripletsInGPU = new SDL::PixelTriplets();
+    pixelTripletsBuffers = new SDL::PixelTripletsBuffer<Device>(N_MAX_PIXEL_TRIPLETS, devAcc, queue);
     pixelTripletsInGPU->setData(*pixelTripletsBuffers);
   }
 
@@ -934,8 +934,8 @@ void SDL::Event<Acc3D>::createQuintuplets() {
   unsigned int nTotalQuintuplets = *alpaka::getPtrNative(nTotalQuintuplets_buf);
 
   if (quintupletsInGPU == nullptr) {
-    quintupletsInGPU = new SDL::quintuplets();
-    quintupletsBuffers = new SDL::quintupletsBuffer<Device>(nTotalQuintuplets, nLowerModules_, devAcc, queue);
+    quintupletsInGPU = new SDL::Quintuplets();
+    quintupletsBuffers = new SDL::QuintupletsBuffer<Device>(nTotalQuintuplets, nLowerModules_, devAcc, queue);
     quintupletsInGPU->setData(*quintupletsBuffers);
 
     alpaka::memcpy(queue, quintupletsBuffers->nMemoryLocations_buf, nTotalQuintuplets_buf);
@@ -1014,13 +1014,13 @@ void SDL::Event<Acc3D>::pixelLineSegmentCleaning(bool no_pls_dupclean) {
 
 void SDL::Event<Acc3D>::createPixelQuintuplets() {
   if (pixelQuintupletsInGPU == nullptr) {
-    pixelQuintupletsInGPU = new SDL::pixelQuintuplets();
-    pixelQuintupletsBuffers = new SDL::pixelQuintupletsBuffer<Device>(N_MAX_PIXEL_QUINTUPLETS, devAcc, queue);
+    pixelQuintupletsInGPU = new SDL::PixelQuintuplets();
+    pixelQuintupletsBuffers = new SDL::PixelQuintupletsBuffer<Device>(N_MAX_PIXEL_QUINTUPLETS, devAcc, queue);
     pixelQuintupletsInGPU->setData(*pixelQuintupletsBuffers);
   }
   if (trackCandidatesInGPU == nullptr) {
-    trackCandidatesInGPU = new SDL::trackCandidates();
-    trackCandidatesBuffers = new SDL::trackCandidatesBuffer<Device>(
+    trackCandidatesInGPU = new SDL::TrackCandidates();
+    trackCandidatesBuffers = new SDL::TrackCandidatesBuffer<Device>(
         N_MAX_NONPIXEL_TRACK_CANDIDATES + N_MAX_PIXEL_TRACK_CANDIDATES, devAcc, queue);
     trackCandidatesInGPU->setData(*trackCandidatesBuffers);
   }
@@ -1492,7 +1492,7 @@ int SDL::Event<Acc3D>::getNumberOfT5TrackCandidates() {
   return nTrackCandidatesT5;
 }
 
-SDL::hitsBuffer<DevHost>* SDL::Event<Acc3D>::getHits()  //std::shared_ptr should take care of garbage collection
+SDL::HitsBuffer<DevHost>* SDL::Event<Acc3D>::getHits()  //std::shared_ptr should take care of garbage collection
 {
   if (hitsInCPU == nullptr) {
     auto nHits_buf = allocBufWrapper<unsigned int>(devHost, 1, queue);
@@ -1500,7 +1500,7 @@ SDL::hitsBuffer<DevHost>* SDL::Event<Acc3D>::getHits()  //std::shared_ptr should
     alpaka::wait(queue);
 
     unsigned int nHits = *alpaka::getPtrNative(nHits_buf);
-    hitsInCPU = new SDL::hitsBuffer<DevHost>(nModules_, nHits, devHost, queue);
+    hitsInCPU = new SDL::HitsBuffer<DevHost>(nModules_, nHits, devHost, queue);
     hitsInCPU->setData(*hitsInCPU);
 
     *alpaka::getPtrNative(hitsInCPU->nHits_buf) = nHits;
@@ -1515,14 +1515,14 @@ SDL::hitsBuffer<DevHost>* SDL::Event<Acc3D>::getHits()  //std::shared_ptr should
   return hitsInCPU;
 }
 
-SDL::hitsBuffer<DevHost>* SDL::Event<Acc3D>::getHitsInCMSSW() {
+SDL::HitsBuffer<DevHost>* SDL::Event<Acc3D>::getHitsInCMSSW() {
   if (hitsInCPU == nullptr) {
     auto nHits_buf = allocBufWrapper<unsigned int>(devHost, 1, queue);
     alpaka::memcpy(queue, nHits_buf, hitsBuffers->nHits_buf);
     alpaka::wait(queue);
 
     unsigned int nHits = *alpaka::getPtrNative(nHits_buf);
-    hitsInCPU = new SDL::hitsBuffer<DevHost>(nModules_, nHits, devHost, queue);
+    hitsInCPU = new SDL::HitsBuffer<DevHost>(nModules_, nHits, devHost, queue);
     hitsInCPU->setData(*hitsInCPU);
 
     *alpaka::getPtrNative(hitsInCPU->nHits_buf) = nHits;
@@ -1532,9 +1532,9 @@ SDL::hitsBuffer<DevHost>* SDL::Event<Acc3D>::getHitsInCMSSW() {
   return hitsInCPU;
 }
 
-SDL::objectRangesBuffer<DevHost>* SDL::Event<Acc3D>::getRanges() {
+SDL::ObjectRangesBuffer<DevHost>* SDL::Event<Acc3D>::getRanges() {
   if (rangesInCPU == nullptr) {
-    rangesInCPU = new SDL::objectRangesBuffer<DevHost>(nModules_, nLowerModules_, devHost, queue);
+    rangesInCPU = new SDL::ObjectRangesBuffer<DevHost>(nModules_, nLowerModules_, devHost, queue);
     rangesInCPU->setData(*rangesInCPU);
 
     alpaka::memcpy(queue, rangesInCPU->hitRanges_buf, rangesBuffers->hitRanges_buf);
@@ -1547,7 +1547,7 @@ SDL::objectRangesBuffer<DevHost>* SDL::Event<Acc3D>::getRanges() {
   return rangesInCPU;
 }
 
-SDL::miniDoubletsBuffer<DevHost>* SDL::Event<Acc3D>::getMiniDoublets() {
+SDL::MiniDoubletsBuffer<DevHost>* SDL::Event<Acc3D>::getMiniDoublets() {
   if (mdsInCPU == nullptr) {
     // Get nMemoryLocations parameter to initialize host based mdsInCPU
     auto nMemHost_buf = allocBufWrapper<unsigned int>(devHost, 1, queue);
@@ -1555,7 +1555,7 @@ SDL::miniDoubletsBuffer<DevHost>* SDL::Event<Acc3D>::getMiniDoublets() {
     alpaka::wait(queue);
 
     unsigned int nMemHost = *alpaka::getPtrNative(nMemHost_buf);
-    mdsInCPU = new SDL::miniDoubletsBuffer<DevHost>(nMemHost, nLowerModules_, devHost, queue);
+    mdsInCPU = new SDL::MiniDoubletsBuffer<DevHost>(nMemHost, nLowerModules_, devHost, queue);
     mdsInCPU->setData(*mdsInCPU);
 
     *alpaka::getPtrNative(mdsInCPU->nMemoryLocations_buf) = nMemHost;
@@ -1569,7 +1569,7 @@ SDL::miniDoubletsBuffer<DevHost>* SDL::Event<Acc3D>::getMiniDoublets() {
   return mdsInCPU;
 }
 
-SDL::segmentsBuffer<DevHost>* SDL::Event<Acc3D>::getSegments() {
+SDL::SegmentsBuffer<DevHost>* SDL::Event<Acc3D>::getSegments() {
   if (segmentsInCPU == nullptr) {
     // Get nMemoryLocations parameter to initialize host based segmentsInCPU
     auto nMemHost_buf = allocBufWrapper<unsigned int>(devHost, 1, queue);
@@ -1578,7 +1578,7 @@ SDL::segmentsBuffer<DevHost>* SDL::Event<Acc3D>::getSegments() {
 
     unsigned int nMemHost = *alpaka::getPtrNative(nMemHost_buf);
     segmentsInCPU =
-        new SDL::segmentsBuffer<DevHost>(nMemHost, nLowerModules_, N_MAX_PIXEL_SEGMENTS_PER_MODULE, devHost, queue);
+        new SDL::SegmentsBuffer<DevHost>(nMemHost, nLowerModules_, N_MAX_PIXEL_SEGMENTS_PER_MODULE, devHost, queue);
     segmentsInCPU->setData(*segmentsInCPU);
 
     *alpaka::getPtrNative(segmentsInCPU->nMemoryLocations_buf) = nMemHost;
@@ -1605,7 +1605,7 @@ SDL::segmentsBuffer<DevHost>* SDL::Event<Acc3D>::getSegments() {
   return segmentsInCPU;
 }
 
-SDL::tripletsBuffer<DevHost>* SDL::Event<Acc3D>::getTriplets() {
+SDL::TripletsBuffer<DevHost>* SDL::Event<Acc3D>::getTriplets() {
   if (tripletsInCPU == nullptr) {
     // Get nMemoryLocations parameter to initialize host based tripletsInCPU
     auto nMemHost_buf = allocBufWrapper<unsigned int>(devHost, 1, queue);
@@ -1613,7 +1613,7 @@ SDL::tripletsBuffer<DevHost>* SDL::Event<Acc3D>::getTriplets() {
     alpaka::wait(queue);
 
     unsigned int nMemHost = *alpaka::getPtrNative(nMemHost_buf);
-    tripletsInCPU = new SDL::tripletsBuffer<DevHost>(nMemHost, nLowerModules_, devHost, queue);
+    tripletsInCPU = new SDL::TripletsBuffer<DevHost>(nMemHost, nLowerModules_, devHost, queue);
     tripletsInCPU->setData(*tripletsInCPU);
 
     *alpaka::getPtrNative(tripletsInCPU->nMemoryLocations_buf) = nMemHost;
@@ -1641,7 +1641,7 @@ SDL::tripletsBuffer<DevHost>* SDL::Event<Acc3D>::getTriplets() {
   return tripletsInCPU;
 }
 
-SDL::quintupletsBuffer<DevHost>* SDL::Event<Acc3D>::getQuintuplets() {
+SDL::QuintupletsBuffer<DevHost>* SDL::Event<Acc3D>::getQuintuplets() {
   if (quintupletsInCPU == nullptr) {
     // Get nMemoryLocations parameter to initialize host based quintupletsInCPU
     auto nMemHost_buf = allocBufWrapper<unsigned int>(devHost, 1, queue);
@@ -1649,7 +1649,7 @@ SDL::quintupletsBuffer<DevHost>* SDL::Event<Acc3D>::getQuintuplets() {
     alpaka::wait(queue);
 
     unsigned int nMemHost = *alpaka::getPtrNative(nMemHost_buf);
-    quintupletsInCPU = new SDL::quintupletsBuffer<DevHost>(nMemHost, nLowerModules_, devHost, queue);
+    quintupletsInCPU = new SDL::QuintupletsBuffer<DevHost>(nMemHost, nLowerModules_, devHost, queue);
     quintupletsInCPU->setData(*quintupletsInCPU);
 
     *alpaka::getPtrNative(quintupletsInCPU->nMemoryLocations_buf) = nMemHost;
@@ -1677,7 +1677,7 @@ SDL::quintupletsBuffer<DevHost>* SDL::Event<Acc3D>::getQuintuplets() {
   return quintupletsInCPU;
 }
 
-SDL::pixelTripletsBuffer<DevHost>* SDL::Event<Acc3D>::getPixelTriplets() {
+SDL::PixelTripletsBuffer<DevHost>* SDL::Event<Acc3D>::getPixelTriplets() {
   if (pixelTripletsInCPU == nullptr) {
     // Get nPixelTriplets parameter to initialize host based quintupletsInCPU
     auto nPixelTriplets_buf = allocBufWrapper<unsigned int>(devHost, 1, queue);
@@ -1685,7 +1685,7 @@ SDL::pixelTripletsBuffer<DevHost>* SDL::Event<Acc3D>::getPixelTriplets() {
     alpaka::wait(queue);
 
     unsigned int nPixelTriplets = *alpaka::getPtrNative(nPixelTriplets_buf);
-    pixelTripletsInCPU = new SDL::pixelTripletsBuffer<DevHost>(nPixelTriplets, devHost, queue);
+    pixelTripletsInCPU = new SDL::PixelTripletsBuffer<DevHost>(nPixelTriplets, devHost, queue);
     pixelTripletsInCPU->setData(*pixelTripletsInCPU);
 
     *alpaka::getPtrNative(pixelTripletsInCPU->nPixelTriplets_buf) = nPixelTriplets;
@@ -1716,7 +1716,7 @@ SDL::pixelTripletsBuffer<DevHost>* SDL::Event<Acc3D>::getPixelTriplets() {
   return pixelTripletsInCPU;
 }
 
-SDL::pixelQuintupletsBuffer<DevHost>* SDL::Event<Acc3D>::getPixelQuintuplets() {
+SDL::PixelQuintupletsBuffer<DevHost>* SDL::Event<Acc3D>::getPixelQuintuplets() {
   if (pixelQuintupletsInCPU == nullptr) {
     // Get nPixelQuintuplets parameter to initialize host based quintupletsInCPU
     auto nPixelQuintuplets_buf = allocBufWrapper<unsigned int>(devHost, 1, queue);
@@ -1724,7 +1724,7 @@ SDL::pixelQuintupletsBuffer<DevHost>* SDL::Event<Acc3D>::getPixelQuintuplets() {
     alpaka::wait(queue);
 
     unsigned int nPixelQuintuplets = *alpaka::getPtrNative(nPixelQuintuplets_buf);
-    pixelQuintupletsInCPU = new SDL::pixelQuintupletsBuffer<DevHost>(nPixelQuintuplets, devHost, queue);
+    pixelQuintupletsInCPU = new SDL::PixelQuintupletsBuffer<DevHost>(nPixelQuintuplets, devHost, queue);
     pixelQuintupletsInCPU->setData(*pixelQuintupletsInCPU);
 
     *alpaka::getPtrNative(pixelQuintupletsInCPU->nPixelQuintuplets_buf) = nPixelQuintuplets;
@@ -1752,7 +1752,7 @@ SDL::pixelQuintupletsBuffer<DevHost>* SDL::Event<Acc3D>::getPixelQuintuplets() {
   return pixelQuintupletsInCPU;
 }
 
-SDL::trackCandidatesBuffer<DevHost>* SDL::Event<Acc3D>::getTrackCandidates() {
+SDL::TrackCandidatesBuffer<DevHost>* SDL::Event<Acc3D>::getTrackCandidates() {
   if (trackCandidatesInCPU == nullptr) {
     // Get nTrackCanHost parameter to initialize host based trackCandidatesInCPU
     auto nTrackCanHost_buf = allocBufWrapper<unsigned int>(devHost, 1, queue);
@@ -1760,7 +1760,7 @@ SDL::trackCandidatesBuffer<DevHost>* SDL::Event<Acc3D>::getTrackCandidates() {
     alpaka::wait(queue);
 
     unsigned int nTrackCanHost = *alpaka::getPtrNative(nTrackCanHost_buf);
-    trackCandidatesInCPU = new SDL::trackCandidatesBuffer<DevHost>(
+    trackCandidatesInCPU = new SDL::TrackCandidatesBuffer<DevHost>(
         N_MAX_NONPIXEL_TRACK_CANDIDATES + N_MAX_PIXEL_TRACK_CANDIDATES, devHost, queue);
     trackCandidatesInCPU->setData(*trackCandidatesInCPU);
 
@@ -1790,7 +1790,7 @@ SDL::trackCandidatesBuffer<DevHost>* SDL::Event<Acc3D>::getTrackCandidates() {
   return trackCandidatesInCPU;
 }
 
-SDL::trackCandidatesBuffer<DevHost>* SDL::Event<Acc3D>::getTrackCandidatesInCMSSW() {
+SDL::TrackCandidatesBuffer<DevHost>* SDL::Event<Acc3D>::getTrackCandidatesInCMSSW() {
   if (trackCandidatesInCPU == nullptr) {
     // Get nTrackCanHost parameter to initialize host based trackCandidatesInCPU
     auto nTrackCanHost_buf = allocBufWrapper<unsigned int>(devHost, 1, queue);
@@ -1798,7 +1798,7 @@ SDL::trackCandidatesBuffer<DevHost>* SDL::Event<Acc3D>::getTrackCandidatesInCMSS
     alpaka::wait(queue);
 
     unsigned int nTrackCanHost = *alpaka::getPtrNative(nTrackCanHost_buf);
-    trackCandidatesInCPU = new SDL::trackCandidatesBuffer<DevHost>(
+    trackCandidatesInCPU = new SDL::TrackCandidatesBuffer<DevHost>(
         N_MAX_NONPIXEL_TRACK_CANDIDATES + N_MAX_PIXEL_TRACK_CANDIDATES, devHost, queue);
     trackCandidatesInCPU->setData(*trackCandidatesInCPU);
 
@@ -1818,10 +1818,10 @@ SDL::trackCandidatesBuffer<DevHost>* SDL::Event<Acc3D>::getTrackCandidatesInCMSS
   return trackCandidatesInCPU;
 }
 
-SDL::modulesBuffer<DevHost>* SDL::Event<Acc3D>::getModules(bool isFull) {
+SDL::ModulesBuffer<DevHost>* SDL::Event<Acc3D>::getModules(bool isFull) {
   if (modulesInCPU == nullptr) {
     // The last input here is just a small placeholder for the allocation.
-    modulesInCPU = new SDL::modulesBuffer<DevHost>(devHost, nModules_, nPixels_);
+    modulesInCPU = new SDL::ModulesBuffer<DevHost>(devHost, nModules_, nPixels_);
 
     modulesInCPU->copyFromSrc(queue, *modulesBuffers_, isFull);
   }

--- a/RecoTracker/LSTCore/src/alpaka/Event.h
+++ b/RecoTracker/LSTCore/src/alpaka/Event.h
@@ -46,36 +46,36 @@ namespace SDL {
 
     //Device stuff
     unsigned int nTotalSegments;
-    struct objectRanges* rangesInGPU;
-    struct objectRangesBuffer<Device>* rangesBuffers;
-    struct hits* hitsInGPU;
-    struct hitsBuffer<Device>* hitsBuffers;
-    struct miniDoublets* mdsInGPU;
-    struct miniDoubletsBuffer<Device>* miniDoubletsBuffers;
-    struct segments* segmentsInGPU;
-    struct segmentsBuffer<Device>* segmentsBuffers;
-    struct triplets* tripletsInGPU;
-    struct tripletsBuffer<Device>* tripletsBuffers;
-    struct quintuplets* quintupletsInGPU;
-    struct quintupletsBuffer<Device>* quintupletsBuffers;
-    struct trackCandidates* trackCandidatesInGPU;
-    struct trackCandidatesBuffer<Device>* trackCandidatesBuffers;
-    struct pixelTriplets* pixelTripletsInGPU;
-    struct pixelTripletsBuffer<Device>* pixelTripletsBuffers;
-    struct pixelQuintuplets* pixelQuintupletsInGPU;
-    struct pixelQuintupletsBuffer<Device>* pixelQuintupletsBuffers;
+    struct ObjectRanges* rangesInGPU;
+    struct ObjectRangesBuffer<Device>* rangesBuffers;
+    struct Hits* hitsInGPU;
+    struct HitsBuffer<Device>* hitsBuffers;
+    struct MiniDoublets* mdsInGPU;
+    struct MiniDoubletsBuffer<Device>* miniDoubletsBuffers;
+    struct Segments* segmentsInGPU;
+    struct SegmentsBuffer<Device>* segmentsBuffers;
+    struct Triplets* tripletsInGPU;
+    struct TripletsBuffer<Device>* tripletsBuffers;
+    struct Quintuplets* quintupletsInGPU;
+    struct QuintupletsBuffer<Device>* quintupletsBuffers;
+    struct TrackCandidates* trackCandidatesInGPU;
+    struct TrackCandidatesBuffer<Device>* trackCandidatesBuffers;
+    struct PixelTriplets* pixelTripletsInGPU;
+    struct PixelTripletsBuffer<Device>* pixelTripletsBuffers;
+    struct PixelQuintuplets* pixelQuintupletsInGPU;
+    struct PixelQuintupletsBuffer<Device>* pixelQuintupletsBuffers;
 
     //CPU interface stuff
-    objectRangesBuffer<DevHost>* rangesInCPU;
-    hitsBuffer<DevHost>* hitsInCPU;
-    miniDoubletsBuffer<DevHost>* mdsInCPU;
-    segmentsBuffer<DevHost>* segmentsInCPU;
-    tripletsBuffer<DevHost>* tripletsInCPU;
-    trackCandidatesBuffer<DevHost>* trackCandidatesInCPU;
-    modulesBuffer<DevHost>* modulesInCPU;
-    quintupletsBuffer<DevHost>* quintupletsInCPU;
-    pixelTripletsBuffer<DevHost>* pixelTripletsInCPU;
-    pixelQuintupletsBuffer<DevHost>* pixelQuintupletsInCPU;
+    ObjectRangesBuffer<DevHost>* rangesInCPU;
+    HitsBuffer<DevHost>* hitsInCPU;
+    MiniDoubletsBuffer<DevHost>* mdsInCPU;
+    SegmentsBuffer<DevHost>* segmentsInCPU;
+    TripletsBuffer<DevHost>* tripletsInCPU;
+    TrackCandidatesBuffer<DevHost>* trackCandidatesInCPU;
+    ModulesBuffer<DevHost>* modulesInCPU;
+    QuintupletsBuffer<DevHost>* quintupletsInCPU;
+    PixelTripletsBuffer<DevHost>* pixelTripletsInCPU;
+    PixelQuintupletsBuffer<DevHost>* pixelQuintupletsInCPU;
 
     void init(bool verbose);
 
@@ -87,7 +87,7 @@ namespace SDL {
     const uint16_t nLowerModules_;
     const unsigned int nPixels_;
     const unsigned int nEndCapMap_;
-    const std::shared_ptr<const modulesBuffer<Device>> modulesBuffers_;
+    const std::shared_ptr<const ModulesBuffer<Device>> modulesBuffers_;
     const std::shared_ptr<const pixelMap> pixelMapping_;
     const std::shared_ptr<const EndcapGeometryBuffer<Device>> endcapGeometryBuffers_;
 
@@ -188,18 +188,18 @@ namespace SDL {
     int getNumberOfPixelTriplets();
     int getNumberOfPixelQuintuplets();
 
-    objectRangesBuffer<DevHost>* getRanges();
-    hitsBuffer<DevHost>* getHits();
-    hitsBuffer<DevHost>* getHitsInCMSSW();
-    miniDoubletsBuffer<DevHost>* getMiniDoublets();
-    segmentsBuffer<DevHost>* getSegments();
-    tripletsBuffer<DevHost>* getTriplets();
-    quintupletsBuffer<DevHost>* getQuintuplets();
-    trackCandidatesBuffer<DevHost>* getTrackCandidates();
-    trackCandidatesBuffer<DevHost>* getTrackCandidatesInCMSSW();
-    pixelTripletsBuffer<DevHost>* getPixelTriplets();
-    pixelQuintupletsBuffer<DevHost>* getPixelQuintuplets();
-    modulesBuffer<DevHost>* getModules(bool isFull = false);
+    ObjectRangesBuffer<DevHost>* getRanges();
+    HitsBuffer<DevHost>* getHits();
+    HitsBuffer<DevHost>* getHitsInCMSSW();
+    MiniDoubletsBuffer<DevHost>* getMiniDoublets();
+    SegmentsBuffer<DevHost>* getSegments();
+    TripletsBuffer<DevHost>* getTriplets();
+    QuintupletsBuffer<DevHost>* getQuintuplets();
+    TrackCandidatesBuffer<DevHost>* getTrackCandidates();
+    TrackCandidatesBuffer<DevHost>* getTrackCandidatesInCMSSW();
+    PixelTripletsBuffer<DevHost>* getPixelTriplets();
+    PixelQuintupletsBuffer<DevHost>* getPixelQuintuplets();
+    ModulesBuffer<DevHost>* getModules(bool isFull = false);
   };
 
 }  // namespace SDL

--- a/RecoTracker/LSTCore/src/alpaka/Kernels.h
+++ b/RecoTracker/LSTCore/src/alpaka/Kernels.h
@@ -6,29 +6,30 @@
 
 #include "Hit.h"
 #include "MiniDoublet.h"
+#include "ObjectRanges.h"
 #include "Segment.h"
 #include "Triplet.h"
 #include "Quintuplet.h"
 #include "PixelTriplet.h"
 
 namespace SDL {
-  ALPAKA_FN_ACC ALPAKA_FN_INLINE void rmQuintupletFromMemory(struct SDL::quintuplets& quintupletsInGPU,
+  ALPAKA_FN_ACC ALPAKA_FN_INLINE void rmQuintupletFromMemory(struct SDL::Quintuplets& quintupletsInGPU,
                                                              unsigned int quintupletIndex,
                                                              bool secondpass = false) {
     quintupletsInGPU.isDup[quintupletIndex] |= 1 + secondpass;
   };
 
-  ALPAKA_FN_ACC ALPAKA_FN_INLINE void rmPixelTripletFromMemory(struct SDL::pixelTriplets& pixelTripletsInGPU,
+  ALPAKA_FN_ACC ALPAKA_FN_INLINE void rmPixelTripletFromMemory(struct SDL::PixelTriplets& pixelTripletsInGPU,
                                                                unsigned int pixelTripletIndex) {
     pixelTripletsInGPU.isDup[pixelTripletIndex] = true;
   };
 
-  ALPAKA_FN_ACC ALPAKA_FN_INLINE void rmPixelQuintupletFromMemory(struct SDL::pixelQuintuplets& pixelQuintupletsInGPU,
+  ALPAKA_FN_ACC ALPAKA_FN_INLINE void rmPixelQuintupletFromMemory(struct SDL::PixelQuintuplets& pixelQuintupletsInGPU,
                                                                   unsigned int pixelQuintupletIndex) {
     pixelQuintupletsInGPU.isDup[pixelQuintupletIndex] = true;
   };
 
-  ALPAKA_FN_ACC ALPAKA_FN_INLINE void rmPixelSegmentFromMemory(struct SDL::segments& segmentsInGPU,
+  ALPAKA_FN_ACC ALPAKA_FN_INLINE void rmPixelSegmentFromMemory(struct SDL::Segments& segmentsInGPU,
                                                                unsigned int pixelSegmentArrayIndex,
                                                                bool secondpass = false) {
     segmentsInGPU.isDup[pixelSegmentArrayIndex] |= 1 + secondpass;
@@ -36,7 +37,7 @@ namespace SDL {
 
   ALPAKA_FN_ACC ALPAKA_FN_INLINE int checkHitsT5(unsigned int ix,
                                                  unsigned int jx,
-                                                 struct SDL::quintuplets& quintupletsInGPU) {
+                                                 struct SDL::Quintuplets& quintupletsInGPU) {
     unsigned int hits1[Params_T5::kHits];
     unsigned int hits2[Params_T5::kHits];
 
@@ -63,7 +64,7 @@ namespace SDL {
 
   ALPAKA_FN_ACC ALPAKA_FN_INLINE int checkHitspT5(unsigned int ix,
                                                   unsigned int jx,
-                                                  struct SDL::pixelQuintuplets& pixelQuintupletsInGPU) {
+                                                  struct SDL::PixelQuintuplets& pixelQuintupletsInGPU) {
     unsigned int hits1[Params_pT5::kHits];
     unsigned int hits2[Params_pT5::kHits];
 
@@ -90,7 +91,7 @@ namespace SDL {
 
   ALPAKA_FN_ACC ALPAKA_FN_INLINE void checkHitspT3(unsigned int ix,
                                                    unsigned int jx,
-                                                   struct SDL::pixelTriplets& pixelTripletsInGPU,
+                                                   struct SDL::PixelTriplets& pixelTripletsInGPU,
                                                    int* matched) {
     int phits1[Params_pLS::kHits];
     int phits2[Params_pLS::kHits];
@@ -143,9 +144,9 @@ namespace SDL {
   struct removeDupQuintupletsInGPUAfterBuild {
     template <typename TAcc>
     ALPAKA_FN_ACC void operator()(TAcc const& acc,
-                                  struct SDL::modules modulesInGPU,
-                                  struct SDL::quintuplets quintupletsInGPU,
-                                  struct SDL::objectRanges rangesInGPU) const {
+                                  struct SDL::Modules modulesInGPU,
+                                  struct SDL::Quintuplets quintupletsInGPU,
+                                  struct SDL::ObjectRanges rangesInGPU) const {
       auto const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
       auto const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
 
@@ -193,8 +194,8 @@ namespace SDL {
   struct removeDupQuintupletsInGPUBeforeTC {
     template <typename TAcc>
     ALPAKA_FN_ACC void operator()(TAcc const& acc,
-                                  struct SDL::quintuplets quintupletsInGPU,
-                                  struct SDL::objectRanges rangesInGPU) const {
+                                  struct SDL::Quintuplets quintupletsInGPU,
+                                  struct SDL::ObjectRanges rangesInGPU) const {
       auto const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
       auto const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
 
@@ -267,7 +268,7 @@ namespace SDL {
 
   struct removeDupPixelTripletsInGPUFromMap {
     template <typename TAcc>
-    ALPAKA_FN_ACC void operator()(TAcc const& acc, struct SDL::pixelTriplets pixelTripletsInGPU) const {
+    ALPAKA_FN_ACC void operator()(TAcc const& acc, struct SDL::PixelTriplets pixelTripletsInGPU) const {
       auto const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
       auto const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
 
@@ -304,7 +305,7 @@ namespace SDL {
 
   struct removeDupPixelQuintupletsInGPUFromMap {
     template <typename TAcc>
-    ALPAKA_FN_ACC void operator()(TAcc const& acc, struct SDL::pixelQuintuplets pixelQuintupletsInGPU) const {
+    ALPAKA_FN_ACC void operator()(TAcc const& acc, struct SDL::PixelQuintuplets pixelQuintupletsInGPU) const {
       auto const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
       auto const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
 
@@ -332,8 +333,8 @@ namespace SDL {
   struct checkHitspLS {
     template <typename TAcc>
     ALPAKA_FN_ACC void operator()(TAcc const& acc,
-                                  struct SDL::modules modulesInGPU,
-                                  struct SDL::segments segmentsInGPU,
+                                  struct SDL::Modules modulesInGPU,
+                                  struct SDL::Segments segmentsInGPU,
                                   bool secondpass) const {
       auto const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
       auto const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);

--- a/RecoTracker/LSTCore/src/alpaka/LST.dev.cc
+++ b/RecoTracker/LSTCore/src/alpaka/LST.dev.cc
@@ -255,18 +255,18 @@ void SDL::LST<Acc3D>::getOutput(SDL::Event<Acc3D>& event) {
   std::vector<int> tc_seedIdx;
   std::vector<short> tc_trackCandidateType;
 
-  SDL::hitsBuffer<alpaka::DevCpu>& hitsInGPU = (*event.getHitsInCMSSW());
-  SDL::trackCandidatesBuffer<alpaka::DevCpu>& trackCandidatesInGPU = (*event.getTrackCandidatesInCMSSW());
+  SDL::HitsBuffer<alpaka::DevCpu>& hitsInGPU = (*event.getHitsInCMSSW());
+  SDL::TrackCandidates const* trackCandidates = event.getTrackCandidatesInCMSSW()->data();
 
-  unsigned int nTrackCandidates = *trackCandidatesInGPU.nTrackCandidates;
+  unsigned int nTrackCandidates = *trackCandidates->nTrackCandidates;
   for (unsigned int idx = 0; idx < nTrackCandidates; idx++) {
-    short trackCandidateType = trackCandidatesInGPU.trackCandidateType[idx];
+    short trackCandidateType = trackCandidates->trackCandidateType[idx];
     std::vector<unsigned int> hit_idx =
-        getHitIdxs(trackCandidateType, idx, trackCandidatesInGPU.hitIndices, hitsInGPU.idxs);
+        getHitIdxs(trackCandidateType, idx, trackCandidates->hitIndices, hitsInGPU.data()->idxs);
 
     tc_hitIdxs.push_back(hit_idx);
     tc_len.push_back(hit_idx.size());
-    tc_seedIdx.push_back(trackCandidatesInGPU.pixelSeedIndex[idx]);
+    tc_seedIdx.push_back(trackCandidates->pixelSeedIndex[idx]);
     tc_trackCandidateType.push_back(trackCandidateType);
   }
 

--- a/RecoTracker/LSTCore/src/alpaka/MiniDoublet.h
+++ b/RecoTracker/LSTCore/src/alpaka/MiniDoublet.h
@@ -6,9 +6,10 @@
 #include "RecoTracker/LSTCore/interface/EndcapGeometry.h"
 
 #include "Hit.h"
+#include "ObjectRanges.h"
 
 namespace SDL {
-  struct miniDoublets {
+  struct MiniDoublets {
     unsigned int* nMemoryLocations;
 
     unsigned int* anchorHitIndices;
@@ -53,49 +54,49 @@ namespace SDL {
     float* outerLowEdgeY;
 
     template <typename TBuf>
-    void setData(TBuf& mdsbuf) {
-      nMemoryLocations = alpaka::getPtrNative(mdsbuf.nMemoryLocations_buf);
-      anchorHitIndices = alpaka::getPtrNative(mdsbuf.anchorHitIndices_buf);
-      outerHitIndices = alpaka::getPtrNative(mdsbuf.outerHitIndices_buf);
-      moduleIndices = alpaka::getPtrNative(mdsbuf.moduleIndices_buf);
-      nMDs = alpaka::getPtrNative(mdsbuf.nMDs_buf);
-      totOccupancyMDs = alpaka::getPtrNative(mdsbuf.totOccupancyMDs_buf);
-      dphichanges = alpaka::getPtrNative(mdsbuf.dphichanges_buf);
-      dzs = alpaka::getPtrNative(mdsbuf.dzs_buf);
-      dphis = alpaka::getPtrNative(mdsbuf.dphis_buf);
-      shiftedXs = alpaka::getPtrNative(mdsbuf.shiftedXs_buf);
-      shiftedYs = alpaka::getPtrNative(mdsbuf.shiftedYs_buf);
-      shiftedZs = alpaka::getPtrNative(mdsbuf.shiftedZs_buf);
-      noShiftedDzs = alpaka::getPtrNative(mdsbuf.noShiftedDzs_buf);
-      noShiftedDphis = alpaka::getPtrNative(mdsbuf.noShiftedDphis_buf);
-      noShiftedDphiChanges = alpaka::getPtrNative(mdsbuf.noShiftedDphiChanges_buf);
-      anchorX = alpaka::getPtrNative(mdsbuf.anchorX_buf);
-      anchorY = alpaka::getPtrNative(mdsbuf.anchorY_buf);
-      anchorZ = alpaka::getPtrNative(mdsbuf.anchorZ_buf);
-      anchorRt = alpaka::getPtrNative(mdsbuf.anchorRt_buf);
-      anchorPhi = alpaka::getPtrNative(mdsbuf.anchorPhi_buf);
-      anchorEta = alpaka::getPtrNative(mdsbuf.anchorEta_buf);
-      anchorHighEdgeX = alpaka::getPtrNative(mdsbuf.anchorHighEdgeX_buf);
-      anchorHighEdgeY = alpaka::getPtrNative(mdsbuf.anchorHighEdgeY_buf);
-      anchorLowEdgeX = alpaka::getPtrNative(mdsbuf.anchorLowEdgeX_buf);
-      anchorLowEdgeY = alpaka::getPtrNative(mdsbuf.anchorLowEdgeY_buf);
-      outerX = alpaka::getPtrNative(mdsbuf.outerX_buf);
-      outerY = alpaka::getPtrNative(mdsbuf.outerY_buf);
-      outerZ = alpaka::getPtrNative(mdsbuf.outerZ_buf);
-      outerRt = alpaka::getPtrNative(mdsbuf.outerRt_buf);
-      outerPhi = alpaka::getPtrNative(mdsbuf.outerPhi_buf);
-      outerEta = alpaka::getPtrNative(mdsbuf.outerEta_buf);
-      outerHighEdgeX = alpaka::getPtrNative(mdsbuf.outerHighEdgeX_buf);
-      outerHighEdgeY = alpaka::getPtrNative(mdsbuf.outerHighEdgeY_buf);
-      outerLowEdgeX = alpaka::getPtrNative(mdsbuf.outerLowEdgeX_buf);
-      outerLowEdgeY = alpaka::getPtrNative(mdsbuf.outerLowEdgeY_buf);
-      anchorLowEdgePhi = alpaka::getPtrNative(mdsbuf.anchorLowEdgePhi_buf);
-      anchorHighEdgePhi = alpaka::getPtrNative(mdsbuf.anchorHighEdgePhi_buf);
+    void setData(TBuf& buf) {
+      nMemoryLocations = alpaka::getPtrNative(buf.nMemoryLocations_buf);
+      anchorHitIndices = alpaka::getPtrNative(buf.anchorHitIndices_buf);
+      outerHitIndices = alpaka::getPtrNative(buf.outerHitIndices_buf);
+      moduleIndices = alpaka::getPtrNative(buf.moduleIndices_buf);
+      nMDs = alpaka::getPtrNative(buf.nMDs_buf);
+      totOccupancyMDs = alpaka::getPtrNative(buf.totOccupancyMDs_buf);
+      dphichanges = alpaka::getPtrNative(buf.dphichanges_buf);
+      dzs = alpaka::getPtrNative(buf.dzs_buf);
+      dphis = alpaka::getPtrNative(buf.dphis_buf);
+      shiftedXs = alpaka::getPtrNative(buf.shiftedXs_buf);
+      shiftedYs = alpaka::getPtrNative(buf.shiftedYs_buf);
+      shiftedZs = alpaka::getPtrNative(buf.shiftedZs_buf);
+      noShiftedDzs = alpaka::getPtrNative(buf.noShiftedDzs_buf);
+      noShiftedDphis = alpaka::getPtrNative(buf.noShiftedDphis_buf);
+      noShiftedDphiChanges = alpaka::getPtrNative(buf.noShiftedDphiChanges_buf);
+      anchorX = alpaka::getPtrNative(buf.anchorX_buf);
+      anchorY = alpaka::getPtrNative(buf.anchorY_buf);
+      anchorZ = alpaka::getPtrNative(buf.anchorZ_buf);
+      anchorRt = alpaka::getPtrNative(buf.anchorRt_buf);
+      anchorPhi = alpaka::getPtrNative(buf.anchorPhi_buf);
+      anchorEta = alpaka::getPtrNative(buf.anchorEta_buf);
+      anchorHighEdgeX = alpaka::getPtrNative(buf.anchorHighEdgeX_buf);
+      anchorHighEdgeY = alpaka::getPtrNative(buf.anchorHighEdgeY_buf);
+      anchorLowEdgeX = alpaka::getPtrNative(buf.anchorLowEdgeX_buf);
+      anchorLowEdgeY = alpaka::getPtrNative(buf.anchorLowEdgeY_buf);
+      outerX = alpaka::getPtrNative(buf.outerX_buf);
+      outerY = alpaka::getPtrNative(buf.outerY_buf);
+      outerZ = alpaka::getPtrNative(buf.outerZ_buf);
+      outerRt = alpaka::getPtrNative(buf.outerRt_buf);
+      outerPhi = alpaka::getPtrNative(buf.outerPhi_buf);
+      outerEta = alpaka::getPtrNative(buf.outerEta_buf);
+      outerHighEdgeX = alpaka::getPtrNative(buf.outerHighEdgeX_buf);
+      outerHighEdgeY = alpaka::getPtrNative(buf.outerHighEdgeY_buf);
+      outerLowEdgeX = alpaka::getPtrNative(buf.outerLowEdgeX_buf);
+      outerLowEdgeY = alpaka::getPtrNative(buf.outerLowEdgeY_buf);
+      anchorLowEdgePhi = alpaka::getPtrNative(buf.anchorLowEdgePhi_buf);
+      anchorHighEdgePhi = alpaka::getPtrNative(buf.anchorHighEdgePhi_buf);
     }
   };
 
   template <typename TDev>
-  struct miniDoubletsBuffer : miniDoublets {
+  struct MiniDoubletsBuffer {
     Buf<TDev, unsigned int> nMemoryLocations_buf;
 
     Buf<TDev, unsigned int> anchorHitIndices_buf;
@@ -139,8 +140,10 @@ namespace SDL {
     Buf<TDev, float> outerLowEdgeX_buf;
     Buf<TDev, float> outerLowEdgeY_buf;
 
+    MiniDoublets data_;
+
     template <typename TQueue, typename TDevAcc>
-    miniDoubletsBuffer(unsigned int nMemoryLoc, uint16_t nLowerModules, TDevAcc const& devAccIn, TQueue& queue)
+    MiniDoubletsBuffer(unsigned int nMemoryLoc, uint16_t nLowerModules, TDevAcc const& devAccIn, TQueue& queue)
         : nMemoryLocations_buf(allocBufWrapper<unsigned int>(devAccIn, 1, queue)),
           anchorHitIndices_buf(allocBufWrapper<unsigned int>(devAccIn, nMemoryLoc, queue)),
           outerHitIndices_buf(allocBufWrapper<unsigned int>(devAccIn, nMemoryLoc, queue)),
@@ -182,13 +185,16 @@ namespace SDL {
       alpaka::memset(queue, totOccupancyMDs_buf, 0u);
       alpaka::wait(queue);
     }
+
+    inline MiniDoublets const* data() const { return &data_; }
+    inline void setData(MiniDoubletsBuffer& buf) { data_.setData(buf); }
   };
 
   template <typename TAcc>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE void addMDToMemory(TAcc const& acc,
-                                                    struct SDL::miniDoublets& mdsInGPU,
-                                                    struct SDL::hits& hitsInGPU,
-                                                    struct SDL::modules& modulesInGPU,
+                                                    struct SDL::MiniDoublets& mdsInGPU,
+                                                    struct SDL::Hits& hitsInGPU,
+                                                    struct SDL::Modules& modulesInGPU,
                                                     unsigned int lowerHitIdx,
                                                     unsigned int upperHitIdx,
                                                     uint16_t& lowerModuleIdx,
@@ -260,7 +266,7 @@ namespace SDL {
     mdsInGPU.outerLowEdgeY[idx] = hitsInGPU.lowEdgeYs[outerHitIndex];
   };
 
-  ALPAKA_FN_ACC ALPAKA_FN_INLINE float isTighterTiltedModules(struct SDL::modules& modulesInGPU,
+  ALPAKA_FN_ACC ALPAKA_FN_INLINE float isTighterTiltedModules(struct SDL::Modules& modulesInGPU,
                                                               uint16_t& moduleIndex) {
     // The "tighter" tilted modules are the subset of tilted modules that have smaller spacing
     // This is the same as what was previously considered as"isNormalTiltedModules"
@@ -281,7 +287,7 @@ namespace SDL {
       return false;
   };
 
-  ALPAKA_FN_ACC ALPAKA_FN_INLINE float moduleGapSize(struct SDL::modules& modulesInGPU, uint16_t& moduleIndex) {
+  ALPAKA_FN_ACC ALPAKA_FN_INLINE float moduleGapSize(struct SDL::Modules& modulesInGPU, uint16_t& moduleIndex) {
     float miniDeltaTilted[3] = {0.26f, 0.26f, 0.26f};
     float miniDeltaFlat[6] = {0.26f, 0.16f, 0.16f, 0.18f, 0.18f, 0.18f};
     float miniDeltaLooseTilted[3] = {0.4f, 0.4f, 0.4f};
@@ -335,7 +341,7 @@ namespace SDL {
   template <typename TAcc>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE float dPhiThreshold(TAcc const& acc,
                                                      float rt,
-                                                     struct SDL::modules& modulesInGPU,
+                                                     struct SDL::Modules& modulesInGPU,
                                                      uint16_t& moduleIndex,
                                                      float dPhi = 0,
                                                      float dz = 0) {
@@ -397,7 +403,7 @@ namespace SDL {
 
   template <typename TAcc>
   ALPAKA_FN_INLINE ALPAKA_FN_ACC void shiftStripHits(TAcc const& acc,
-                                                     struct SDL::modules& modulesInGPU,
+                                                     struct SDL::Modules& modulesInGPU,
                                                      uint16_t& lowerModuleIndex,
                                                      uint16_t& upperModuleIndex,
                                                      unsigned int lowerHitIndex,
@@ -563,7 +569,7 @@ namespace SDL {
 
   template <typename TAcc>
   ALPAKA_FN_ACC bool runMiniDoubletDefaultAlgo(TAcc const& acc,
-                                               struct SDL::modules& modulesInGPU,
+                                               struct SDL::Modules& modulesInGPU,
                                                uint16_t& lowerModuleIndex,
                                                uint16_t& upperModuleIndex,
                                                unsigned int lowerHitIndex,
@@ -638,7 +644,7 @@ namespace SDL {
 
   template <typename TAcc>
   ALPAKA_FN_ACC bool runMiniDoubletDefaultAlgoBarrel(TAcc const& acc,
-                                                     struct SDL::modules& modulesInGPU,
+                                                     struct SDL::Modules& modulesInGPU,
                                                      uint16_t& lowerModuleIndex,
                                                      uint16_t& upperModuleIndex,
                                                      unsigned int lowerHitIndex,
@@ -769,7 +775,7 @@ namespace SDL {
 
   template <typename TAcc>
   ALPAKA_FN_ACC bool runMiniDoubletDefaultAlgoEndcap(TAcc const& acc,
-                                                     struct SDL::modules& modulesInGPU,
+                                                     struct SDL::Modules& modulesInGPU,
                                                      uint16_t& lowerModuleIndex,
                                                      uint16_t& upperModuleIndex,
                                                      unsigned int lowerHitIndex,
@@ -883,10 +889,10 @@ namespace SDL {
   struct createMiniDoubletsInGPUv2 {
     template <typename TAcc>
     ALPAKA_FN_ACC void operator()(TAcc const& acc,
-                                  struct SDL::modules modulesInGPU,
-                                  struct SDL::hits hitsInGPU,
-                                  struct SDL::miniDoublets mdsInGPU,
-                                  struct SDL::objectRanges rangesInGPU) const {
+                                  struct SDL::Modules modulesInGPU,
+                                  struct SDL::Hits hitsInGPU,
+                                  struct SDL::MiniDoublets mdsInGPU,
+                                  struct SDL::ObjectRanges rangesInGPU) const {
       auto const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
       auto const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
 
@@ -981,8 +987,8 @@ namespace SDL {
   struct createMDArrayRangesGPU {
     template <typename TAcc>
     ALPAKA_FN_ACC void operator()(TAcc const& acc,
-                                  struct SDL::modules modulesInGPU,
-                                  struct SDL::objectRanges rangesInGPU) const {
+                                  struct SDL::Modules modulesInGPU,
+                                  struct SDL::ObjectRanges rangesInGPU) const {
       auto const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
       auto const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
 
@@ -1071,10 +1077,10 @@ namespace SDL {
   struct addMiniDoubletRangesToEventExplicit {
     template <typename TAcc>
     ALPAKA_FN_ACC void operator()(TAcc const& acc,
-                                  struct SDL::modules modulesInGPU,
-                                  struct SDL::miniDoublets mdsInGPU,
-                                  struct SDL::objectRanges rangesInGPU,
-                                  struct SDL::hits hitsInGPU) const {
+                                  struct SDL::Modules modulesInGPU,
+                                  struct SDL::MiniDoublets mdsInGPU,
+                                  struct SDL::ObjectRanges rangesInGPU,
+                                  struct SDL::Hits hitsInGPU) const {
       auto const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
       auto const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
 

--- a/RecoTracker/LSTCore/src/alpaka/NeuralNetwork.h
+++ b/RecoTracker/LSTCore/src/alpaka/NeuralNetwork.h
@@ -14,10 +14,10 @@ namespace T5DNN {
 
   template <typename TAcc>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE float runInference(TAcc const& acc,
-                                                    struct SDL::modules& modulesInGPU,
-                                                    struct SDL::miniDoublets& mdsInGPU,
-                                                    struct SDL::segments& segmentsInGPU,
-                                                    struct SDL::triplets& tripletsInGPU,
+                                                    struct SDL::Modules& modulesInGPU,
+                                                    struct SDL::MiniDoublets& mdsInGPU,
+                                                    struct SDL::Segments& segmentsInGPU,
+                                                    struct SDL::Triplets& tripletsInGPU,
                                                     const float* xVec,
                                                     const float* yVec,
                                                     const unsigned int* mdIndices,

--- a/RecoTracker/LSTCore/src/alpaka/ObjectRanges.h
+++ b/RecoTracker/LSTCore/src/alpaka/ObjectRanges.h
@@ -1,0 +1,155 @@
+#ifndef RecoTracker_LSTCore_interface_ObjectRanges_h
+#define RecoTracker_LSTCore_interface_ObjectRanges_h
+
+#include "RecoTracker/LSTCore/interface/Constants.h"
+
+namespace SDL {
+
+  struct ObjectRanges {
+    int* hitRanges;
+    int* hitRangesLower;
+    int* hitRangesUpper;
+    int8_t* hitRangesnLower;
+    int8_t* hitRangesnUpper;
+    int* mdRanges;
+    int* segmentRanges;
+    int* trackletRanges;
+    int* tripletRanges;
+    int* trackCandidateRanges;
+    // Others will be added later
+    int* quintupletRanges;
+
+    // This number is just nEligibleModules - 1, but still we want this to be independent of the TC kernel
+    uint16_t* nEligibleT5Modules;
+    // Will be allocated in createQuintuplets kernel!
+    uint16_t* indicesOfEligibleT5Modules;
+    // To store different starting points for variable occupancy stuff
+    int* quintupletModuleIndices;
+    int* quintupletModuleOccupancy;
+    int* miniDoubletModuleIndices;
+    int* miniDoubletModuleOccupancy;
+    int* segmentModuleIndices;
+    int* segmentModuleOccupancy;
+    int* tripletModuleIndices;
+    int* tripletModuleOccupancy;
+
+    unsigned int* device_nTotalMDs;
+    unsigned int* device_nTotalSegs;
+    unsigned int* device_nTotalTrips;
+    unsigned int* device_nTotalQuints;
+
+    template <typename TBuff>
+    void setData(TBuff& buf) {
+      hitRanges = alpaka::getPtrNative(buf.hitRanges_buf);
+      hitRangesLower = alpaka::getPtrNative(buf.hitRangesLower_buf);
+      hitRangesUpper = alpaka::getPtrNative(buf.hitRangesUpper_buf);
+      hitRangesnLower = alpaka::getPtrNative(buf.hitRangesnLower_buf);
+      hitRangesnUpper = alpaka::getPtrNative(buf.hitRangesnUpper_buf);
+      mdRanges = alpaka::getPtrNative(buf.mdRanges_buf);
+      segmentRanges = alpaka::getPtrNative(buf.segmentRanges_buf);
+      trackletRanges = alpaka::getPtrNative(buf.trackletRanges_buf);
+      tripletRanges = alpaka::getPtrNative(buf.tripletRanges_buf);
+      trackCandidateRanges = alpaka::getPtrNative(buf.trackCandidateRanges_buf);
+      quintupletRanges = alpaka::getPtrNative(buf.quintupletRanges_buf);
+
+      nEligibleT5Modules = alpaka::getPtrNative(buf.nEligibleT5Modules_buf);
+      indicesOfEligibleT5Modules = alpaka::getPtrNative(buf.indicesOfEligibleT5Modules_buf);
+
+      quintupletModuleIndices = alpaka::getPtrNative(buf.quintupletModuleIndices_buf);
+      quintupletModuleOccupancy = alpaka::getPtrNative(buf.quintupletModuleOccupancy_buf);
+      miniDoubletModuleIndices = alpaka::getPtrNative(buf.miniDoubletModuleIndices_buf);
+      miniDoubletModuleOccupancy = alpaka::getPtrNative(buf.miniDoubletModuleOccupancy_buf);
+      segmentModuleIndices = alpaka::getPtrNative(buf.segmentModuleIndices_buf);
+      segmentModuleOccupancy = alpaka::getPtrNative(buf.segmentModuleOccupancy_buf);
+      tripletModuleIndices = alpaka::getPtrNative(buf.tripletModuleIndices_buf);
+      tripletModuleOccupancy = alpaka::getPtrNative(buf.tripletModuleOccupancy_buf);
+
+      device_nTotalMDs = alpaka::getPtrNative(buf.device_nTotalMDs_buf);
+      device_nTotalSegs = alpaka::getPtrNative(buf.device_nTotalSegs_buf);
+      device_nTotalTrips = alpaka::getPtrNative(buf.device_nTotalTrips_buf);
+      device_nTotalQuints = alpaka::getPtrNative(buf.device_nTotalQuints_buf);
+    }
+  };
+
+  template <typename TDev>
+  struct ObjectRangesBuffer {
+    Buf<TDev, int> hitRanges_buf;
+    Buf<TDev, int> hitRangesLower_buf;
+    Buf<TDev, int> hitRangesUpper_buf;
+    Buf<TDev, int8_t> hitRangesnLower_buf;
+    Buf<TDev, int8_t> hitRangesnUpper_buf;
+    Buf<TDev, int> mdRanges_buf;
+    Buf<TDev, int> segmentRanges_buf;
+    Buf<TDev, int> trackletRanges_buf;
+    Buf<TDev, int> tripletRanges_buf;
+    Buf<TDev, int> trackCandidateRanges_buf;
+    Buf<TDev, int> quintupletRanges_buf;
+
+    Buf<TDev, uint16_t> nEligibleT5Modules_buf;
+    Buf<TDev, uint16_t> indicesOfEligibleT5Modules_buf;
+
+    Buf<TDev, int> quintupletModuleIndices_buf;
+    Buf<TDev, int> quintupletModuleOccupancy_buf;
+    Buf<TDev, int> miniDoubletModuleIndices_buf;
+    Buf<TDev, int> miniDoubletModuleOccupancy_buf;
+    Buf<TDev, int> segmentModuleIndices_buf;
+    Buf<TDev, int> segmentModuleOccupancy_buf;
+    Buf<TDev, int> tripletModuleIndices_buf;
+    Buf<TDev, int> tripletModuleOccupancy_buf;
+
+    Buf<TDev, unsigned int> device_nTotalMDs_buf;
+    Buf<TDev, unsigned int> device_nTotalSegs_buf;
+    Buf<TDev, unsigned int> device_nTotalTrips_buf;
+    Buf<TDev, unsigned int> device_nTotalQuints_buf;
+
+    ObjectRanges data_;
+
+    template <typename TQueue, typename TDevAcc>
+    ObjectRangesBuffer(unsigned int nMod, unsigned int nLowerMod, TDevAcc const& devAccIn, TQueue& queue)
+        : hitRanges_buf(allocBufWrapper<int>(devAccIn, nMod * 2, queue)),
+          hitRangesLower_buf(allocBufWrapper<int>(devAccIn, nMod, queue)),
+          hitRangesUpper_buf(allocBufWrapper<int>(devAccIn, nMod, queue)),
+          hitRangesnLower_buf(allocBufWrapper<int8_t>(devAccIn, nMod, queue)),
+          hitRangesnUpper_buf(allocBufWrapper<int8_t>(devAccIn, nMod, queue)),
+          mdRanges_buf(allocBufWrapper<int>(devAccIn, nMod * 2, queue)),
+          segmentRanges_buf(allocBufWrapper<int>(devAccIn, nMod * 2, queue)),
+          trackletRanges_buf(allocBufWrapper<int>(devAccIn, nMod * 2, queue)),
+          tripletRanges_buf(allocBufWrapper<int>(devAccIn, nMod * 2, queue)),
+          trackCandidateRanges_buf(allocBufWrapper<int>(devAccIn, nMod * 2, queue)),
+          quintupletRanges_buf(allocBufWrapper<int>(devAccIn, nMod * 2, queue)),
+          nEligibleT5Modules_buf(allocBufWrapper<uint16_t>(devAccIn, 1, queue)),
+          indicesOfEligibleT5Modules_buf(allocBufWrapper<uint16_t>(devAccIn, nLowerMod, queue)),
+          quintupletModuleIndices_buf(allocBufWrapper<int>(devAccIn, nLowerMod, queue)),
+          quintupletModuleOccupancy_buf(allocBufWrapper<int>(devAccIn, nLowerMod, queue)),
+          miniDoubletModuleIndices_buf(allocBufWrapper<int>(devAccIn, nLowerMod + 1, queue)),
+          miniDoubletModuleOccupancy_buf(allocBufWrapper<int>(devAccIn, nLowerMod + 1, queue)),
+          segmentModuleIndices_buf(allocBufWrapper<int>(devAccIn, nLowerMod + 1, queue)),
+          segmentModuleOccupancy_buf(allocBufWrapper<int>(devAccIn, nLowerMod + 1, queue)),
+          tripletModuleIndices_buf(allocBufWrapper<int>(devAccIn, nLowerMod, queue)),
+          tripletModuleOccupancy_buf(allocBufWrapper<int>(devAccIn, nLowerMod, queue)),
+          device_nTotalMDs_buf(allocBufWrapper<unsigned int>(devAccIn, 1, queue)),
+          device_nTotalSegs_buf(allocBufWrapper<unsigned int>(devAccIn, 1, queue)),
+          device_nTotalTrips_buf(allocBufWrapper<unsigned int>(devAccIn, 1, queue)),
+          device_nTotalQuints_buf(allocBufWrapper<unsigned int>(devAccIn, 1, queue)) {
+      alpaka::memset(queue, hitRanges_buf, 0xff);
+      alpaka::memset(queue, hitRangesLower_buf, 0xff);
+      alpaka::memset(queue, hitRangesUpper_buf, 0xff);
+      alpaka::memset(queue, hitRangesnLower_buf, 0xff);
+      alpaka::memset(queue, hitRangesnUpper_buf, 0xff);
+      alpaka::memset(queue, mdRanges_buf, 0xff);
+      alpaka::memset(queue, segmentRanges_buf, 0xff);
+      alpaka::memset(queue, trackletRanges_buf, 0xff);
+      alpaka::memset(queue, tripletRanges_buf, 0xff);
+      alpaka::memset(queue, trackCandidateRanges_buf, 0xff);
+      alpaka::memset(queue, quintupletRanges_buf, 0xff);
+      alpaka::memset(queue, quintupletModuleIndices_buf, 0xff);
+      alpaka::wait(queue);
+      data_.setData(*this);
+    }
+
+    inline ObjectRanges const* data() const { return &data_; }
+    void setData(ObjectRangesBuffer& buf) { data_.setData(buf); }
+  };
+
+}  // namespace SDL
+#endif

--- a/RecoTracker/LSTCore/src/alpaka/Segment.h
+++ b/RecoTracker/LSTCore/src/alpaka/Segment.h
@@ -7,9 +7,10 @@
 
 #include "MiniDoublet.h"
 #include "Hit.h"
+#include "ObjectRanges.h"
 
 namespace SDL {
-  struct segments {
+  struct Segments {
     FPX* dPhis;
     FPX* dPhiMins;
     FPX* dPhiMaxs;
@@ -46,46 +47,46 @@ namespace SDL {
     float* circleRadius;
 
     template <typename TBuff>
-    void setData(TBuff& segmentsbuf) {
-      dPhis = alpaka::getPtrNative(segmentsbuf.dPhis_buf);
-      dPhiMins = alpaka::getPtrNative(segmentsbuf.dPhiMins_buf);
-      dPhiMaxs = alpaka::getPtrNative(segmentsbuf.dPhiMaxs_buf);
-      dPhiChanges = alpaka::getPtrNative(segmentsbuf.dPhiChanges_buf);
-      dPhiChangeMins = alpaka::getPtrNative(segmentsbuf.dPhiChangeMins_buf);
-      dPhiChangeMaxs = alpaka::getPtrNative(segmentsbuf.dPhiChangeMaxs_buf);
-      innerLowerModuleIndices = alpaka::getPtrNative(segmentsbuf.innerLowerModuleIndices_buf);
-      outerLowerModuleIndices = alpaka::getPtrNative(segmentsbuf.outerLowerModuleIndices_buf);
-      seedIdx = alpaka::getPtrNative(segmentsbuf.seedIdx_buf);
-      mdIndices = alpaka::getPtrNative(segmentsbuf.mdIndices_buf);
-      nMemoryLocations = alpaka::getPtrNative(segmentsbuf.nMemoryLocations_buf);
-      innerMiniDoubletAnchorHitIndices = alpaka::getPtrNative(segmentsbuf.innerMiniDoubletAnchorHitIndices_buf);
-      outerMiniDoubletAnchorHitIndices = alpaka::getPtrNative(segmentsbuf.outerMiniDoubletAnchorHitIndices_buf);
-      charge = alpaka::getPtrNative(segmentsbuf.charge_buf);
-      superbin = alpaka::getPtrNative(segmentsbuf.superbin_buf);
-      nSegments = alpaka::getPtrNative(segmentsbuf.nSegments_buf);
-      totOccupancySegments = alpaka::getPtrNative(segmentsbuf.totOccupancySegments_buf);
-      pLSHitsIdxs = alpaka::getPtrNative(segmentsbuf.pLSHitsIdxs_buf);
-      pixelType = alpaka::getPtrNative(segmentsbuf.pixelType_buf);
-      isQuad = alpaka::getPtrNative(segmentsbuf.isQuad_buf);
-      isDup = alpaka::getPtrNative(segmentsbuf.isDup_buf);
-      partOfPT5 = alpaka::getPtrNative(segmentsbuf.partOfPT5_buf);
-      ptIn = alpaka::getPtrNative(segmentsbuf.ptIn_buf);
-      ptErr = alpaka::getPtrNative(segmentsbuf.ptErr_buf);
-      px = alpaka::getPtrNative(segmentsbuf.px_buf);
-      py = alpaka::getPtrNative(segmentsbuf.py_buf);
-      pz = alpaka::getPtrNative(segmentsbuf.pz_buf);
-      etaErr = alpaka::getPtrNative(segmentsbuf.etaErr_buf);
-      eta = alpaka::getPtrNative(segmentsbuf.eta_buf);
-      phi = alpaka::getPtrNative(segmentsbuf.phi_buf);
-      score = alpaka::getPtrNative(segmentsbuf.score_buf);
-      circleCenterX = alpaka::getPtrNative(segmentsbuf.circleCenterX_buf);
-      circleCenterY = alpaka::getPtrNative(segmentsbuf.circleCenterY_buf);
-      circleRadius = alpaka::getPtrNative(segmentsbuf.circleRadius_buf);
+    void setData(TBuff& buf) {
+      dPhis = alpaka::getPtrNative(buf.dPhis_buf);
+      dPhiMins = alpaka::getPtrNative(buf.dPhiMins_buf);
+      dPhiMaxs = alpaka::getPtrNative(buf.dPhiMaxs_buf);
+      dPhiChanges = alpaka::getPtrNative(buf.dPhiChanges_buf);
+      dPhiChangeMins = alpaka::getPtrNative(buf.dPhiChangeMins_buf);
+      dPhiChangeMaxs = alpaka::getPtrNative(buf.dPhiChangeMaxs_buf);
+      innerLowerModuleIndices = alpaka::getPtrNative(buf.innerLowerModuleIndices_buf);
+      outerLowerModuleIndices = alpaka::getPtrNative(buf.outerLowerModuleIndices_buf);
+      seedIdx = alpaka::getPtrNative(buf.seedIdx_buf);
+      mdIndices = alpaka::getPtrNative(buf.mdIndices_buf);
+      nMemoryLocations = alpaka::getPtrNative(buf.nMemoryLocations_buf);
+      innerMiniDoubletAnchorHitIndices = alpaka::getPtrNative(buf.innerMiniDoubletAnchorHitIndices_buf);
+      outerMiniDoubletAnchorHitIndices = alpaka::getPtrNative(buf.outerMiniDoubletAnchorHitIndices_buf);
+      charge = alpaka::getPtrNative(buf.charge_buf);
+      superbin = alpaka::getPtrNative(buf.superbin_buf);
+      nSegments = alpaka::getPtrNative(buf.nSegments_buf);
+      totOccupancySegments = alpaka::getPtrNative(buf.totOccupancySegments_buf);
+      pLSHitsIdxs = alpaka::getPtrNative(buf.pLSHitsIdxs_buf);
+      pixelType = alpaka::getPtrNative(buf.pixelType_buf);
+      isQuad = alpaka::getPtrNative(buf.isQuad_buf);
+      isDup = alpaka::getPtrNative(buf.isDup_buf);
+      partOfPT5 = alpaka::getPtrNative(buf.partOfPT5_buf);
+      ptIn = alpaka::getPtrNative(buf.ptIn_buf);
+      ptErr = alpaka::getPtrNative(buf.ptErr_buf);
+      px = alpaka::getPtrNative(buf.px_buf);
+      py = alpaka::getPtrNative(buf.py_buf);
+      pz = alpaka::getPtrNative(buf.pz_buf);
+      etaErr = alpaka::getPtrNative(buf.etaErr_buf);
+      eta = alpaka::getPtrNative(buf.eta_buf);
+      phi = alpaka::getPtrNative(buf.phi_buf);
+      score = alpaka::getPtrNative(buf.score_buf);
+      circleCenterX = alpaka::getPtrNative(buf.circleCenterX_buf);
+      circleCenterY = alpaka::getPtrNative(buf.circleCenterY_buf);
+      circleRadius = alpaka::getPtrNative(buf.circleRadius_buf);
     }
   };
 
   template <typename TDev>
-  struct segmentsBuffer : segments {
+  struct SegmentsBuffer {
     Buf<TDev, FPX> dPhis_buf;
     Buf<TDev, FPX> dPhiMins_buf;
     Buf<TDev, FPX> dPhiMaxs_buf;
@@ -121,8 +122,10 @@ namespace SDL {
     Buf<TDev, float> circleCenterY_buf;
     Buf<TDev, float> circleRadius_buf;
 
+    Segments data_;
+
     template <typename TQueue, typename TDevAcc>
-    segmentsBuffer(unsigned int nMemoryLocationsIn,
+    SegmentsBuffer(unsigned int nMemoryLocationsIn,
                    uint16_t nLowerModules,
                    unsigned int maxPixelSegments,
                    TDevAcc const& devAccIn,
@@ -167,9 +170,12 @@ namespace SDL {
       alpaka::memset(queue, pLSHitsIdxs_buf, 0u);
       alpaka::wait(queue);
     }
+
+    inline Segments const* data() const { return &data_; }
+    inline void setData(SegmentsBuffer& buf) { data_.setData(buf); }
   };
 
-  ALPAKA_FN_ACC ALPAKA_FN_INLINE float isTighterTiltedModules_seg(struct SDL::modules& modulesInGPU,
+  ALPAKA_FN_ACC ALPAKA_FN_INLINE float isTighterTiltedModules_seg(struct SDL::Modules& modulesInGPU,
                                                                   unsigned int moduleIndex) {
     // The "tighter" tilted modules are the subset of tilted modules that have smaller spacing
     // This is the same as what was previously considered as"isNormalTiltedModules"
@@ -223,7 +229,7 @@ namespace SDL {
     return moduleSeparation;
   };
 
-  ALPAKA_FN_ACC ALPAKA_FN_INLINE float moduleGapSize_seg(struct SDL::modules& modulesInGPU, unsigned int moduleIndex) {
+  ALPAKA_FN_ACC ALPAKA_FN_INLINE float moduleGapSize_seg(struct SDL::Modules& modulesInGPU, unsigned int moduleIndex) {
     static constexpr float miniDeltaTilted[3] = {0.26f, 0.26f, 0.26f};
     static constexpr float miniDeltaFlat[6] = {0.26f, 0.16f, 0.16f, 0.18f, 0.18f, 0.18f};
     static constexpr float miniDeltaLooseTilted[3] = {0.4f, 0.4f, 0.4f};
@@ -258,8 +264,8 @@ namespace SDL {
   template <typename TAcc>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE void dAlphaThreshold(TAcc const& acc,
                                                       float* dAlphaThresholdValues,
-                                                      struct SDL::modules& modulesInGPU,
-                                                      struct SDL::miniDoublets& mdsInGPU,
+                                                      struct SDL::Modules& modulesInGPU,
+                                                      struct SDL::MiniDoublets& mdsInGPU,
                                                       float& xIn,
                                                       float& yIn,
                                                       float& zIn,
@@ -350,7 +356,7 @@ namespace SDL {
     dAlphaThresholdValues[2] = dAlpha_Bfield + alpaka::math::sqrt(acc, dAlpha_res * dAlpha_res + sdMuls * sdMuls);
   };
 
-  ALPAKA_FN_ACC ALPAKA_FN_INLINE void addSegmentToMemory(struct SDL::segments& segmentsInGPU,
+  ALPAKA_FN_ACC ALPAKA_FN_INLINE void addSegmentToMemory(struct SDL::Segments& segmentsInGPU,
                                                          unsigned int lowerMDIndex,
                                                          unsigned int upperMDIndex,
                                                          uint16_t innerLowerModuleIndex,
@@ -385,8 +391,8 @@ namespace SDL {
 
   template <typename TAcc>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE void addPixelSegmentToMemory(TAcc const& acc,
-                                                              struct SDL::segments& segmentsInGPU,
-                                                              struct SDL::miniDoublets& mdsInGPU,
+                                                              struct SDL::Segments& segmentsInGPU,
+                                                              struct SDL::MiniDoublets& mdsInGPU,
                                                               unsigned int innerMDIndex,
                                                               unsigned int outerMDIndex,
                                                               uint16_t pixelModuleIndex,
@@ -448,8 +454,8 @@ namespace SDL {
 
   template <typename TAcc>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE bool runSegmentDefaultAlgoBarrel(TAcc const& acc,
-                                                                  struct SDL::modules& modulesInGPU,
-                                                                  struct SDL::miniDoublets& mdsInGPU,
+                                                                  struct SDL::Modules& modulesInGPU,
+                                                                  struct SDL::MiniDoublets& mdsInGPU,
                                                                   uint16_t& innerLowerModuleIndex,
                                                                   uint16_t& outerLowerModuleIndex,
                                                                   unsigned int& innerMDIndex,
@@ -551,8 +557,8 @@ namespace SDL {
 
   template <typename TAcc>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE bool runSegmentDefaultAlgoEndcap(TAcc const& acc,
-                                                                  struct SDL::modules& modulesInGPU,
-                                                                  struct SDL::miniDoublets& mdsInGPU,
+                                                                  struct SDL::Modules& modulesInGPU,
+                                                                  struct SDL::MiniDoublets& mdsInGPU,
                                                                   uint16_t& innerLowerModuleIndex,
                                                                   uint16_t& outerLowerModuleIndex,
                                                                   unsigned int& innerMDIndex,
@@ -681,8 +687,8 @@ namespace SDL {
 
   template <typename TAcc>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE bool runSegmentDefaultAlgo(TAcc const& acc,
-                                                            struct SDL::modules& modulesInGPU,
-                                                            struct SDL::miniDoublets& mdsInGPU,
+                                                            struct SDL::Modules& modulesInGPU,
+                                                            struct SDL::MiniDoublets& mdsInGPU,
                                                             uint16_t& innerLowerModuleIndex,
                                                             uint16_t& outerLowerModuleIndex,
                                                             unsigned int& innerMDIndex,
@@ -774,10 +780,10 @@ namespace SDL {
   struct createSegmentsInGPUv2 {
     template <typename TAcc>
     ALPAKA_FN_ACC void operator()(TAcc const& acc,
-                                  struct SDL::modules modulesInGPU,
-                                  struct SDL::miniDoublets mdsInGPU,
-                                  struct SDL::segments segmentsInGPU,
-                                  struct SDL::objectRanges rangesInGPU) const {
+                                  struct SDL::Modules modulesInGPU,
+                                  struct SDL::MiniDoublets mdsInGPU,
+                                  struct SDL::Segments segmentsInGPU,
+                                  struct SDL::ObjectRanges rangesInGPU) const {
       auto const globalBlockIdx = alpaka::getIdx<alpaka::Grid, alpaka::Blocks>(acc);
       auto const blockThreadIdx = alpaka::getIdx<alpaka::Block, alpaka::Threads>(acc);
       auto const gridBlockExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Blocks>(acc);
@@ -886,9 +892,9 @@ namespace SDL {
   struct createSegmentArrayRanges {
     template <typename TAcc>
     ALPAKA_FN_ACC void operator()(TAcc const& acc,
-                                  struct SDL::modules modulesInGPU,
-                                  struct SDL::objectRanges rangesInGPU,
-                                  struct SDL::miniDoublets mdsInGPU) const {
+                                  struct SDL::Modules modulesInGPU,
+                                  struct SDL::ObjectRanges rangesInGPU,
+                                  struct SDL::MiniDoublets mdsInGPU) const {
       auto const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
       auto const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
 
@@ -984,9 +990,9 @@ namespace SDL {
   struct addSegmentRangesToEventExplicit {
     template <typename TAcc>
     ALPAKA_FN_ACC void operator()(TAcc const& acc,
-                                  struct SDL::modules modulesInGPU,
-                                  struct SDL::segments segmentsInGPU,
-                                  struct SDL::objectRanges rangesInGPU) const {
+                                  struct SDL::Modules modulesInGPU,
+                                  struct SDL::Segments segmentsInGPU,
+                                  struct SDL::ObjectRanges rangesInGPU) const {
       auto const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
       auto const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
 
@@ -1005,11 +1011,11 @@ namespace SDL {
   struct addPixelSegmentToEventKernel {
     template <typename TAcc>
     ALPAKA_FN_ACC void operator()(TAcc const& acc,
-                                  struct SDL::modules modulesInGPU,
-                                  struct SDL::objectRanges rangesInGPU,
-                                  struct SDL::hits hitsInGPU,
-                                  struct SDL::miniDoublets mdsInGPU,
-                                  struct SDL::segments segmentsInGPU,
+                                  struct SDL::Modules modulesInGPU,
+                                  struct SDL::ObjectRanges rangesInGPU,
+                                  struct SDL::Hits hitsInGPU,
+                                  struct SDL::MiniDoublets mdsInGPU,
+                                  struct SDL::Segments segmentsInGPU,
                                   unsigned int* hitIndices0,
                                   unsigned int* hitIndices1,
                                   unsigned int* hitIndices2,

--- a/RecoTracker/LSTCore/standalone/code/core/AccessHelper.cc
+++ b/RecoTracker/LSTCore/standalone/code/core/AccessHelper.cc
@@ -9,12 +9,12 @@ using namespace ALPAKA_ACCELERATOR_NAMESPACE;
 //____________________________________________________________________________________________
 std::tuple<std::vector<unsigned int>, std::vector<unsigned int>> convertHitsToHitIdxsAndHitTypes(
     SDL::Event<Acc3D>* event, std::vector<unsigned int> hits) {
-  SDL::hitsBuffer<alpaka::DevCpu>& hitsInGPU = *(event->getHits());
+  SDL::Hits const* hitsEvt = event->getHits()->data();
   std::vector<unsigned int> hitidxs;
   std::vector<unsigned int> hittypes;
   for (auto& hit : hits) {
-    hitidxs.push_back(hitsInGPU.idxs[hit]);
-    if (hitsInGPU.detid[hit] == 1)
+    hitidxs.push_back(hitsEvt->idxs[hit]);
+    if (hitsEvt->detid[hit] == 1)
       hittypes.push_back(0);
     else
       hittypes.push_back(4);
@@ -28,17 +28,17 @@ std::tuple<std::vector<unsigned int>, std::vector<unsigned int>> convertHitsToHi
 
 //____________________________________________________________________________________________
 std::vector<unsigned int> getPixelHitsFrompLS(SDL::Event<Acc3D>* event, unsigned int pLS) {
-  SDL::segmentsBuffer<alpaka::DevCpu>& segments_ = *(event->getSegments());
-  SDL::miniDoubletsBuffer<alpaka::DevCpu>& miniDoublets_ = *(event->getMiniDoublets());
-  SDL::objectRangesBuffer<alpaka::DevCpu>& rangesInGPU = (*event->getRanges());
-  SDL::modulesBuffer<alpaka::DevCpu>& modulesInGPU = (*event->getModules());
-  const unsigned int pLS_offset = rangesInGPU.segmentModuleIndices[*(modulesInGPU.nLowerModules)];
-  unsigned int MD_1 = segments_.mdIndices[2 * (pLS + pLS_offset)];
-  unsigned int MD_2 = segments_.mdIndices[2 * (pLS + pLS_offset) + 1];
-  unsigned int hit_1 = miniDoublets_.anchorHitIndices[MD_1];
-  unsigned int hit_2 = miniDoublets_.outerHitIndices[MD_1];
-  unsigned int hit_3 = miniDoublets_.anchorHitIndices[MD_2];
-  unsigned int hit_4 = miniDoublets_.outerHitIndices[MD_2];
+  SDL::Segments const* segments = event->getSegments()->data();
+  SDL::MiniDoublets const* miniDoublets = event->getMiniDoublets()->data();
+  SDL::ObjectRanges const* rangesEvt = event->getRanges()->data();
+  SDL::Modules const* modulesEvt = event->getModules()->data();
+  const unsigned int pLS_offset = rangesEvt->segmentModuleIndices[*(modulesEvt->nLowerModules)];
+  unsigned int MD_1 = segments->mdIndices[2 * (pLS + pLS_offset)];
+  unsigned int MD_2 = segments->mdIndices[2 * (pLS + pLS_offset) + 1];
+  unsigned int hit_1 = miniDoublets->anchorHitIndices[MD_1];
+  unsigned int hit_2 = miniDoublets->outerHitIndices[MD_1];
+  unsigned int hit_3 = miniDoublets->anchorHitIndices[MD_2];
+  unsigned int hit_4 = miniDoublets->outerHitIndices[MD_2];
   if (hit_3 == hit_4)
     return {hit_1, hit_2, hit_3};
   else
@@ -47,11 +47,11 @@ std::vector<unsigned int> getPixelHitsFrompLS(SDL::Event<Acc3D>* event, unsigned
 
 //____________________________________________________________________________________________
 std::vector<unsigned int> getPixelHitIdxsFrompLS(SDL::Event<Acc3D>* event, unsigned int pLS) {
-  SDL::hitsBuffer<alpaka::DevCpu>& hitsInGPU = *(event->getHits());
+  SDL::Hits const* hitsEvt = event->getHits()->data();
   std::vector<unsigned int> hits = getPixelHitsFrompLS(event, pLS);
   std::vector<unsigned int> hitidxs;
   for (auto& hit : hits)
-    hitidxs.push_back(hitsInGPU.idxs[hit]);
+    hitidxs.push_back(hitsEvt->idxs[hit]);
   return hitidxs;
 }
 
@@ -74,9 +74,9 @@ std::tuple<std::vector<unsigned int>, std::vector<unsigned int>> getHitIdxsAndHi
 
 //____________________________________________________________________________________________
 std::vector<unsigned int> getHitsFromMD(SDL::Event<Acc3D>* event, unsigned int MD) {
-  SDL::miniDoubletsBuffer<alpaka::DevCpu>& miniDoublets_ = *(event->getMiniDoublets());
-  unsigned int hit_1 = miniDoublets_.anchorHitIndices[MD];
-  unsigned int hit_2 = miniDoublets_.outerHitIndices[MD];
+  SDL::MiniDoublets const* miniDoublets = event->getMiniDoublets()->data();
+  unsigned int hit_1 = miniDoublets->anchorHitIndices[MD];
+  unsigned int hit_2 = miniDoublets->outerHitIndices[MD];
   return {hit_1, hit_2};
 }
 
@@ -92,9 +92,9 @@ std::tuple<std::vector<unsigned int>, std::vector<unsigned int>> getHitIdxsAndHi
 
 //____________________________________________________________________________________________
 std::vector<unsigned int> getMDsFromLS(SDL::Event<Acc3D>* event, unsigned int LS) {
-  SDL::segmentsBuffer<alpaka::DevCpu>& segments_ = *(event->getSegments());
-  unsigned int MD_1 = segments_.mdIndices[2 * LS];
-  unsigned int MD_2 = segments_.mdIndices[2 * LS + 1];
+  SDL::Segments const* segments = event->getSegments()->data();
+  unsigned int MD_1 = segments->mdIndices[2 * LS];
+  unsigned int MD_2 = segments->mdIndices[2 * LS + 1];
   return {MD_1, MD_2};
 }
 
@@ -118,9 +118,9 @@ std::tuple<std::vector<unsigned int>, std::vector<unsigned int>> getHitIdxsAndHi
 
 //____________________________________________________________________________________________
 std::vector<unsigned int> getLSsFromT3(SDL::Event<Acc3D>* event, unsigned int T3) {
-  SDL::tripletsBuffer<alpaka::DevCpu>& triplets_ = *(event->getTriplets());
-  unsigned int LS_1 = triplets_.segmentIndices[2 * T3];
-  unsigned int LS_2 = triplets_.segmentIndices[2 * T3 + 1];
+  SDL::Triplets const* triplets = event->getTriplets()->data();
+  unsigned int LS_1 = triplets->segmentIndices[2 * T3];
+  unsigned int LS_2 = triplets->segmentIndices[2 * T3 + 1];
   return {LS_1, LS_2};
 }
 
@@ -153,9 +153,9 @@ std::tuple<std::vector<unsigned int>, std::vector<unsigned int>> getHitIdxsAndHi
 
 //____________________________________________________________________________________________
 std::vector<unsigned int> getT3sFromT5(SDL::Event<Acc3D>* event, unsigned int T5) {
-  SDL::quintupletsBuffer<alpaka::DevCpu>& quintuplets_ = *(event->getQuintuplets());
-  unsigned int T3_1 = quintuplets_.tripletIndices[2 * T5];
-  unsigned int T3_2 = quintuplets_.tripletIndices[2 * T5 + 1];
+  SDL::Quintuplets const* quintuplets = event->getQuintuplets()->data();
+  unsigned int T3_1 = quintuplets->tripletIndices[2 * T5];
+  unsigned int T3_2 = quintuplets->tripletIndices[2 * T5 + 1];
   return {T3_1, T3_2};
 }
 
@@ -190,20 +190,20 @@ std::vector<unsigned int> getHitsFromT5(SDL::Event<Acc3D>* event, unsigned int T
 
 //____________________________________________________________________________________________
 std::vector<unsigned int> getHitIdxsFromT5(SDL::Event<Acc3D>* event, unsigned int T5) {
-  SDL::hitsBuffer<alpaka::DevCpu>& hitsInGPU = *(event->getHits());
+  SDL::Hits const* hitsEvt = event->getHits()->data();
   std::vector<unsigned int> hits = getHitsFromT5(event, T5);
   std::vector<unsigned int> hitidxs;
   for (auto& hit : hits)
-    hitidxs.push_back(hitsInGPU.idxs[hit]);
+    hitidxs.push_back(hitsEvt->idxs[hit]);
   return hitidxs;
 }
 //____________________________________________________________________________________________
 std::vector<unsigned int> getModuleIdxsFromT5(SDL::Event<Acc3D>* event, unsigned int T5) {
   std::vector<unsigned int> hits = getHitsFromT5(event, T5);
   std::vector<unsigned int> module_idxs;
-  SDL::hitsBuffer<alpaka::DevCpu>& hitsInGPU = *(event->getHits());
+  SDL::Hits const* hitsEvt = event->getHits()->data();
   for (auto& hitIdx : hits) {
-    module_idxs.push_back(hitsInGPU.moduleIndices[hitIdx]);
+    module_idxs.push_back(hitsEvt->moduleIndices[hitIdx]);
   }
   return module_idxs;
 }
@@ -225,17 +225,17 @@ std::tuple<std::vector<unsigned int>, std::vector<unsigned int>> getHitIdxsAndHi
 
 //____________________________________________________________________________________________
 unsigned int getPixelLSFrompT3(SDL::Event<Acc3D>* event, unsigned int pT3) {
-  SDL::pixelTripletsBuffer<alpaka::DevCpu>& pixelTriplets_ = *(event->getPixelTriplets());
-  SDL::objectRangesBuffer<alpaka::DevCpu>& rangesInGPU = (*event->getRanges());
-  SDL::modulesBuffer<alpaka::DevCpu>& modulesInGPU = (*event->getModules());
-  const unsigned int pLS_offset = rangesInGPU.segmentModuleIndices[*(modulesInGPU.nLowerModules)];
-  return pixelTriplets_.pixelSegmentIndices[pT3] - pLS_offset;
+  SDL::PixelTriplets const* pixelTriplets = event->getPixelTriplets()->data();
+  SDL::ObjectRanges const* rangesEvt = event->getRanges()->data();
+  SDL::Modules const* modulesEvt = event->getModules()->data();
+  const unsigned int pLS_offset = rangesEvt->segmentModuleIndices[*(modulesEvt->nLowerModules)];
+  return pixelTriplets->pixelSegmentIndices[pT3] - pLS_offset;
 }
 
 //____________________________________________________________________________________________
 unsigned int getT3FrompT3(SDL::Event<Acc3D>* event, unsigned int pT3) {
-  SDL::pixelTriplets& pixelTriplets_ = *(event->getPixelTriplets());
-  return pixelTriplets_.tripletIndices[pT3];
+  SDL::PixelTriplets const* pixelTriplets = event->getPixelTriplets()->data();
+  return pixelTriplets->tripletIndices[pT3];
 }
 
 //____________________________________________________________________________________________
@@ -274,20 +274,20 @@ std::vector<unsigned int> getHitsFrompT3(SDL::Event<Acc3D>* event, unsigned int 
 
 //____________________________________________________________________________________________
 std::vector<unsigned int> getHitIdxsFrompT3(SDL::Event<Acc3D>* event, unsigned int pT3) {
-  SDL::hitsBuffer<alpaka::DevCpu>& hitsInGPU = *(event->getHits());
+  SDL::Hits const* hitsEvt = event->getHits()->data();
   std::vector<unsigned int> hits = getHitsFrompT3(event, pT3);
   std::vector<unsigned int> hitidxs;
   for (auto& hit : hits)
-    hitidxs.push_back(hitsInGPU.idxs[hit]);
+    hitidxs.push_back(hitsEvt->idxs[hit]);
   return hitidxs;
 }
 //____________________________________________________________________________________________
 std::vector<unsigned int> getModuleIdxsFrompT3(SDL::Event<Acc3D>* event, unsigned int pT3) {
   std::vector<unsigned int> hits = getOuterTrackerHitsFrompT3(event, pT3);
   std::vector<unsigned int> module_idxs;
-  SDL::hitsBuffer<alpaka::DevCpu>& hitsInGPU = *(event->getHits());
+  SDL::Hits const* hitsEvt = event->getHits()->data();
   for (auto& hitIdx : hits) {
-    module_idxs.push_back(hitsInGPU.moduleIndices[hitIdx]);
+    module_idxs.push_back(hitsEvt->moduleIndices[hitIdx]);
   }
   return module_idxs;
 }
@@ -314,17 +314,17 @@ std::tuple<std::vector<unsigned int>, std::vector<unsigned int>> getHitIdxsAndHi
 
 //____________________________________________________________________________________________
 unsigned int getPixelLSFrompT5(SDL::Event<Acc3D>* event, unsigned int pT5) {
-  SDL::pixelQuintupletsBuffer<alpaka::DevCpu>& pixelQuintuplets_ = *(event->getPixelQuintuplets());
-  SDL::objectRangesBuffer<alpaka::DevCpu>& rangesInGPU = (*event->getRanges());
-  SDL::modulesBuffer<alpaka::DevCpu>& modulesInGPU = (*event->getModules());
-  const unsigned int pLS_offset = rangesInGPU.segmentModuleIndices[*(modulesInGPU.nLowerModules)];
-  return pixelQuintuplets_.pixelIndices[pT5] - pLS_offset;
+  SDL::PixelQuintuplets const* pixelQuintuplets = event->getPixelQuintuplets()->data();
+  SDL::ObjectRanges const* rangesEvt = event->getRanges()->data();
+  SDL::Modules const* modulesEvt = event->getModules()->data();
+  const unsigned int pLS_offset = rangesEvt->segmentModuleIndices[*(modulesEvt->nLowerModules)];
+  return pixelQuintuplets->pixelIndices[pT5] - pLS_offset;
 }
 
 //____________________________________________________________________________________________
 unsigned int getT5FrompT5(SDL::Event<Acc3D>* event, unsigned int pT5) {
-  SDL::pixelQuintupletsBuffer<alpaka::DevCpu>& pixelQuintuplets_ = *(event->getPixelQuintuplets());
-  return pixelQuintuplets_.T5Indices[pT5];
+  SDL::PixelQuintuplets const* pixelQuintuplets = event->getPixelQuintuplets()->data();
+  return pixelQuintuplets->T5Indices[pT5];
 }
 
 //____________________________________________________________________________________________
@@ -369,11 +369,11 @@ std::vector<unsigned int> getHitsFrompT5(SDL::Event<Acc3D>* event, unsigned int 
 
 //____________________________________________________________________________________________
 std::vector<unsigned int> getHitIdxsFrompT5(SDL::Event<Acc3D>* event, unsigned int pT5) {
-  SDL::hitsBuffer<alpaka::DevCpu>& hitsInGPU = *(event->getHits());
+  SDL::Hits const* hitsEvt = event->getHits()->data();
   std::vector<unsigned int> hits = getHitsFrompT5(event, pT5);
   std::vector<unsigned int> hitidxs;
   for (auto& hit : hits)
-    hitidxs.push_back(hitsInGPU.idxs[hit]);
+    hitidxs.push_back(hitsEvt->idxs[hit]);
   return hitidxs;
 }
 
@@ -381,9 +381,9 @@ std::vector<unsigned int> getHitIdxsFrompT5(SDL::Event<Acc3D>* event, unsigned i
 std::vector<unsigned int> getModuleIdxsFrompT5(SDL::Event<Acc3D>* event, unsigned int pT5) {
   std::vector<unsigned int> hits = getOuterTrackerHitsFrompT5(event, pT5);
   std::vector<unsigned int> module_idxs;
-  SDL::hitsBuffer<alpaka::DevCpu>& hitsInGPU = *(event->getHits());
+  SDL::Hits const* hitsEvt = event->getHits()->data();
   for (auto& hitIdx : hits) {
-    module_idxs.push_back(hitsInGPU.moduleIndices[hitIdx]);
+    module_idxs.push_back(hitsEvt->moduleIndices[hitIdx]);
   }
   return module_idxs;
 }
@@ -412,9 +412,9 @@ std::tuple<std::vector<unsigned int>, std::vector<unsigned int>> getHitIdxsAndHi
 //____________________________________________________________________________________________
 std::vector<unsigned int> getLSsFromTC(SDL::Event<Acc3D>* event, unsigned int TC) {
   // Get the type of the track candidate
-  SDL::trackCandidatesBuffer<alpaka::DevCpu>& trackCandidatesInGPU = (*event->getTrackCandidates());
-  short type = trackCandidatesInGPU.trackCandidateType[TC];
-  unsigned int objidx = trackCandidatesInGPU.directObjectIndices[TC];
+  SDL::TrackCandidates const* trackCandidates = event->getTrackCandidates()->data();
+  short type = trackCandidates->trackCandidateType[TC];
+  unsigned int objidx = trackCandidates->directObjectIndices[TC];
   switch (type) {
     case kpT5:
       return getLSsFrompT5(event, objidx);
@@ -435,9 +435,9 @@ std::vector<unsigned int> getLSsFromTC(SDL::Event<Acc3D>* event, unsigned int TC
 std::tuple<std::vector<unsigned int>, std::vector<unsigned int>> getHitIdxsAndHitTypesFromTC(SDL::Event<Acc3D>* event,
                                                                                              unsigned TC) {
   // Get the type of the track candidate
-  SDL::trackCandidatesBuffer<alpaka::DevCpu>& trackCandidatesInGPU = (*event->getTrackCandidates());
-  short type = trackCandidatesInGPU.trackCandidateType[TC];
-  unsigned int objidx = trackCandidatesInGPU.directObjectIndices[TC];
+  SDL::TrackCandidates const* trackCandidates = event->getTrackCandidates()->data();
+  short type = trackCandidates->trackCandidateType[TC];
+  unsigned int objidx = trackCandidates->directObjectIndices[TC];
   switch (type) {
     case kpT5:
       return getHitIdxsAndHitTypesFrompT5(event, objidx);

--- a/RecoTracker/LSTCore/standalone/code/core/write_sdl_ntuple.cc
+++ b/RecoTracker/LSTCore/standalone/code/core/write_sdl_ntuple.cc
@@ -226,8 +226,8 @@ void setOutputBranches(SDL::Event<Acc3D>* event) {
   std::vector<std::vector<int>> tc_matched_simIdx;
 
   // ============ Track candidates =============
-  SDL::trackCandidatesBuffer<alpaka::DevCpu>& trackCandidatesInGPU = (*event->getTrackCandidates());
-  unsigned int nTrackCandidates = *trackCandidatesInGPU.nTrackCandidates;
+  SDL::TrackCandidates const* trackCandidates = event->getTrackCandidates()->data();
+  unsigned int nTrackCandidates = *trackCandidates->nTrackCandidates;
   for (unsigned int idx = 0; idx < nTrackCandidates; idx++) {
     // Compute reco quantities of track candidate based on final object
     int type, isFake;
@@ -291,23 +291,23 @@ void setOptionalOutputBranches(SDL::Event<Acc3D>* event) {
 //________________________________________________________________________________________________________________________________
 void setPixelQuintupletOutputBranches(SDL::Event<Acc3D>* event) {
   // ============ pT5 =============
-  SDL::pixelQuintupletsBuffer<alpaka::DevCpu>& pixelQuintupletsInGPU = (*event->getPixelQuintuplets());
-  SDL::quintupletsBuffer<alpaka::DevCpu>& quintupletsInGPU = (*event->getQuintuplets());
-  SDL::segmentsBuffer<alpaka::DevCpu>& segmentsInGPU = (*event->getSegments());
-  SDL::modulesBuffer<alpaka::DevCpu>& modulesInGPU = (*event->getModules());
+  SDL::PixelQuintuplets const* pixelQuintuplets = event->getPixelQuintuplets()->data();
+  SDL::Quintuplets const* quintuplets = event->getQuintuplets()->data();
+  SDL::Segments const* segments = event->getSegments()->data();
+  SDL::Modules const* modules = event->getModules()->data();
   int n_accepted_simtrk = ana.tx->getBranch<std::vector<int>>("sim_TC_matched").size();
 
   unsigned int nPixelQuintuplets =
-      *pixelQuintupletsInGPU.nPixelQuintuplets;  // size of this nPixelTriplets array is 1 (NOTE: parallelism lost here.)
+      *pixelQuintuplets->nPixelQuintuplets;  // size of this nPixelTriplets array is 1 (NOTE: parallelism lost here.)
   std::vector<int> sim_pT5_matched(n_accepted_simtrk);
   std::vector<std::vector<int>> pT5_matched_simIdx;
 
   for (unsigned int pT5 = 0; pT5 < nPixelQuintuplets; pT5++) {
     unsigned int T5Index = getT5FrompT5(event, pT5);
     unsigned int pLSIndex = getPixelLSFrompT5(event, pT5);
-    float pt = (__H2F(quintupletsInGPU.innerRadius[T5Index]) * SDL::k2Rinv1GeVf * 2 + segmentsInGPU.ptIn[pLSIndex]) / 2;
-    float eta = segmentsInGPU.eta[pLSIndex];
-    float phi = segmentsInGPU.phi[pLSIndex];
+    float pt = (__H2F(quintuplets->innerRadius[T5Index]) * SDL::k2Rinv1GeVf * 2 + segments->ptIn[pLSIndex]) / 2;
+    float eta = segments->eta[pLSIndex];
+    float phi = segments->phi[pLSIndex];
 
     std::vector<unsigned int> hit_idx = getHitIdxsFrompT5(event, pT5);
     std::vector<unsigned int> module_idx = getModuleIdxsFrompT5(event, pT5);
@@ -316,8 +316,8 @@ void setPixelQuintupletOutputBranches(SDL::Event<Acc3D>* event) {
     int layer_binary = 1;
     int moduleType_binary = 0;
     for (size_t i = 0; i < module_idx.size(); i += 2) {
-      layer_binary |= (1 << (modulesInGPU.layers[module_idx[i]] + 6 * (modulesInGPU.subdets[module_idx[i]] == 4)));
-      moduleType_binary |= (modulesInGPU.moduleType[module_idx[i]] << i);
+      layer_binary |= (1 << (modules->layers[module_idx[i]] + 6 * (modules->subdets[module_idx[i]] == 4)));
+      moduleType_binary |= (modules->moduleType[module_idx[i]] << i);
     }
     std::vector<int> simidx = matchedSimTrkIdxs(hit_idx, hit_type);
     ana.tx->pushbackToBranch<int>("pT5_isFake", static_cast<int>(simidx.size() == 0));
@@ -366,21 +366,21 @@ void setPixelQuintupletOutputBranches(SDL::Event<Acc3D>* event) {
 
 //________________________________________________________________________________________________________________________________
 void setQuintupletOutputBranches(SDL::Event<Acc3D>* event) {
-  SDL::quintupletsBuffer<alpaka::DevCpu>& quintupletsInGPU = (*event->getQuintuplets());
-  SDL::objectRangesBuffer<alpaka::DevCpu>& rangesInGPU = (*event->getRanges());
-  SDL::modulesBuffer<alpaka::DevCpu>& modulesInGPU = (*event->getModules());
+  SDL::Quintuplets const* quintuplets = event->getQuintuplets()->data();
+  SDL::ObjectRanges const* ranges = event->getRanges()->data();
+  SDL::Modules const* modules = event->getModules()->data();
   int n_accepted_simtrk = ana.tx->getBranch<std::vector<int>>("sim_TC_matched").size();
 
   std::vector<int> sim_t5_matched(n_accepted_simtrk);
   std::vector<std::vector<int>> t5_matched_simIdx;
 
-  for (unsigned int lowerModuleIdx = 0; lowerModuleIdx < *(modulesInGPU.nLowerModules); ++lowerModuleIdx) {
-    int nQuintuplets = quintupletsInGPU.nQuintuplets[lowerModuleIdx];
+  for (unsigned int lowerModuleIdx = 0; lowerModuleIdx < *(modules->nLowerModules); ++lowerModuleIdx) {
+    int nQuintuplets = quintuplets->nQuintuplets[lowerModuleIdx];
     for (unsigned int idx = 0; idx < nQuintuplets; idx++) {
-      unsigned int quintupletIndex = rangesInGPU.quintupletModuleIndices[lowerModuleIdx] + idx;
-      float pt = __H2F(quintupletsInGPU.innerRadius[quintupletIndex]) * SDL::k2Rinv1GeVf * 2;
-      float eta = __H2F(quintupletsInGPU.eta[quintupletIndex]);
-      float phi = __H2F(quintupletsInGPU.phi[quintupletIndex]);
+      unsigned int quintupletIndex = ranges->quintupletModuleIndices[lowerModuleIdx] + idx;
+      float pt = __H2F(quintuplets->innerRadius[quintupletIndex]) * SDL::k2Rinv1GeVf * 2;
+      float eta = __H2F(quintuplets->eta[quintupletIndex]);
+      float phi = __H2F(quintuplets->phi[quintupletIndex]);
 
       std::vector<unsigned int> hit_idx = getHitIdxsFromT5(event, quintupletIndex);
       std::vector<unsigned int> hit_type = getHitTypesFromT5(event, quintupletIndex);
@@ -389,8 +389,8 @@ void setQuintupletOutputBranches(SDL::Event<Acc3D>* event) {
       int layer_binary = 0;
       int moduleType_binary = 0;
       for (size_t i = 0; i < module_idx.size(); i += 2) {
-        layer_binary |= (1 << (modulesInGPU.layers[module_idx[i]] + 6 * (modulesInGPU.subdets[module_idx[i]] == 4)));
-        moduleType_binary |= (modulesInGPU.moduleType[module_idx[i]] << i);
+        layer_binary |= (1 << (modules->layers[module_idx[i]] + 6 * (modules->subdets[module_idx[i]] == 4)));
+        moduleType_binary |= (modules->moduleType[module_idx[i]] << i);
       }
 
       std::vector<int> simidx = matchedSimTrkIdxs(hit_idx, hit_type);
@@ -399,11 +399,11 @@ void setQuintupletOutputBranches(SDL::Event<Acc3D>* event) {
       ana.tx->pushbackToBranch<float>("t5_pt", pt);
       ana.tx->pushbackToBranch<float>("t5_eta", eta);
       ana.tx->pushbackToBranch<float>("t5_phi", phi);
-      ana.tx->pushbackToBranch<float>("t5_innerRadius", __H2F(quintupletsInGPU.innerRadius[quintupletIndex]));
-      ana.tx->pushbackToBranch<float>("t5_bridgeRadius", __H2F(quintupletsInGPU.bridgeRadius[quintupletIndex]));
-      ana.tx->pushbackToBranch<float>("t5_outerRadius", __H2F(quintupletsInGPU.outerRadius[quintupletIndex]));
-      ana.tx->pushbackToBranch<float>("t5_chiSquared", quintupletsInGPU.chiSquared[quintupletIndex]);
-      ana.tx->pushbackToBranch<float>("t5_rzChiSquared", quintupletsInGPU.rzChiSquared[quintupletIndex]);
+      ana.tx->pushbackToBranch<float>("t5_innerRadius", __H2F(quintuplets->innerRadius[quintupletIndex]));
+      ana.tx->pushbackToBranch<float>("t5_bridgeRadius", __H2F(quintuplets->bridgeRadius[quintupletIndex]));
+      ana.tx->pushbackToBranch<float>("t5_outerRadius", __H2F(quintuplets->outerRadius[quintupletIndex]));
+      ana.tx->pushbackToBranch<float>("t5_chiSquared", quintuplets->chiSquared[quintupletIndex]);
+      ana.tx->pushbackToBranch<float>("t5_rzChiSquared", quintuplets->rzChiSquared[quintupletIndex]);
       ana.tx->pushbackToBranch<int>("t5_layer_binary", layer_binary);
       ana.tx->pushbackToBranch<int>("t5_moduleType_binary", moduleType_binary);
 
@@ -437,24 +437,22 @@ void setQuintupletOutputBranches(SDL::Event<Acc3D>* event) {
 
 //________________________________________________________________________________________________________________________________
 void setPixelTripletOutputBranches(SDL::Event<Acc3D>* event) {
-  SDL::pixelTripletsBuffer<alpaka::DevCpu>& pixelTripletsInGPU = (*event->getPixelTriplets());
-  SDL::tripletsBuffer<alpaka::DevCpu>& tripletsInGPU = *(event->getTriplets());
-  SDL::modulesBuffer<alpaka::DevCpu>& modulesInGPU = *(event->getModules());
-  SDL::segmentsBuffer<alpaka::DevCpu>& segmentsInGPU = *(event->getSegments());
-  SDL::hitsBuffer<alpaka::DevCpu>& hitsInGPU = *(event->getHits());
+  SDL::PixelTriplets const* pixelTriplets = event->getPixelTriplets()->data();
+  SDL::Modules const* modules = event->getModules()->data();
+  SDL::Segments const* segments = event->getSegments()->data();
   int n_accepted_simtrk = ana.tx->getBranch<std::vector<int>>("sim_TC_matched").size();
 
-  unsigned int nPixelTriplets = *pixelTripletsInGPU.nPixelTriplets;
+  unsigned int nPixelTriplets = *pixelTriplets->nPixelTriplets;
   std::vector<int> sim_pT3_matched(n_accepted_simtrk);
   std::vector<std::vector<int>> pT3_matched_simIdx;
 
   for (unsigned int pT3 = 0; pT3 < nPixelTriplets; pT3++) {
     unsigned int T3Index = getT3FrompT3(event, pT3);
     unsigned int pLSIndex = getPixelLSFrompT3(event, pT3);
-    const float pt = segmentsInGPU.ptIn[pLSIndex];
+    const float pt = segments->ptIn[pLSIndex];
 
-    float eta = segmentsInGPU.eta[pLSIndex];
-    float phi = segmentsInGPU.phi[pLSIndex];
+    float eta = segments->eta[pLSIndex];
+    float phi = segments->phi[pLSIndex];
     std::vector<unsigned int> hit_idx = getHitIdxsFrompT3(event, pT3);
     std::vector<unsigned int> hit_type = getHitTypesFrompT3(event, pT3);
 
@@ -463,8 +461,8 @@ void setPixelTripletOutputBranches(SDL::Event<Acc3D>* event) {
     int layer_binary = 1;
     int moduleType_binary = 0;
     for (size_t i = 0; i < module_idx.size(); i += 2) {
-      layer_binary |= (1 << (modulesInGPU.layers[module_idx[i]] + 6 * (modulesInGPU.subdets[module_idx[i]] == 4)));
-      moduleType_binary |= (modulesInGPU.moduleType[module_idx[i]] << i);
+      layer_binary |= (1 << (modules->layers[module_idx[i]] + 6 * (modules->subdets[module_idx[i]] == 4)));
+      moduleType_binary |= (modules->moduleType[module_idx[i]] << i);
     }
     ana.tx->pushbackToBranch<int>("pT3_isFake", static_cast<int>(simidx.size() == 0));
     ana.tx->pushbackToBranch<float>("pT3_pt", pt);
@@ -503,12 +501,12 @@ void setPixelTripletOutputBranches(SDL::Event<Acc3D>* event) {
 //________________________________________________________________________________________________________________________________
 void setGnnNtupleBranches(SDL::Event<Acc3D>* event) {
   // Get relevant information
-  SDL::segmentsBuffer<alpaka::DevCpu>& segmentsInGPU = (*event->getSegments());
-  SDL::miniDoubletsBuffer<alpaka::DevCpu>& miniDoubletsInGPU = (*event->getMiniDoublets());
-  SDL::hitsBuffer<alpaka::DevCpu>& hitsInGPU = (*event->getHits());
-  SDL::modulesBuffer<alpaka::DevCpu>& modulesInGPU = (*event->getModules());
-  SDL::objectRangesBuffer<alpaka::DevCpu>& rangesInGPU = (*event->getRanges());
-  SDL::trackCandidatesBuffer<alpaka::DevCpu>& trackCandidatesInGPU = (*event->getTrackCandidates());
+  SDL::Segments const* segments = event->getSegments()->data();
+  SDL::MiniDoublets const* miniDoublets = event->getMiniDoublets()->data();
+  SDL::Hits const* hitsEvt = event->getHits()->data();
+  SDL::Modules const* modules = event->getModules()->data();
+  SDL::ObjectRanges const* ranges = event->getRanges()->data();
+  SDL::TrackCandidates const* trackCandidates = event->getTrackCandidates()->data();
 
   std::set<unsigned int> mds_used_in_sg;
   std::map<unsigned int, unsigned int> md_index_map;
@@ -517,13 +515,13 @@ void setGnnNtupleBranches(SDL::Event<Acc3D>* event) {
   // Loop over modules (lower ones where the MDs are saved)
   unsigned int nTotalMD = 0;
   unsigned int nTotalLS = 0;
-  for (unsigned int idx = 0; idx < *(modulesInGPU.nLowerModules); ++idx) {
-    nTotalMD += miniDoubletsInGPU.nMDs[idx];
-    nTotalLS += segmentsInGPU.nSegments[idx];
+  for (unsigned int idx = 0; idx < *(modules->nLowerModules); ++idx) {
+    nTotalMD += miniDoublets->nMDs[idx];
+    nTotalLS += segments->nSegments[idx];
   }
 
   std::set<unsigned int> lss_used_in_true_tc;
-  unsigned int nTrackCandidates = *trackCandidatesInGPU.nTrackCandidates;
+  unsigned int nTrackCandidates = *trackCandidates->nTrackCandidates;
   for (unsigned int idx = 0; idx < nTrackCandidates; idx++) {
     // Only consider true track candidates
     std::vector<unsigned int> hitidxs;
@@ -547,20 +545,20 @@ void setGnnNtupleBranches(SDL::Event<Acc3D>* event) {
   // std::cout <<  " nTotalLS: " << nTotalLS <<  std::endl;
 
   // Loop over modules (lower ones where the MDs are saved)
-  for (unsigned int idx = 0; idx < *(modulesInGPU.nLowerModules); ++idx) {
+  for (unsigned int idx = 0; idx < *(modules->nLowerModules); ++idx) {
     // // Loop over minidoublets
-    // for (unsigned int jdx = 0; jdx < miniDoubletsInGPU.nMDs[idx]; jdx++)
+    // for (unsigned int jdx = 0; jdx < miniDoublets->nMDs[idx]; jdx++)
     // {
-    //     // Get the actual index to the mini-doublet using rangesInGPU
-    //     unsigned int mdIdx = rangesInGPU.miniDoubletModuleIndices[idx] + jdx;
+    //     // Get the actual index to the mini-doublet using ranges
+    //     unsigned int mdIdx = ranges->miniDoubletModuleIndices[idx] + jdx;
 
     //     setGnnNtupleMiniDoublet(event, mdIdx);
     // }
 
     // Loop over segments
-    for (unsigned int jdx = 0; jdx < segmentsInGPU.nSegments[idx]; jdx++) {
-      // Get the actual index to the segments using rangesInGPU
-      unsigned int sgIdx = rangesInGPU.segmentModuleIndices[idx] + jdx;
+    for (unsigned int jdx = 0; jdx < segments->nSegments[idx]; jdx++) {
+      // Get the actual index to the segments using ranges
+      unsigned int sgIdx = ranges->segmentModuleIndices[idx] + jdx;
 
       // Get the hit indices
       std::vector<unsigned int> MDs = getMDsFromLS(event, sgIdx);
@@ -584,8 +582,8 @@ void setGnnNtupleBranches(SDL::Event<Acc3D>* event) {
 
       // Computing line segment pt estimate (assuming beam spot is at zero)
       SDLMath::Hit hitA(0, 0, 0);
-      SDLMath::Hit hitB(hitsInGPU.xs[hits[0]], hitsInGPU.ys[hits[0]], hitsInGPU.zs[hits[0]]);
-      SDLMath::Hit hitC(hitsInGPU.xs[hits[2]], hitsInGPU.ys[hits[2]], hitsInGPU.zs[hits[2]]);
+      SDLMath::Hit hitB(hitsEvt->xs[hits[0]], hitsEvt->ys[hits[0]], hitsEvt->zs[hits[0]]);
+      SDLMath::Hit hitC(hitsEvt->xs[hits[2]], hitsEvt->ys[hits[2]], hitsEvt->zs[hits[2]]);
       SDLMath::Hit center = SDLMath::getCenterFromThreePoints(hitA, hitB, hitC);
       float pt = SDLMath::ptEstimateFromRadius(center.rt());
       float eta = hitC.eta();
@@ -644,25 +642,25 @@ void setGnnNtupleBranches(SDL::Event<Acc3D>* event) {
 //________________________________________________________________________________________________________________________________
 void setGnnNtupleMiniDoublet(SDL::Event<Acc3D>* event, unsigned int MD) {
   // Get relevant information
-  SDL::miniDoubletsBuffer<alpaka::DevCpu>& miniDoubletsInGPU = (*event->getMiniDoublets());
-  SDL::hitsBuffer<alpaka::DevCpu>& hitsInGPU = (*event->getHits());
+  SDL::MiniDoublets const* miniDoublets = event->getMiniDoublets()->data();
+  SDL::Hits const* hitsEvt = event->getHits()->data();
 
   // Get the hit indices
-  unsigned int hit0 = miniDoubletsInGPU.anchorHitIndices[MD];
-  unsigned int hit1 = miniDoubletsInGPU.outerHitIndices[MD];
+  unsigned int hit0 = miniDoublets->anchorHitIndices[MD];
+  unsigned int hit1 = miniDoublets->outerHitIndices[MD];
 
   // Get the hit infos
-  const float hit0_x = hitsInGPU.xs[hit0];
-  const float hit0_y = hitsInGPU.ys[hit0];
-  const float hit0_z = hitsInGPU.zs[hit0];
+  const float hit0_x = hitsEvt->xs[hit0];
+  const float hit0_y = hitsEvt->ys[hit0];
+  const float hit0_z = hitsEvt->zs[hit0];
   const float hit0_r = sqrt(hit0_x * hit0_x + hit0_y * hit0_y);
-  const float hit1_x = hitsInGPU.xs[hit1];
-  const float hit1_y = hitsInGPU.ys[hit1];
-  const float hit1_z = hitsInGPU.zs[hit1];
+  const float hit1_x = hitsEvt->xs[hit1];
+  const float hit1_y = hitsEvt->ys[hit1];
+  const float hit1_z = hitsEvt->zs[hit1];
   const float hit1_r = sqrt(hit1_x * hit1_x + hit1_y * hit1_y);
 
   // Do sim matching
-  std::vector<unsigned int> hit_idx = {hitsInGPU.idxs[hit0], hitsInGPU.idxs[hit1]};
+  std::vector<unsigned int> hit_idx = {hitsEvt->idxs[hit0], hitsEvt->idxs[hit1]};
   std::vector<unsigned int> hit_type = {4, 4};
   std::vector<int> simidxs = matchedSimTrkIdxs(hit_idx, hit_type);
 
@@ -670,8 +668,8 @@ void setGnnNtupleMiniDoublet(SDL::Event<Acc3D>* event, unsigned int MD) {
   int tp_type = getDenomSimTrkType(simidxs);
 
   // Obtain where the actual hit is located in terms of their layer, module, rod, and ring number
-  unsigned int anchitidx = hitsInGPU.idxs[hit0];
-  int subdet = trk.ph2_subdet()[hitsInGPU.idxs[anchitidx]];
+  unsigned int anchitidx = hitsEvt->idxs[hit0];
+  int subdet = trk.ph2_subdet()[hitsEvt->idxs[anchitidx]];
   int is_endcap = subdet == 4;
   int layer =
       trk.ph2_layer()[anchitidx] +
@@ -679,7 +677,7 @@ void setGnnNtupleMiniDoublet(SDL::Event<Acc3D>* event, unsigned int MD) {
   int detId = trk.ph2_detId()[anchitidx];
 
   // Obtaining dPhiChange
-  float dphichange = miniDoubletsInGPU.dphichanges[MD];
+  float dphichange = miniDoublets->dphichanges[MD];
 
   // Computing pt
   float pt = hit0_r * SDL::k2Rinv1GeVf / sin(dphichange);
@@ -713,8 +711,8 @@ void setGnnNtupleMiniDoublet(SDL::Event<Acc3D>* event, unsigned int MD) {
 std::tuple<int, float, float, float, int, std::vector<int>> parseTrackCandidate(SDL::Event<Acc3D>* event,
                                                                                 unsigned int idx) {
   // Get the type of the track candidate
-  SDL::trackCandidatesBuffer<alpaka::DevCpu>& trackCandidatesInGPU = (*event->getTrackCandidates());
-  short type = trackCandidatesInGPU.trackCandidateType[idx];
+  SDL::TrackCandidates const* trackCandidates = event->getTrackCandidates()->data();
+  short type = trackCandidates->trackCandidateType[idx];
 
   enum { pT5 = 7, pT3 = 5, T5 = 4, pLS = 8 };
 
@@ -747,9 +745,9 @@ std::tuple<int, float, float, float, int, std::vector<int>> parseTrackCandidate(
 std::tuple<float, float, float, std::vector<unsigned int>, std::vector<unsigned int>> parsepT5(SDL::Event<Acc3D>* event,
                                                                                                unsigned int idx) {
   // Get relevant information
-  SDL::trackCandidatesBuffer<alpaka::DevCpu>& trackCandidatesInGPU = (*event->getTrackCandidates());
-  SDL::quintupletsBuffer<alpaka::DevCpu>& quintupletsInGPU = (*event->getQuintuplets());
-  SDL::segmentsBuffer<alpaka::DevCpu>& segmentsInGPU = (*event->getSegments());
+  SDL::TrackCandidates const* trackCandidates = event->getTrackCandidates()->data();
+  SDL::Quintuplets const* quintuplets = event->getQuintuplets()->data();
+  SDL::Segments const* segments = event->getSegments()->data();
 
   //
   // pictorial representation of a pT5
@@ -760,7 +758,7 @@ std::tuple<float, float, float, std::vector<unsigned int>, std::vector<unsigned 
   // ****           oo -- oo -- oo -- oo -- oo   pT5
   //                oo -- oo -- oo               first T3 of the T5
   //                            oo -- oo -- oo   second T3 of the T5
-  unsigned int pT5 = trackCandidatesInGPU.directObjectIndices[idx];
+  unsigned int pT5 = trackCandidates->directObjectIndices[idx];
   unsigned int pLS = getPixelLSFrompT5(event, pT5);
   unsigned int T5Index = getT5FrompT5(event, pT5);
 
@@ -842,10 +840,10 @@ std::tuple<float, float, float, std::vector<unsigned int>, std::vector<unsigned 
   // And from there we estimate the pt's and we compute pt_T5.
 
   // pixel pt
-  const float pt_pLS = segmentsInGPU.ptIn[pLS];
-  const float eta_pLS = segmentsInGPU.eta[pLS];
-  const float phi_pLS = segmentsInGPU.phi[pLS];
-  float pt_T5 = __H2F(quintupletsInGPU.innerRadius[T5Index]) * 2 * SDL::k2Rinv1GeVf;
+  const float pt_pLS = segments->ptIn[pLS];
+  const float eta_pLS = segments->eta[pLS];
+  const float phi_pLS = segments->phi[pLS];
+  float pt_T5 = __H2F(quintuplets->innerRadius[T5Index]) * 2 * SDL::k2Rinv1GeVf;
   const float pt = (pt_T5 + pt_pLS) / 2;
 
   // Form the hit idx/type std::vector
@@ -859,9 +857,9 @@ std::tuple<float, float, float, std::vector<unsigned int>, std::vector<unsigned 
 std::tuple<float, float, float, std::vector<unsigned int>, std::vector<unsigned int>> parsepT3(SDL::Event<Acc3D>* event,
                                                                                                unsigned int idx) {
   // Get relevant information
-  SDL::trackCandidatesBuffer<alpaka::DevCpu>& trackCandidatesInGPU = (*event->getTrackCandidates());
-  SDL::tripletsBuffer<alpaka::DevCpu>& tripletsInGPU = (*event->getTriplets());
-  SDL::segmentsBuffer<alpaka::DevCpu>& segmentsInGPU = (*event->getSegments());
+  SDL::TrackCandidates const* trackCandidates = event->getTrackCandidates()->data();
+  SDL::Triplets const* triplets = event->getTriplets()->data();
+  SDL::Segments const* segments = event->getSegments()->data();
 
   //
   // pictorial representation of a pT3
@@ -870,15 +868,15 @@ std::tuple<float, float, float, std::vector<unsigned int>, std::vector<unsigned 
   // -------------  --------------------------
   // pLS            01    23    45               (anchor hit of a minidoublet is always the first of the pair)
   // ****           oo -- oo -- oo               pT3
-  unsigned int pT3 = trackCandidatesInGPU.directObjectIndices[idx];
+  unsigned int pT3 = trackCandidates->directObjectIndices[idx];
   unsigned int pLS = getPixelLSFrompT3(event, pT3);
   unsigned int T3 = getT3FrompT3(event, pT3);
 
   // pixel pt
-  const float pt_pLS = segmentsInGPU.ptIn[pLS];
-  const float eta_pLS = segmentsInGPU.eta[pLS];
-  const float phi_pLS = segmentsInGPU.phi[pLS];
-  float pt_T3 = tripletsInGPU.circleRadius[T3] * 2 * SDL::k2Rinv1GeVf;
+  const float pt_pLS = segments->ptIn[pLS];
+  const float eta_pLS = segments->eta[pLS];
+  const float phi_pLS = segments->phi[pLS];
+  float pt_T3 = triplets->circleRadius[T3] * 2 * SDL::k2Rinv1GeVf;
 
   // average pt
   const float pt = (pt_pLS + pt_T3) / 2;
@@ -893,9 +891,9 @@ std::tuple<float, float, float, std::vector<unsigned int>, std::vector<unsigned 
 //________________________________________________________________________________________________________________________________
 std::tuple<float, float, float, std::vector<unsigned int>, std::vector<unsigned int>> parseT5(SDL::Event<Acc3D>* event,
                                                                                               unsigned int idx) {
-  SDL::trackCandidatesBuffer<alpaka::DevCpu>& trackCandidatesInGPU = (*event->getTrackCandidates());
-  SDL::quintupletsBuffer<alpaka::DevCpu>& quintupletsInGPU = (*event->getQuintuplets());
-  unsigned int T5 = trackCandidatesInGPU.directObjectIndices[idx];
+  SDL::TrackCandidates const* trackCandidates = event->getTrackCandidates()->data();
+  SDL::Quintuplets const* quintuplets = event->getQuintuplets()->data();
+  unsigned int T5 = trackCandidates->directObjectIndices[idx];
   std::vector<unsigned int> hits = getHitsFromT5(event, T5);
 
   //
@@ -910,7 +908,7 @@ std::tuple<float, float, float, std::vector<unsigned int>, std::vector<unsigned 
   unsigned int Hit_8 = hits[8];
 
   // T5 radius is average of the inner and outer radius
-  const float pt = quintupletsInGPU.innerRadius[T5] * SDL::k2Rinv1GeVf * 2;
+  const float pt = quintuplets->innerRadius[T5] * SDL::k2Rinv1GeVf * 2;
 
   // T5 eta and phi are computed using outer and innermost hits
   SDLMath::Hit hitA(trk.ph2_x()[Hit_0], trk.ph2_y()[Hit_0], trk.ph2_z()[Hit_0]);
@@ -927,16 +925,16 @@ std::tuple<float, float, float, std::vector<unsigned int>, std::vector<unsigned 
 //________________________________________________________________________________________________________________________________
 std::tuple<float, float, float, std::vector<unsigned int>, std::vector<unsigned int>> parsepLS(SDL::Event<Acc3D>* event,
                                                                                                unsigned int idx) {
-  SDL::trackCandidatesBuffer<alpaka::DevCpu>& trackCandidatesInGPU = (*event->getTrackCandidates());
-  SDL::segmentsBuffer<alpaka::DevCpu>& segmentsInGPU = (*event->getSegments());
+  SDL::TrackCandidates const* trackCandidates = event->getTrackCandidates()->data();
+  SDL::Segments const* segments = event->getSegments()->data();
 
   // Getting pLS index
-  unsigned int pLS = trackCandidatesInGPU.directObjectIndices[idx];
+  unsigned int pLS = trackCandidates->directObjectIndices[idx];
 
   // Getting pt eta and phi
-  float pt = segmentsInGPU.ptIn[pLS];
-  float eta = segmentsInGPU.eta[pLS];
-  float phi = segmentsInGPU.phi[pLS];
+  float pt = segments->ptIn[pLS];
+  float eta = segments->eta[pLS];
+  float phi = segments->phi[pLS];
 
   // Getting hit indices and types
   std::vector<unsigned int> hit_idx = getPixelHitIdxsFrompLS(event, pLS);
@@ -947,32 +945,32 @@ std::tuple<float, float, float, std::vector<unsigned int>, std::vector<unsigned 
 
 //________________________________________________________________________________________________________________________________
 void printHitMultiplicities(SDL::Event<Acc3D>* event) {
-  SDL::modulesBuffer<alpaka::DevCpu>& modulesInGPU = (*event->getModules());
-  SDL::objectRangesBuffer<alpaka::DevCpu>& rangesInGPU = (*event->getRanges());
+  SDL::Modules const* modules = event->getModules()->data();
+  SDL::ObjectRanges const* ranges = event->getRanges()->data();
 
   int nHits = 0;
-  for (unsigned int idx = 0; idx <= *(modulesInGPU.nLowerModules);
+  for (unsigned int idx = 0; idx <= *(modules->nLowerModules);
        idx++)  // "<=" because cheating to include pixel track candidate lower module
   {
-    nHits += rangesInGPU.hitRanges[4 * idx + 1] - rangesInGPU.hitRanges[4 * idx] + 1;
-    nHits += rangesInGPU.hitRanges[4 * idx + 3] - rangesInGPU.hitRanges[4 * idx + 2] + 1;
+    nHits += ranges->hitRanges[4 * idx + 1] - ranges->hitRanges[4 * idx] + 1;
+    nHits += ranges->hitRanges[4 * idx + 3] - ranges->hitRanges[4 * idx + 2] + 1;
   }
   std::cout << " nHits: " << nHits << std::endl;
 }
 
 //________________________________________________________________________________________________________________________________
 void printMiniDoubletMultiplicities(SDL::Event<Acc3D>* event) {
-  SDL::miniDoubletsBuffer<alpaka::DevCpu>& miniDoubletsInGPU = (*event->getMiniDoublets());
-  SDL::modulesBuffer<alpaka::DevCpu>& modulesInGPU = (*event->getModules());
+  SDL::MiniDoublets const* miniDoublets = event->getMiniDoublets()->data();
+  SDL::Modules const* modules = event->getModules()->data();
 
   int nMiniDoublets = 0;
   int totOccupancyMiniDoublets = 0;
-  for (unsigned int idx = 0; idx <= *(modulesInGPU.nModules);
+  for (unsigned int idx = 0; idx <= *(modules->nModules);
        idx++)  // "<=" because cheating to include pixel track candidate lower module
   {
-    if (modulesInGPU.isLower[idx]) {
-      nMiniDoublets += miniDoubletsInGPU.nMDs[idx];
-      totOccupancyMiniDoublets += miniDoubletsInGPU.totOccupancyMDs[idx];
+    if (modules->isLower[idx]) {
+      nMiniDoublets += miniDoublets->nMDs[idx];
+      totOccupancyMiniDoublets += miniDoublets->totOccupancyMDs[idx];
     }
   }
   std::cout << " nMiniDoublets: " << nMiniDoublets << std::endl;
@@ -989,19 +987,19 @@ void printAllObjects(SDL::Event<Acc3D>* event) {
 
 //________________________________________________________________________________________________________________________________
 void printMDs(SDL::Event<Acc3D>* event) {
-  SDL::miniDoubletsBuffer<alpaka::DevCpu>& miniDoubletsInGPU = (*event->getMiniDoublets());
-  SDL::hitsBuffer<alpaka::DevCpu>& hitsInGPU = (*event->getHits());
-  SDL::modulesBuffer<alpaka::DevCpu>& modulesInGPU = (*event->getModules());
-  SDL::objectRangesBuffer<alpaka::DevCpu>& rangesInGPU = (*event->getRanges());
+  SDL::MiniDoublets const* miniDoublets = event->getMiniDoublets()->data();
+  SDL::Hits const* hitsEvt = event->getHits()->data();
+  SDL::Modules const* modules = event->getModules()->data();
+  SDL::ObjectRanges const* ranges = event->getRanges()->data();
 
   // Then obtain the lower module index
-  for (unsigned int idx = 0; idx <= *(modulesInGPU.nLowerModules); ++idx) {
-    for (unsigned int iMD = 0; iMD < miniDoubletsInGPU.nMDs[idx]; iMD++) {
-      unsigned int mdIdx = rangesInGPU.miniDoubletModuleIndices[idx] + iMD;
-      unsigned int LowerHitIndex = miniDoubletsInGPU.anchorHitIndices[mdIdx];
-      unsigned int UpperHitIndex = miniDoubletsInGPU.outerHitIndices[mdIdx];
-      unsigned int hit0 = hitsInGPU.idxs[LowerHitIndex];
-      unsigned int hit1 = hitsInGPU.idxs[UpperHitIndex];
+  for (unsigned int idx = 0; idx <= *(modules->nLowerModules); ++idx) {
+    for (unsigned int iMD = 0; iMD < miniDoublets->nMDs[idx]; iMD++) {
+      unsigned int mdIdx = ranges->miniDoubletModuleIndices[idx] + iMD;
+      unsigned int LowerHitIndex = miniDoublets->anchorHitIndices[mdIdx];
+      unsigned int UpperHitIndex = miniDoublets->outerHitIndices[mdIdx];
+      unsigned int hit0 = hitsEvt->idxs[LowerHitIndex];
+      unsigned int hit1 = hitsEvt->idxs[UpperHitIndex];
       std::cout << "VALIDATION 'MD': "
                 << "MD"
                 << " hit0: " << hit0 << " hit1: " << hit1 << std::endl;
@@ -1011,28 +1009,28 @@ void printMDs(SDL::Event<Acc3D>* event) {
 
 //________________________________________________________________________________________________________________________________
 void printLSs(SDL::Event<Acc3D>* event) {
-  SDL::segmentsBuffer<alpaka::DevCpu>& segmentsInGPU = (*event->getSegments());
-  SDL::miniDoubletsBuffer<alpaka::DevCpu>& miniDoubletsInGPU = (*event->getMiniDoublets());
-  SDL::hitsBuffer<alpaka::DevCpu>& hitsInGPU = (*event->getHits());
-  SDL::modulesBuffer<alpaka::DevCpu>& modulesInGPU = (*event->getModules());
-  SDL::objectRangesBuffer<alpaka::DevCpu>& rangesInGPU = (*event->getRanges());
+  SDL::Segments const* segments = event->getSegments()->data();
+  SDL::MiniDoublets const* miniDoublets = event->getMiniDoublets()->data();
+  SDL::Hits const* hitsEvt = event->getHits()->data();
+  SDL::Modules const* modules = event->getModules()->data();
+  SDL::ObjectRanges const* ranges = event->getRanges()->data();
 
   int nSegments = 0;
-  for (unsigned int i = 0; i < *(modulesInGPU.nLowerModules); ++i) {
-    unsigned int idx = i;  //modulesInGPU.lowerModuleIndices[i];
-    nSegments += segmentsInGPU.nSegments[idx];
-    for (unsigned int jdx = 0; jdx < segmentsInGPU.nSegments[idx]; jdx++) {
-      unsigned int sgIdx = rangesInGPU.segmentModuleIndices[idx] + jdx;
-      unsigned int InnerMiniDoubletIndex = segmentsInGPU.mdIndices[2 * sgIdx];
-      unsigned int OuterMiniDoubletIndex = segmentsInGPU.mdIndices[2 * sgIdx + 1];
-      unsigned int InnerMiniDoubletLowerHitIndex = miniDoubletsInGPU.anchorHitIndices[InnerMiniDoubletIndex];
-      unsigned int InnerMiniDoubletUpperHitIndex = miniDoubletsInGPU.outerHitIndices[InnerMiniDoubletIndex];
-      unsigned int OuterMiniDoubletLowerHitIndex = miniDoubletsInGPU.anchorHitIndices[OuterMiniDoubletIndex];
-      unsigned int OuterMiniDoubletUpperHitIndex = miniDoubletsInGPU.outerHitIndices[OuterMiniDoubletIndex];
-      unsigned int hit0 = hitsInGPU.idxs[InnerMiniDoubletLowerHitIndex];
-      unsigned int hit1 = hitsInGPU.idxs[InnerMiniDoubletUpperHitIndex];
-      unsigned int hit2 = hitsInGPU.idxs[OuterMiniDoubletLowerHitIndex];
-      unsigned int hit3 = hitsInGPU.idxs[OuterMiniDoubletUpperHitIndex];
+  for (unsigned int i = 0; i < *(modules->nLowerModules); ++i) {
+    unsigned int idx = i;  //modules->lowerModuleIndices[i];
+    nSegments += segments->nSegments[idx];
+    for (unsigned int jdx = 0; jdx < segments->nSegments[idx]; jdx++) {
+      unsigned int sgIdx = ranges->segmentModuleIndices[idx] + jdx;
+      unsigned int InnerMiniDoubletIndex = segments->mdIndices[2 * sgIdx];
+      unsigned int OuterMiniDoubletIndex = segments->mdIndices[2 * sgIdx + 1];
+      unsigned int InnerMiniDoubletLowerHitIndex = miniDoublets->anchorHitIndices[InnerMiniDoubletIndex];
+      unsigned int InnerMiniDoubletUpperHitIndex = miniDoublets->outerHitIndices[InnerMiniDoubletIndex];
+      unsigned int OuterMiniDoubletLowerHitIndex = miniDoublets->anchorHitIndices[OuterMiniDoubletIndex];
+      unsigned int OuterMiniDoubletUpperHitIndex = miniDoublets->outerHitIndices[OuterMiniDoubletIndex];
+      unsigned int hit0 = hitsEvt->idxs[InnerMiniDoubletLowerHitIndex];
+      unsigned int hit1 = hitsEvt->idxs[InnerMiniDoubletUpperHitIndex];
+      unsigned int hit2 = hitsEvt->idxs[OuterMiniDoubletLowerHitIndex];
+      unsigned int hit3 = hitsEvt->idxs[OuterMiniDoubletUpperHitIndex];
       std::cout << "VALIDATION 'LS': "
                 << "LS"
                 << " hit0: " << hit0 << " hit1: " << hit1 << " hit2: " << hit2 << " hit3: " << hit3 << std::endl;
@@ -1043,27 +1041,27 @@ void printLSs(SDL::Event<Acc3D>* event) {
 
 //________________________________________________________________________________________________________________________________
 void printpLSs(SDL::Event<Acc3D>* event) {
-  SDL::segmentsBuffer<alpaka::DevCpu>& segmentsInGPU = (*event->getSegments());
-  SDL::miniDoubletsBuffer<alpaka::DevCpu>& miniDoubletsInGPU = (*event->getMiniDoublets());
-  SDL::hitsBuffer<alpaka::DevCpu>& hitsInGPU = (*event->getHits());
-  SDL::modulesBuffer<alpaka::DevCpu>& modulesInGPU = (*event->getModules());
-  SDL::objectRangesBuffer<alpaka::DevCpu>& rangesInGPU = (*event->getRanges());
+  SDL::Segments const* segments = event->getSegments()->data();
+  SDL::MiniDoublets const* miniDoublets = event->getMiniDoublets()->data();
+  SDL::Hits const* hitsEvt = event->getHits()->data();
+  SDL::Modules const* modules = event->getModules()->data();
+  SDL::ObjectRanges const* ranges = event->getRanges()->data();
 
-  unsigned int i = *(modulesInGPU.nLowerModules);
-  unsigned int idx = i;  //modulesInGPU.lowerModuleIndices[i];
-  int npLS = segmentsInGPU.nSegments[idx];
-  for (unsigned int jdx = 0; jdx < segmentsInGPU.nSegments[idx]; jdx++) {
-    unsigned int sgIdx = rangesInGPU.segmentModuleIndices[idx] + jdx;
-    unsigned int InnerMiniDoubletIndex = segmentsInGPU.mdIndices[2 * sgIdx];
-    unsigned int OuterMiniDoubletIndex = segmentsInGPU.mdIndices[2 * sgIdx + 1];
-    unsigned int InnerMiniDoubletLowerHitIndex = miniDoubletsInGPU.anchorHitIndices[InnerMiniDoubletIndex];
-    unsigned int InnerMiniDoubletUpperHitIndex = miniDoubletsInGPU.outerHitIndices[InnerMiniDoubletIndex];
-    unsigned int OuterMiniDoubletLowerHitIndex = miniDoubletsInGPU.anchorHitIndices[OuterMiniDoubletIndex];
-    unsigned int OuterMiniDoubletUpperHitIndex = miniDoubletsInGPU.outerHitIndices[OuterMiniDoubletIndex];
-    unsigned int hit0 = hitsInGPU.idxs[InnerMiniDoubletLowerHitIndex];
-    unsigned int hit1 = hitsInGPU.idxs[InnerMiniDoubletUpperHitIndex];
-    unsigned int hit2 = hitsInGPU.idxs[OuterMiniDoubletLowerHitIndex];
-    unsigned int hit3 = hitsInGPU.idxs[OuterMiniDoubletUpperHitIndex];
+  unsigned int i = *(modules->nLowerModules);
+  unsigned int idx = i;  //modules->lowerModuleIndices[i];
+  int npLS = segments->nSegments[idx];
+  for (unsigned int jdx = 0; jdx < segments->nSegments[idx]; jdx++) {
+    unsigned int sgIdx = ranges->segmentModuleIndices[idx] + jdx;
+    unsigned int InnerMiniDoubletIndex = segments->mdIndices[2 * sgIdx];
+    unsigned int OuterMiniDoubletIndex = segments->mdIndices[2 * sgIdx + 1];
+    unsigned int InnerMiniDoubletLowerHitIndex = miniDoublets->anchorHitIndices[InnerMiniDoubletIndex];
+    unsigned int InnerMiniDoubletUpperHitIndex = miniDoublets->outerHitIndices[InnerMiniDoubletIndex];
+    unsigned int OuterMiniDoubletLowerHitIndex = miniDoublets->anchorHitIndices[OuterMiniDoubletIndex];
+    unsigned int OuterMiniDoubletUpperHitIndex = miniDoublets->outerHitIndices[OuterMiniDoubletIndex];
+    unsigned int hit0 = hitsEvt->idxs[InnerMiniDoubletLowerHitIndex];
+    unsigned int hit1 = hitsEvt->idxs[InnerMiniDoubletUpperHitIndex];
+    unsigned int hit2 = hitsEvt->idxs[OuterMiniDoubletLowerHitIndex];
+    unsigned int hit3 = hitsEvt->idxs[OuterMiniDoubletUpperHitIndex];
     std::cout << "VALIDATION 'pLS': "
               << "pLS"
               << " hit0: " << hit0 << " hit1: " << hit1 << " hit2: " << hit2 << " hit3: " << hit3 << std::endl;
@@ -1073,37 +1071,37 @@ void printpLSs(SDL::Event<Acc3D>* event) {
 
 //________________________________________________________________________________________________________________________________
 void printT3s(SDL::Event<Acc3D>* event) {
-  SDL::tripletsBuffer<alpaka::DevCpu>& tripletsInGPU = (*event->getTriplets());
-  SDL::segmentsBuffer<alpaka::DevCpu>& segmentsInGPU = (*event->getSegments());
-  SDL::miniDoubletsBuffer<alpaka::DevCpu>& miniDoubletsInGPU = (*event->getMiniDoublets());
-  SDL::hitsBuffer<alpaka::DevCpu>& hitsInGPU = (*event->getHits());
-  SDL::modulesBuffer<alpaka::DevCpu>& modulesInGPU = (*event->getModules());
+  SDL::Triplets const* triplets = event->getTriplets()->data();
+  SDL::Segments const* segments = event->getSegments()->data();
+  SDL::MiniDoublets const* miniDoublets = event->getMiniDoublets()->data();
+  SDL::Hits const* hitsEvt = event->getHits()->data();
+  SDL::Modules const* modules = event->getModules()->data();
   int nTriplets = 0;
-  for (unsigned int i = 0; i < *(modulesInGPU.nLowerModules); ++i) {
-    // unsigned int idx = SDL::modulesInGPU->lowerModuleIndices[i];
-    nTriplets += tripletsInGPU.nTriplets[i];
+  for (unsigned int i = 0; i < *(modules->nLowerModules); ++i) {
+    // unsigned int idx = modules->lowerModuleIndices[i];
+    nTriplets += triplets->nTriplets[i];
     unsigned int idx = i;
-    for (unsigned int jdx = 0; jdx < tripletsInGPU.nTriplets[idx]; jdx++) {
+    for (unsigned int jdx = 0; jdx < triplets->nTriplets[idx]; jdx++) {
       unsigned int tpIdx = idx * 5000 + jdx;
-      unsigned int InnerSegmentIndex = tripletsInGPU.segmentIndices[2 * tpIdx];
-      unsigned int OuterSegmentIndex = tripletsInGPU.segmentIndices[2 * tpIdx + 1];
-      unsigned int InnerSegmentInnerMiniDoubletIndex = segmentsInGPU.mdIndices[2 * InnerSegmentIndex];
-      unsigned int InnerSegmentOuterMiniDoubletIndex = segmentsInGPU.mdIndices[2 * InnerSegmentIndex + 1];
-      unsigned int OuterSegmentOuterMiniDoubletIndex = segmentsInGPU.mdIndices[2 * OuterSegmentIndex + 1];
+      unsigned int InnerSegmentIndex = triplets->segmentIndices[2 * tpIdx];
+      unsigned int OuterSegmentIndex = triplets->segmentIndices[2 * tpIdx + 1];
+      unsigned int InnerSegmentInnerMiniDoubletIndex = segments->mdIndices[2 * InnerSegmentIndex];
+      unsigned int InnerSegmentOuterMiniDoubletIndex = segments->mdIndices[2 * InnerSegmentIndex + 1];
+      unsigned int OuterSegmentOuterMiniDoubletIndex = segments->mdIndices[2 * OuterSegmentIndex + 1];
 
-      unsigned int hit_idx0 = miniDoubletsInGPU.anchorHitIndices[InnerSegmentInnerMiniDoubletIndex];
-      unsigned int hit_idx1 = miniDoubletsInGPU.outerHitIndices[InnerSegmentInnerMiniDoubletIndex];
-      unsigned int hit_idx2 = miniDoubletsInGPU.anchorHitIndices[InnerSegmentOuterMiniDoubletIndex];
-      unsigned int hit_idx3 = miniDoubletsInGPU.outerHitIndices[InnerSegmentOuterMiniDoubletIndex];
-      unsigned int hit_idx4 = miniDoubletsInGPU.anchorHitIndices[OuterSegmentOuterMiniDoubletIndex];
-      unsigned int hit_idx5 = miniDoubletsInGPU.outerHitIndices[OuterSegmentOuterMiniDoubletIndex];
+      unsigned int hit_idx0 = miniDoublets->anchorHitIndices[InnerSegmentInnerMiniDoubletIndex];
+      unsigned int hit_idx1 = miniDoublets->outerHitIndices[InnerSegmentInnerMiniDoubletIndex];
+      unsigned int hit_idx2 = miniDoublets->anchorHitIndices[InnerSegmentOuterMiniDoubletIndex];
+      unsigned int hit_idx3 = miniDoublets->outerHitIndices[InnerSegmentOuterMiniDoubletIndex];
+      unsigned int hit_idx4 = miniDoublets->anchorHitIndices[OuterSegmentOuterMiniDoubletIndex];
+      unsigned int hit_idx5 = miniDoublets->outerHitIndices[OuterSegmentOuterMiniDoubletIndex];
 
-      unsigned int hit0 = hitsInGPU.idxs[hit_idx0];
-      unsigned int hit1 = hitsInGPU.idxs[hit_idx1];
-      unsigned int hit2 = hitsInGPU.idxs[hit_idx2];
-      unsigned int hit3 = hitsInGPU.idxs[hit_idx3];
-      unsigned int hit4 = hitsInGPU.idxs[hit_idx4];
-      unsigned int hit5 = hitsInGPU.idxs[hit_idx5];
+      unsigned int hit0 = hitsEvt->idxs[hit_idx0];
+      unsigned int hit1 = hitsEvt->idxs[hit_idx1];
+      unsigned int hit2 = hitsEvt->idxs[hit_idx2];
+      unsigned int hit3 = hitsEvt->idxs[hit_idx3];
+      unsigned int hit4 = hitsEvt->idxs[hit_idx4];
+      unsigned int hit5 = hitsEvt->idxs[hit_idx5];
       std::cout << "VALIDATION 'T3': "
                 << "T3"
                 << " hit0: " << hit0 << " hit1: " << hit1 << " hit2: " << hit2 << " hit3: " << hit3 << " hit4: " << hit4
@@ -1115,29 +1113,26 @@ void printT3s(SDL::Event<Acc3D>* event) {
 
 //________________________________________________________________________________________________________________________________
 void debugPrintOutlierMultiplicities(SDL::Event<Acc3D>* event) {
-  SDL::trackCandidatesBuffer<alpaka::DevCpu>& trackCandidatesInGPU = (*event->getTrackCandidates());
-  SDL::tripletsBuffer<alpaka::DevCpu>& tripletsInGPU = (*event->getTriplets());
-  SDL::segmentsBuffer<alpaka::DevCpu>& segmentsInGPU = (*event->getSegments());
-  SDL::miniDoubletsBuffer<alpaka::DevCpu>& miniDoubletsInGPU = (*event->getMiniDoublets());
-  SDL::modulesBuffer<alpaka::DevCpu>& modulesInGPU = (*event->getModules());
-  SDL::objectRangesBuffer<alpaka::DevCpu>& rangesInGPU = (*event->getRanges());
+  SDL::TrackCandidates const* trackCandidates = event->getTrackCandidates()->data();
+  SDL::Triplets const* triplets = event->getTriplets()->data();
+  SDL::Segments const* segments = event->getSegments()->data();
+  SDL::MiniDoublets const* miniDoublets = event->getMiniDoublets()->data();
+  SDL::Modules const* modules = event->getModules()->data();
+  SDL::ObjectRanges const* ranges = event->getRanges()->data();
   //int nTrackCandidates = 0;
-  for (unsigned int idx = 0; idx <= *(modulesInGPU.nLowerModules); ++idx) {
-    if (trackCandidatesInGPU.nTrackCandidates[idx] > 50000) {
-      std::cout << " SDL::modulesInGPU->detIds[SDL::modulesInGPU->lowerModuleIndices[idx]]: "
-                << modulesInGPU.detIds[idx] << std::endl;
+  for (unsigned int idx = 0; idx <= *(modules->nLowerModules); ++idx) {
+    if (trackCandidates->nTrackCandidates[idx] > 50000) {
+      std::cout << " modules->detIds[modules->lowerModuleIndices[idx]]: " << modules->detIds[idx] << std::endl;
       std::cout << " idx: " << idx
-                << " trackCandidatesInGPU.nTrackCandidates[idx]: " << trackCandidatesInGPU.nTrackCandidates[idx]
-                << std::endl;
-      std::cout << " idx: " << idx << " tripletsInGPU.nTriplets[idx]: " << tripletsInGPU.nTriplets[idx] << std::endl;
-      unsigned int i = idx;  //modulesInGPU.lowerModuleIndices[idx];
-      std::cout << " idx: " << idx << " i: " << i << " segmentsInGPU.nSegments[i]: " << segmentsInGPU.nSegments[i]
-                << std::endl;
-      int nMD = miniDoubletsInGPU.nMDs[2 * idx] + miniDoubletsInGPU.nMDs[2 * idx + 1];
+                << " trackCandidates->nTrackCandidates[idx]: " << trackCandidates->nTrackCandidates[idx] << std::endl;
+      std::cout << " idx: " << idx << " triplets->nTriplets[idx]: " << triplets->nTriplets[idx] << std::endl;
+      unsigned int i = idx;  //modules->lowerModuleIndices[idx];
+      std::cout << " idx: " << idx << " i: " << i << " segments->nSegments[i]: " << segments->nSegments[i] << std::endl;
+      int nMD = miniDoublets->nMDs[2 * idx] + miniDoublets->nMDs[2 * idx + 1];
       std::cout << " idx: " << idx << " nMD: " << nMD << std::endl;
       int nHits = 0;
-      nHits += rangesInGPU.hitRanges[4 * idx + 1] - rangesInGPU.hitRanges[4 * idx] + 1;
-      nHits += rangesInGPU.hitRanges[4 * idx + 3] - rangesInGPU.hitRanges[4 * idx + 2] + 1;
+      nHits += ranges->hitRanges[4 * idx + 1] - ranges->hitRanges[4 * idx] + 1;
+      nHits += ranges->hitRanges[4 * idx + 3] - ranges->hitRanges[4 * idx + 2] + 1;
       std::cout << " idx: " << idx << " nHits: " << nHits << std::endl;
     }
   }


### PR DESCRIPTION
to address https://github.com/cms-sw/cmssw/pull/45117#discussion_r1625125690

- instead of inheritance, keep the SoA as a `data_` member of the buffer. Perhaps in the next iteration these can be fully decoupled
- Also, renamed the related structs to start with a capital letter, per CMSSW style.
