### PR TITLE
Remove SDL_INF and switch to T33 maps

### DIFF
--- a/RecoTracker/LSTCore/interface/alpaka/Constants.h
+++ b/RecoTracker/LSTCore/interface/alpaka/Constants.h
@@ -83,8 +83,6 @@ namespace lst {
   ALPAKA_STATIC_ACC_MEM_GLOBAL constexpr float widthPS = 0.01;
   ALPAKA_STATIC_ACC_MEM_GLOBAL constexpr float pt_betaMax = 7.0;
   ALPAKA_STATIC_ACC_MEM_GLOBAL constexpr float magnetic_field = 3.8112;
-  // Since C++ can't represent infinity, lst_INF = 123456789 was used to represent infinity in the data table
-  ALPAKA_STATIC_ACC_MEM_GLOBAL constexpr float lst_INF = 123456789.0;
 
   namespace t5dnn {
 

--- a/RecoTracker/LSTCore/src/LSTESData.cc
+++ b/RecoTracker/LSTCore/src/LSTESData.cc
@@ -45,18 +45,18 @@ namespace {
                     std::shared_ptr<lst::ModuleConnectionMap> moduleConnectionMap) {
     // Module orientation information (DrDz or phi angles)
     auto endcap_geom =
-        get_absolute_path_after_check_file_exists(trackLooperDir() + "/data/OT800_IT615_pt0.8/endcap_orientation.bin");
+        get_absolute_path_after_check_file_exists(trackLooperDir() + "/data/OT800_IT711_pt0.8/endcap_orientation.bin");
     auto tilted_geom = get_absolute_path_after_check_file_exists(
-        trackLooperDir() + "/data/OT800_IT615_pt0.8/tilted_barrel_orientation.bin");
+        trackLooperDir() + "/data/OT800_IT711_pt0.8/tilted_barrel_orientation.bin");
     // Module connection map (for line segment building)
     auto mappath = get_absolute_path_after_check_file_exists(
-        trackLooperDir() + "/data/OT800_IT615_pt0.8/module_connection_tracing_merged.bin");
+        trackLooperDir() + "/data/OT800_IT711_pt0.8/module_connection_tracing_merged.bin");
 
     endcapGeometry->load(endcap_geom);
     tiltedGeometry->load(tilted_geom);
     moduleConnectionMap->load(mappath);
 
-    auto pLSMapDir = trackLooperDir() + "/data/OT800_IT615_pt0.8/pixelmap/pLS_map";
+    auto pLSMapDir = trackLooperDir() + "/data/OT800_IT711_pt0.8/pixelmap/pLS_map";
     const std::array<std::string, 4> connects{
         {"_layer1_subdet5", "_layer2_subdet5", "_layer1_subdet4", "_layer2_subdet4"}};
     std::string path;
@@ -98,7 +98,7 @@ std::unique_ptr<lst::LSTESData<alpaka_common::DevHost>> lst::loadAndFillESHost()
       queue, endcapGeometryBuffers->geoMapPhi_buf, endcapGeometry->geoMapPhi_buf, endcapGeometry->nEndCapMap);
 
   auto path =
-      get_absolute_path_after_check_file_exists(trackLooperDir() + "/data/OT800_IT615_pt0.8/sensor_centroids.bin");
+      get_absolute_path_after_check_file_exists(trackLooperDir() + "/data/OT800_IT711_pt0.8/sensor_centroids.bin");
   lst::loadModulesFromFile(pLStoLayer.get(),
                            path.c_str(),
                            nModules,

--- a/RecoTracker/LSTCore/src/alpaka/MiniDoublet.h
+++ b/RecoTracker/LSTCore/src/alpaka/MiniDoublet.h
@@ -508,8 +508,7 @@ namespace lst {
 
     drprime = (moduleSeparation / alpaka::math::sin(acc, angleA + angleB)) * alpaka::math::sin(acc, angleA);
 
-    // Compute arctan of the slope and take care of the slope = infinity case
-    absArctanSlope = ((slope != lst::lst_INF) ? fabs(alpaka::math::atan(acc, slope)) : float(M_PI) / 2.f);
+    absArctanSlope = fabs(alpaka::math::atan(acc, slope));
 
     // Depending on which quadrant the pixel hit lies, we define the angleM by shifting them slightly differently
     if (xp > 0 and yp > 0) {
@@ -532,8 +531,8 @@ namespace lst {
     ya = yp + drprime_y;
 
     // Compute the new strip hit position (if the slope value is in special condition take care of the exceptions)
-    if (slope ==
-        lst::lst_INF)  // Designated for tilted module when the slope is exactly infinity (module lying along y-axis)
+    if (std::isinf(
+            slope))  // Designated for tilted module when the slope is exactly infinity (module lying along y-axis)
     {
       xn = xa;  // New x point is simply where the anchor is
       yn = yo;  // No shift in y

--- a/RecoTracker/LSTCore/src/alpaka/PixelTriplet.h
+++ b/RecoTracker/LSTCore/src/alpaka/PixelTriplet.h
@@ -395,8 +395,7 @@ namespace lst {
     float chiSquared = 0.f;
     float absArctanSlope, angleM, xPrime, yPrime, sigma2;
     for (size_t i = 0; i < nPoints; i++) {
-      absArctanSlope = ((slopes[i] != lst::lst_INF) ? alpaka::math::abs(acc, alpaka::math::atan(acc, slopes[i]))
-                                                    : 0.5f * float(M_PI));
+      absArctanSlope = alpaka::math::abs(acc, alpaka::math::atan(acc, slopes[i]));
       if (xs[i] > 0 and ys[i] > 0) {
         angleM = 0.5f * float(M_PI) - absArctanSlope;
       } else if (xs[i] < 0 and ys[i] > 0) {
@@ -2234,8 +2233,7 @@ namespace lst {
     float chiSquared = 0.f;
     float absArctanSlope, angleM, xPrime, yPrime, sigma2;
     for (size_t i = 0; i < nPoints; i++) {
-      absArctanSlope = ((slopes[i] != lst::lst_INF) ? alpaka::math::abs(acc, alpaka::math::atan(acc, slopes[i]))
-                                                    : 0.5f * float(M_PI));
+      absArctanSlope = alpaka::math::abs(acc, alpaka::math::atan(acc, slopes[i]));
       if (xs[i] > 0 and ys[i] > 0) {
         angleM = 0.5f * float(M_PI) - absArctanSlope;
       } else if (xs[i] < 0 and ys[i] > 0) {

--- a/RecoTracker/LSTCore/src/alpaka/Quintuplet.h
+++ b/RecoTracker/LSTCore/src/alpaka/Quintuplet.h
@@ -777,7 +777,7 @@ namespace lst {
     //brute force
     float candidateRadius;
     float g, f;
-    minimumRadius = lst::lst_INF;
+    minimumRadius = std::numeric_limits<float>::infinity();
     maximumRadius = 0.f;
     for (size_t i = 0; i < 3; i++) {
       float x1 = x1Vec[i];
@@ -1267,8 +1267,7 @@ namespace lst {
       // Computing sigmas is a very tricky affair
       // if the module is tilted or endcap, we need to use the slopes properly!
 
-      absArctanSlope = ((slopes[i] != lst::lst_INF) ? alpaka::math::abs(acc, alpaka::math::atan(acc, slopes[i]))
-                                                    : 0.5f * float(M_PI));
+      absArctanSlope = alpaka::math::abs(acc, alpaka::math::atan(acc, slopes[i]));
 
       if (xs[i] > 0 and ys[i] > 0) {
         angleM = 0.5f * float(M_PI) - absArctanSlope;
@@ -1350,8 +1349,7 @@ namespace lst {
     float chiSquared = 0.f;
     float absArctanSlope, angleM, xPrime, yPrime, sigma2;
     for (size_t i = 0; i < nPoints; i++) {
-      absArctanSlope = ((slopes[i] != lst::lst_INF) ? alpaka::math::abs(acc, alpaka::math::atan(acc, slopes[i]))
-                                                    : 0.5f * float(M_PI));
+      absArctanSlope = alpaka::math::abs(acc, alpaka::math::atan(acc, slopes[i]));
       if (xs[i] > 0 and ys[i] > 0) {
         angleM = 0.5f * float(M_PI) - absArctanSlope;
       } else if (xs[i] < 0 and ys[i] > 0) {

--- a/RecoTracker/LSTCore/src/alpaka/Segment.h
+++ b/RecoTracker/LSTCore/src/alpaka/Segment.h
@@ -430,7 +430,7 @@ namespace lst {
                                  mdsInGPU.anchorY[innerMDIndex] + circleRadius * alpaka::math::cos(acc, circlePhi)};
 
     //check which of the circles can accommodate r3LH better (we won't get perfect agreement)
-    float bestChiSquared = lst::lst_INF;
+    float bestChiSquared = std::numeric_limits<float>::infinity();
     float chiSquared;
     size_t bestIndex;
     for (size_t i = 0; i < 2; i++) {


### PR DESCRIPTION
I removed `SDL_INF` (which is now called `lst_INF`) and I updated the paths so that it uses the modules maps generated with the T33 (OT800_IT711) geometry.