### PR TITLE
More review fixes

### DIFF
--- a/RecoTracker/LSTCore/interface/alpaka/Constants.h
+++ b/RecoTracker/LSTCore/interface/alpaka/Constants.h
@@ -3,8 +3,10 @@
 
 #include "RecoTracker/LSTCore/interface/Constants.h"
 
-#ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
+#if defined ALPAKA_ACC_GPU_CUDA_ENABLED
 #include <cuda_fp16.h>
+#elif defined ALPAKA_ACC_GPU_HIP_ENABLED
+#include <hip/hip_fp16.h>
 #endif
 
 namespace lst {

--- a/RecoTracker/LSTCore/src/ModuleConnectionMap.cc
+++ b/RecoTracker/LSTCore/src/ModuleConnectionMap.cc
@@ -69,15 +69,17 @@ void lst::ModuleConnectionMap::add(std::string const& filename) {
       connected_detids.push_back(connected_detid);
     }
 
+    auto& thisModuleConnections = moduleConnections_.at(detid);
+
     // Concatenate
-    moduleConnections_[detid].insert(moduleConnections_[detid].end(), connected_detids.begin(), connected_detids.end());
+    thisModuleConnections.insert(thisModuleConnections.end(), connected_detids.begin(), connected_detids.end());
 
     // Sort
-    std::sort(moduleConnections_[detid].begin(), moduleConnections_[detid].end());
+    std::sort(thisModuleConnections.begin(), thisModuleConnections.end());
 
     // Unique
-    moduleConnections_[detid].erase(std::unique(moduleConnections_[detid].begin(), moduleConnections_[detid].end()),
-                                    moduleConnections_[detid].end());
+    thisModuleConnections.erase(std::unique(thisModuleConnections.begin(), thisModuleConnections.end()),
+                                thisModuleConnections.end());
   }
 }
 

--- a/RecoTracker/LSTCore/src/alpaka/Hit.h
+++ b/RecoTracker/LSTCore/src/alpaka/Hit.h
@@ -244,13 +244,15 @@ namespace lst {
           hitsInGPU.lowEdgeYs[ihit] = ihit_y - 2.5f * sin_phi;
         }
         // Need to set initial value if index hasn't been seen before.
-        int old = alpaka::atomicOp<alpaka::AtomicCas>(
-            acc, &(hitsInGPU.hitRanges[lastModuleIndex * 2]), -1, static_cast<int>(ihit));
+        int old = alpaka::atomicCas(
+            acc, &(hitsInGPU.hitRanges[lastModuleIndex * 2]), -1, static_cast<int>(ihit), alpaka::hierarchy::Threads{});
         // For subsequent visits, stores the min value.
         if (old != -1)
-          alpaka::atomicOp<alpaka::AtomicMin>(acc, &hitsInGPU.hitRanges[lastModuleIndex * 2], static_cast<int>(ihit));
+          alpaka::atomicMin(
+              acc, &hitsInGPU.hitRanges[lastModuleIndex * 2], static_cast<int>(ihit), alpaka::hierarchy::Threads{});
 
-        alpaka::atomicOp<alpaka::AtomicMax>(acc, &hitsInGPU.hitRanges[lastModuleIndex * 2 + 1], static_cast<int>(ihit));
+        alpaka::atomicMax(
+            acc, &hitsInGPU.hitRanges[lastModuleIndex * 2 + 1], static_cast<int>(ihit), alpaka::hierarchy::Threads{});
       }
     }
   };

--- a/RecoTracker/LSTCore/src/alpaka/MiniDoublet.h
+++ b/RecoTracker/LSTCore/src/alpaka/MiniDoublet.h
@@ -932,13 +932,14 @@ namespace lst {
                                                    rtUpper);
           if (success) {
             int totOccupancyMDs =
-                alpaka::atomicOp<alpaka::AtomicAdd>(acc, &mdsInGPU.totOccupancyMDs[lowerModuleIndex], 1u);
+                alpaka::atomicAdd(acc, &mdsInGPU.totOccupancyMDs[lowerModuleIndex], 1u, alpaka::hierarchy::Threads{});
             if (totOccupancyMDs >= (rangesInGPU.miniDoubletModuleOccupancy[lowerModuleIndex])) {
 #ifdef WARNINGS
               printf("Mini-doublet excess alert! Module index =  %d\n", lowerModuleIndex);
 #endif
             } else {
-              int mdModuleIndex = alpaka::atomicOp<alpaka::AtomicAdd>(acc, &mdsInGPU.nMDs[lowerModuleIndex], 1u);
+              int mdModuleIndex =
+                  alpaka::atomicAdd(acc, &mdsInGPU.nMDs[lowerModuleIndex], 1u, alpaka::hierarchy::Threads{});
               unsigned int mdIndex = rangesInGPU.miniDoubletModuleIndices[lowerModuleIndex] + mdModuleIndex;
 
               addMDToMemory(acc,
@@ -1041,7 +1042,7 @@ namespace lst {
 #endif
         }
 
-        unsigned int nTotMDs = alpaka::atomicOp<alpaka::AtomicAdd>(acc, &nTotalMDs, occupancy);
+        unsigned int nTotMDs = alpaka::atomicAdd(acc, &nTotalMDs, occupancy, alpaka::hierarchy::Threads{});
 
         rangesInGPU.miniDoubletModuleIndices[i] = nTotMDs;
         rangesInGPU.miniDoubletModuleOccupancy[i] = occupancy;

--- a/RecoTracker/LSTCore/src/alpaka/PixelQuintuplet.h
+++ b/RecoTracker/LSTCore/src/alpaka/PixelQuintuplet.h
@@ -901,15 +901,15 @@ namespace lst {
                                                          centerY,
                                                          static_cast<unsigned int>(i_pLS));
             if (success) {
-              unsigned int totOccupancyPixelQuintuplets =
-                  alpaka::atomicOp<alpaka::AtomicAdd>(acc, pixelQuintupletsInGPU.totOccupancyPixelQuintuplets, 1u);
+              unsigned int totOccupancyPixelQuintuplets = alpaka::atomicAdd(
+                  acc, pixelQuintupletsInGPU.totOccupancyPixelQuintuplets, 1u, alpaka::hierarchy::Threads{});
               if (totOccupancyPixelQuintuplets >= n_max_pixel_quintuplets) {
 #ifdef WARNINGS
                 printf("Pixel Quintuplet excess alert!\n");
 #endif
               } else {
                 unsigned int pixelQuintupletIndex =
-                    alpaka::atomicOp<alpaka::AtomicAdd>(acc, pixelQuintupletsInGPU.nPixelQuintuplets, 1u);
+                    alpaka::atomicAdd(acc, pixelQuintupletsInGPU.nPixelQuintuplets, 1u, alpaka::hierarchy::Threads{});
                 float eta = __H2F(quintupletsInGPU.eta[quintupletIndex]);
                 float phi = __H2F(quintupletsInGPU.phi[quintupletIndex]);
 

--- a/RecoTracker/LSTCore/src/alpaka/PixelTriplet.h
+++ b/RecoTracker/LSTCore/src/alpaka/PixelTriplet.h
@@ -1025,15 +1025,15 @@ namespace lst {
               float phi_pix = segmentsInGPU.phi[i_pLS];
               float pt = segmentsInGPU.ptIn[i_pLS];
               float score = rPhiChiSquared + rPhiChiSquaredInwards;
-              unsigned int totOccupancyPixelTriplets =
-                  alpaka::atomicOp<alpaka::AtomicAdd>(acc, pixelTripletsInGPU.totOccupancyPixelTriplets, 1u);
+              unsigned int totOccupancyPixelTriplets = alpaka::atomicAdd(
+                  acc, pixelTripletsInGPU.totOccupancyPixelTriplets, 1u, alpaka::hierarchy::Threads{});
               if (totOccupancyPixelTriplets >= n_max_pixel_triplets) {
 #ifdef WARNINGS
                 printf("Pixel Triplet excess alert!\n");
 #endif
               } else {
                 unsigned int pixelTripletIndex =
-                    alpaka::atomicOp<alpaka::AtomicAdd>(acc, pixelTripletsInGPU.nPixelTriplets, 1u);
+                    alpaka::atomicAdd(acc, pixelTripletsInGPU.nPixelTriplets, 1u, alpaka::hierarchy::Threads{});
                 addPixelTripletToMemory(mdsInGPU,
                                         segmentsInGPU,
                                         tripletsInGPU,

--- a/RecoTracker/LSTCore/src/alpaka/Quintuplet.h
+++ b/RecoTracker/LSTCore/src/alpaka/Quintuplet.h
@@ -2602,15 +2602,15 @@ namespace lst {
                                                     TightCutFlag);
 
             if (success) {
-              int totOccupancyQuintuplets =
-                  alpaka::atomicOp<alpaka::AtomicAdd>(acc, &quintupletsInGPU.totOccupancyQuintuplets[lowerModule1], 1u);
+              int totOccupancyQuintuplets = alpaka::atomicAdd(
+                  acc, &quintupletsInGPU.totOccupancyQuintuplets[lowerModule1], 1u, alpaka::hierarchy::Threads{});
               if (totOccupancyQuintuplets >= rangesInGPU.quintupletModuleOccupancy[lowerModule1]) {
 #ifdef WARNINGS
                 printf("Quintuplet excess alert! Module index = %d\n", lowerModule1);
 #endif
               } else {
-                int quintupletModuleIndex =
-                    alpaka::atomicOp<alpaka::AtomicAdd>(acc, &quintupletsInGPU.nQuintuplets[lowerModule1], 1u);
+                int quintupletModuleIndex = alpaka::atomicAdd(
+                    acc, &quintupletsInGPU.nQuintuplets[lowerModule1], 1u, alpaka::hierarchy::Threads{});
                 //this if statement should never get executed!
                 if (rangesInGPU.quintupletModuleIndices[lowerModule1] == -1) {
 #ifdef WARNINGS
@@ -2700,7 +2700,7 @@ namespace lst {
         if (module_subdets == lst::Endcap and module_layers > 1)
           continue;
 
-        int nEligibleT5Modules = alpaka::atomicOp<alpaka::AtomicAdd>(acc, &nEligibleT5Modulesx, 1);
+        int nEligibleT5Modules = alpaka::atomicAdd(acc, &nEligibleT5Modulesx, 1, alpaka::hierarchy::Threads{});
 
         if (module_layers <= 3 && module_subdets == 5)
           category_number = 0;
@@ -2749,7 +2749,7 @@ namespace lst {
 #endif
         }
 
-        int nTotQ = alpaka::atomicOp<alpaka::AtomicAdd>(acc, &nTotalQuintupletsx, occupancy);
+        int nTotQ = alpaka::atomicAdd(acc, &nTotalQuintupletsx, occupancy, alpaka::hierarchy::Threads{});
         rangesInGPU.quintupletModuleIndices[i] = nTotQ;
         rangesInGPU.indicesOfEligibleT5Modules[nEligibleT5Modules] = i;
         rangesInGPU.quintupletModuleOccupancy[i] = occupancy;

--- a/RecoTracker/LSTCore/src/alpaka/Segment.h
+++ b/RecoTracker/LSTCore/src/alpaka/Segment.h
@@ -763,15 +763,15 @@ namespace lst {
                                       dPhiChange,
                                       dPhiChangeMin,
                                       dPhiChangeMax)) {
-              unsigned int totOccupancySegments = alpaka::atomicOp<alpaka::AtomicAdd>(
-                  acc, &segmentsInGPU.totOccupancySegments[innerLowerModuleIndex], 1u);
+              unsigned int totOccupancySegments = alpaka::atomicAdd(
+                  acc, &segmentsInGPU.totOccupancySegments[innerLowerModuleIndex], 1u, alpaka::hierarchy::Threads{});
               if (static_cast<int>(totOccupancySegments) >= rangesInGPU.segmentModuleOccupancy[innerLowerModuleIndex]) {
 #ifdef WARNINGS
                 printf("Segment excess alert! Module index = %d\n", innerLowerModuleIndex);
 #endif
               } else {
-                unsigned int segmentModuleIdx =
-                    alpaka::atomicOp<alpaka::AtomicAdd>(acc, &segmentsInGPU.nSegments[innerLowerModuleIndex], 1u);
+                unsigned int segmentModuleIdx = alpaka::atomicAdd(
+                    acc, &segmentsInGPU.nSegments[innerLowerModuleIndex], 1u, alpaka::hierarchy::Threads{});
                 unsigned int segmentIdx = rangesInGPU.segmentModuleIndices[innerLowerModuleIndex] + segmentModuleIdx;
 
                 addSegmentToMemory(segmentsInGPU,
@@ -882,7 +882,7 @@ namespace lst {
 #endif
         }
 
-        int nTotSegs = alpaka::atomicOp<alpaka::AtomicAdd>(acc, &nTotalSegments, occupancy);
+        int nTotSegs = alpaka::atomicAdd(acc, &nTotalSegments, occupancy, alpaka::hierarchy::Threads{});
         rangesInGPU.segmentModuleIndices[i] = nTotSegs;
         rangesInGPU.segmentModuleOccupancy[i] = occupancy;
       }

--- a/RecoTracker/LSTCore/src/alpaka/TrackCandidate.h
+++ b/RecoTracker/LSTCore/src/alpaka/TrackCandidate.h
@@ -401,17 +401,17 @@ namespace lst {
           continue;
 
         unsigned int trackCandidateIdx =
-            alpaka::atomicOp<alpaka::AtomicAdd>(acc, trackCandidatesInGPU.nTrackCandidates, 1u);
+            alpaka::atomicAdd(acc, trackCandidatesInGPU.nTrackCandidates, 1u, alpaka::hierarchy::Threads{});
         if (trackCandidateIdx >= n_max_pixel_track_candidates)  // This is done before any non-pixel TCs are added
         {
 #ifdef WARNINGS
           printf("Track Candidate excess alert! Type = pT3");
 #endif
-          alpaka::atomicOp<alpaka::AtomicSub>(acc, trackCandidatesInGPU.nTrackCandidates, 1u);
+          alpaka::atomicSub(acc, trackCandidatesInGPU.nTrackCandidates, 1u, alpaka::hierarchy::Threads{});
           break;
 
         } else {
-          alpaka::atomicOp<alpaka::AtomicAdd>(acc, trackCandidatesInGPU.nTrackCandidatespT3, 1u);
+          alpaka::atomicAdd(acc, trackCandidatesInGPU.nTrackCandidatespT3, 1u, alpaka::hierarchy::Threads{});
 
           float radius = 0.5f * (__H2F(pixelTripletsInGPU.pixelRadius[pixelTripletIndex]) +
                                  __H2F(pixelTripletsInGPU.tripletRadius[pixelTripletIndex]));
@@ -457,7 +457,7 @@ namespace lst {
             continue;
 
           unsigned int trackCandidateIdx =
-              alpaka::atomicOp<alpaka::AtomicAdd>(acc, trackCandidatesInGPU.nTrackCandidates, 1u);
+              alpaka::atomicAdd(acc, trackCandidatesInGPU.nTrackCandidates, 1u, alpaka::hierarchy::Threads{});
           if (trackCandidateIdx - *trackCandidatesInGPU.nTrackCandidatespT5 -
                   *trackCandidatesInGPU.nTrackCandidatespT3 >=
               n_max_nonpixel_track_candidates)  // pT5 and pT3 TCs have been added, but not pLS TCs
@@ -465,10 +465,10 @@ namespace lst {
 #ifdef WARNINGS
             printf("Track Candidate excess alert! Type = T5");
 #endif
-            alpaka::atomicOp<alpaka::AtomicSub>(acc, trackCandidatesInGPU.nTrackCandidates, 1u);
+            alpaka::atomicSub(acc, trackCandidatesInGPU.nTrackCandidates, 1u, alpaka::hierarchy::Threads{});
             break;
           } else {
-            alpaka::atomicOp<alpaka::AtomicAdd>(acc, trackCandidatesInGPU.nTrackCandidatesT5, 1u);
+            alpaka::atomicAdd(acc, trackCandidatesInGPU.nTrackCandidatesT5, 1u, alpaka::hierarchy::Threads{});
             addTrackCandidateToMemory(trackCandidatesInGPU,
                                       4 /*track candidate type T5=4*/,
                                       quintupletIndex,
@@ -505,18 +505,18 @@ namespace lst {
           continue;
 
         unsigned int trackCandidateIdx =
-            alpaka::atomicOp<alpaka::AtomicAdd>(acc, trackCandidatesInGPU.nTrackCandidates, 1u);
+            alpaka::atomicAdd(acc, trackCandidatesInGPU.nTrackCandidates, 1u, alpaka::hierarchy::Threads{});
         if (trackCandidateIdx - *trackCandidatesInGPU.nTrackCandidatesT5 >=
             n_max_pixel_track_candidates)  // T5 TCs have already been added
         {
 #ifdef WARNINGS
           printf("Track Candidate excess alert! Type = pLS");
 #endif
-          alpaka::atomicOp<alpaka::AtomicSub>(acc, trackCandidatesInGPU.nTrackCandidates, 1u);
+          alpaka::atomicSub(acc, trackCandidatesInGPU.nTrackCandidates, 1u, alpaka::hierarchy::Threads{});
           break;
 
         } else {
-          alpaka::atomicOp<alpaka::AtomicAdd>(acc, trackCandidatesInGPU.nTrackCandidatespLS, 1u);
+          alpaka::atomicAdd(acc, trackCandidatesInGPU.nTrackCandidatespLS, 1u, alpaka::hierarchy::Threads{});
           addpLSTrackCandidateToMemory(trackCandidatesInGPU,
                                        pixelArrayIndex,
                                        trackCandidateIdx,
@@ -546,17 +546,17 @@ namespace lst {
           continue;
 
         unsigned int trackCandidateIdx =
-            alpaka::atomicOp<alpaka::AtomicAdd>(acc, trackCandidatesInGPU.nTrackCandidates, 1u);
+            alpaka::atomicAdd(acc, trackCandidatesInGPU.nTrackCandidates, 1u, alpaka::hierarchy::Threads{});
         if (trackCandidateIdx >= n_max_pixel_track_candidates)  // No other TCs have been added yet
         {
 #ifdef WARNINGS
           printf("Track Candidate excess alert! Type = pT5");
 #endif
-          alpaka::atomicOp<alpaka::AtomicSub>(acc, trackCandidatesInGPU.nTrackCandidates, 1u);
+          alpaka::atomicSub(acc, trackCandidatesInGPU.nTrackCandidates, 1u, alpaka::hierarchy::Threads{});
           break;
 
         } else {
-          alpaka::atomicOp<alpaka::AtomicAdd>(acc, trackCandidatesInGPU.nTrackCandidatespT5, 1u);
+          alpaka::atomicAdd(acc, trackCandidatesInGPU.nTrackCandidatespT5, 1u, alpaka::hierarchy::Threads{});
 
           float radius = 0.5f * (__H2F(pixelQuintupletsInGPU.pixelRadius[pixelQuintupletIndex]) +
                                  __H2F(pixelQuintupletsInGPU.quintupletRadius[pixelQuintupletIndex]));

--- a/RecoTracker/LSTCore/src/alpaka/Triplet.h
+++ b/RecoTracker/LSTCore/src/alpaka/Triplet.h
@@ -868,16 +868,19 @@ namespace lst {
                                                         circleCenterY);
 
             if (success) {
-              unsigned int totOccupancyTriplets = alpaka::atomicOp<alpaka::AtomicAdd>(
-                  acc, &tripletsInGPU.totOccupancyTriplets[innerInnerLowerModuleIndex], 1u);
+              unsigned int totOccupancyTriplets =
+                  alpaka::atomicAdd(acc,
+                                    &tripletsInGPU.totOccupancyTriplets[innerInnerLowerModuleIndex],
+                                    1u,
+                                    alpaka::hierarchy::Threads{});
               if (static_cast<int>(totOccupancyTriplets) >=
                   rangesInGPU.tripletModuleOccupancy[innerInnerLowerModuleIndex]) {
 #ifdef WARNINGS
                 printf("Triplet excess alert! Module index = %d\n", innerInnerLowerModuleIndex);
 #endif
               } else {
-                unsigned int tripletModuleIndex =
-                    alpaka::atomicOp<alpaka::AtomicAdd>(acc, &tripletsInGPU.nTriplets[innerInnerLowerModuleIndex], 1u);
+                unsigned int tripletModuleIndex = alpaka::atomicAdd(
+                    acc, &tripletsInGPU.nTriplets[innerInnerLowerModuleIndex], 1u, alpaka::hierarchy::Threads{});
                 unsigned int tripletIndex =
                     rangesInGPU.tripletModuleIndices[innerInnerLowerModuleIndex] + tripletModuleIndex;
 #ifdef CUT_VALUE_DEBUG
@@ -1009,7 +1012,7 @@ namespace lst {
         }
 
         rangesInGPU.tripletModuleOccupancy[i] = occupancy;
-        unsigned int nTotT = alpaka::atomicOp<alpaka::AtomicAdd>(acc, &nTotalTriplets, occupancy);
+        unsigned int nTotT = alpaka::atomicAdd(acc, &nTotalTriplets, occupancy, alpaka::hierarchy::Threads{});
         rangesInGPU.tripletModuleIndices[i] = nTotT;
       }
 


### PR DESCRIPTION
This PR addresses more review comments from the CMSSW PR. These are the things I have changed. I'll update this comment if I add more commits.

- Atomic operations:
  - https://github.com/cms-sw/cmssw/pull/45117#discussion_r1681629998
  - https://github.com/cms-sw/cmssw/pull/45117#discussion_r1681674098
  - https://github.com/cms-sw/cmssw/pull/45117#discussion_r1681692689
  - https://github.com/cms-sw/cmssw/pull/45117#discussion_r1681705133
  - https://github.com/cms-sw/cmssw/pull/45117#discussion_r1681722349
  
  I changed the syntax to the suggested one and specified `hierarchy::Threads` explicitly. The plots look the same and the timing might be marginally better, so it seems fine.

- Map lookups:
  - https://github.com/cms-sw/cmssw/pull/45117#discussion_r1681636712

  I refactored it so that it only performs one lookup.

- ROCm support:
  - https://github.com/cms-sw/cmssw/pull/45117#discussion_r1682937131

  I added an extra include so that the fp16 header is also imported for ROCm.


Here's a timing comparison.
```
This PR
Average time for map loading = 501.109 ms
Average time for input loading = 7555.69 ms
Average time for lst::Event creation = 0.00690278 ms
   Evt    Hits       MD       LS      T3       T5       pLS       pT5      pT3      TC       Reset    Event     Short             Rate
   avg     17.8      1.3      0.4      1.4      1.5      0.4      0.8      0.6      1.2      0.1      25.5       7.3+/-  1.4      27.6   explicit_cache[s=1]
   avg      5.7      1.4      0.5      1.9      1.9      0.4      1.3      0.9      1.7      0.2      15.9       9.7+/-  2.0       9.2   explicit_cache[s=2]
   avg     14.1      1.8      0.8      3.0      2.8      0.5      2.3      1.3      2.6      0.3      29.7      15.0+/-  3.2       8.1   explicit_cache[s=4]
   avg     17.1      2.3      1.1      4.1      4.3      0.6      3.4      2.0      3.7      0.6      39.2      21.5+/-  6.5       7.1   explicit_cache[s=6]
   avg     21.2      3.0      1.6      5.7      5.9      0.9      5.0      2.8      4.7      0.8      51.4      29.3+/-  7.3       6.9   explicit_cache[s=8]

Current batch5 branch (d3549cba529)
Average time for map loading = 497.301 ms
Average time for input loading = 7684.05 ms
Average time for lst::Event creation = 0.00804947 ms
   Evt    Hits       MD       LS      T3       T5       pLS       pT5      pT3      TC       Reset    Event     Short             Rate
   avg     17.0      1.4      0.4      1.4      1.5      0.4      0.8      0.6      1.2      0.1      24.8       7.4+/-  1.4      26.9   explicit_cache[s=1]
   avg      5.5      1.5      0.5      2.0      1.9      0.4      1.3      0.9      1.6      0.2      15.9       9.9+/-  2.1       9.1   explicit_cache[s=2]
   avg      9.1      1.8      0.8      3.1      3.1      0.5      2.2      1.2      2.6      0.4      24.8      15.1+/-  3.4       6.9   explicit_cache[s=4]
   avg     15.9      2.3      1.1      4.1      4.0      0.6      3.3      2.0      3.7      0.6      37.7      21.2+/-  5.7       6.8   explicit_cache[s=6]
   avg     22.2      2.8      1.3      5.5      5.4      0.8      4.5      2.5      5.0      0.7      50.6      27.7+/-  7.6       6.8   explicit_cache[s=8]
```