### PR TITLE
Small fixes post batch 5

### DIFF
--- a/RecoTracker/LST/plugins/LSTOutputConverter.cc
+++ b/RecoTracker/LST/plugins/LSTOutputConverter.cc
@@ -57,16 +57,14 @@ private:
 };
 
 LSTOutputConverter::LSTOutputConverter(edm::ParameterSet const& iConfig)
-    : lstOutputToken_(consumes<LSTOutput>(iConfig.getParameter<edm::InputTag>("lstOutput"))),
-      lstPhase2OTHitsInputToken_{consumes<LSTPhase2OTHitsInput>(iConfig.getParameter<edm::InputTag>("phase2OTHits"))},
-      lstPixelSeedToken_{consumes<TrajectorySeedCollection>(iConfig.getParameter<edm::InputTag>("lstPixelSeeds"))},
+    : lstOutputToken_(consumes(iConfig.getParameter<edm::InputTag>("lstOutput"))),
+      lstPhase2OTHitsInputToken_{consumes(iConfig.getParameter<edm::InputTag>("phase2OTHits"))},
+      lstPixelSeedToken_{consumes(iConfig.getParameter<edm::InputTag>("lstPixelSeeds"))},
       includeT5s_(iConfig.getParameter<bool>("includeT5s")),
       includeNonpLSTSs_(iConfig.getParameter<bool>("includeNonpLSTSs")),
       mfToken_(esConsumes()),
-      propagatorAlongToken_{
-          esConsumes<Propagator, TrackingComponentsRecord>(iConfig.getParameter<edm::ESInputTag>("propagatorAlong"))},
-      propagatorOppositeToken_{esConsumes<Propagator, TrackingComponentsRecord>(
-          iConfig.getParameter<edm::ESInputTag>("propagatorOpposite"))},
+      propagatorAlongToken_{esConsumes(iConfig.getParameter<edm::ESInputTag>("propagatorAlong"))},
+      propagatorOppositeToken_{esConsumes(iConfig.getParameter<edm::ESInputTag>("propagatorOpposite"))},
       tGeomToken_(esConsumes()),
       seedCreator_(SeedCreatorFactory::get()->create("SeedFromConsecutiveHitsCreator",
                                                      iConfig.getParameter<edm::ParameterSet>("SeedCreatorPSet"),
@@ -77,15 +75,15 @@ LSTOutputConverter::LSTOutputConverter(edm::ParameterSet const& iConfig)
       // - The minimal set for TCs is t5TCsLST, pTTCsLST and pLSTCsLST.
       //   That would complicate the handling of collections though,
       //   so it is deferred to when we have a clearer picture of what's needed.
-      trajectorySeedPutToken_(produces<TrajectorySeedCollection>("")),
-      trajectorySeedpLSPutToken_(produces<TrajectorySeedCollection>("pLSTSsLST")),
-      trackCandidatePutToken_(produces<TrackCandidateCollection>("")),
-      trackCandidatepTCPutToken_(produces<TrackCandidateCollection>("pTCsLST")),
-      trackCandidateT5TCPutToken_(produces<TrackCandidateCollection>("t5TCsLST")),
-      trackCandidateNopLSTCPutToken_(produces<TrackCandidateCollection>("nopLSTCsLST")),
-      trackCandidatepTTCPutToken_(produces<TrackCandidateCollection>("pTTCsLST")),
-      trackCandidatepLSTCPutToken_(produces<TrackCandidateCollection>("pLSTCsLST")),
-      seedStopInfoPutToken_(produces<std::vector<SeedStopInfo>>()) {}
+      trajectorySeedPutToken_(produces("")),
+      trajectorySeedpLSPutToken_(produces("pLSTSsLST")),
+      trackCandidatePutToken_(produces("")),
+      trackCandidatepTCPutToken_(produces("pTCsLST")),
+      trackCandidateT5TCPutToken_(produces("t5TCsLST")),
+      trackCandidateNopLSTCPutToken_(produces("nopLSTCsLST")),
+      trackCandidatepTTCPutToken_(produces("pTTCsLST")),
+      trackCandidatepLSTCPutToken_(produces("pLSTCsLST")),
+      seedStopInfoPutToken_(produces()) {}
 
 void LSTOutputConverter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;

--- a/RecoTracker/LST/plugins/LSTPhase2OTHitsInputProducer.cc
+++ b/RecoTracker/LST/plugins/LSTPhase2OTHitsInputProducer.cc
@@ -21,9 +21,8 @@ private:
 };
 
 LSTPhase2OTHitsInputProducer::LSTPhase2OTHitsInputProducer(edm::ParameterSet const& iConfig)
-    : phase2OTRecHitToken_(
-          consumes<Phase2TrackerRecHit1DCollectionNew>(iConfig.getParameter<edm::InputTag>("phase2OTRecHits"))),
-      lstPhase2OTHitsInputPutToken_(produces<LSTPhase2OTHitsInput>()) {}
+    : phase2OTRecHitToken_(consumes(iConfig.getParameter<edm::InputTag>("phase2OTRecHits"))),
+      lstPhase2OTHitsInputPutToken_(produces()) {}
 
 void LSTPhase2OTHitsInputProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;

--- a/RecoTracker/LST/plugins/LSTPixelSeedInputProducer.cc
+++ b/RecoTracker/LST/plugins/LSTPixelSeedInputProducer.cc
@@ -39,9 +39,9 @@ private:
 
 LSTPixelSeedInputProducer::LSTPixelSeedInputProducer(edm::ParameterSet const& iConfig)
     : mfToken_(esConsumes()),
-      beamSpotToken_(consumes<reco::BeamSpot>(iConfig.getParameter<edm::InputTag>("beamSpot"))),
-      lstPixelSeedInputPutToken_(produces<LSTPixelSeedInput>()),
-      lstPixelSeedsPutToken_(produces<TrajectorySeedCollection>()) {
+      beamSpotToken_(consumes(iConfig.getParameter<edm::InputTag>("beamSpot"))),
+      lstPixelSeedInputPutToken_(produces()),
+      lstPixelSeedsPutToken_(produces()) {
   seedTokens_ = edm::vector_transform(iConfig.getParameter<std::vector<edm::InputTag>>("seedTracks"),
                                       [&](const edm::InputTag& tag) { return consumes<edm::View<reco::Track>>(tag); });
 }

--- a/RecoTracker/LST/plugins/alpaka/LSTProducer.cc
+++ b/RecoTracker/LST/plugins/alpaka/LSTProducer.cc
@@ -26,9 +26,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   class LSTProducer : public stream::SynchronizingEDProducer<> {
   public:
     LSTProducer(edm::ParameterSet const& config)
-        : lstPixelSeedInputToken_{consumes<LSTPixelSeedInput>(config.getParameter<edm::InputTag>("pixelSeedInput"))},
-          lstPhase2OTHitsInputToken_{
-              consumes<LSTPhase2OTHitsInput>(config.getParameter<edm::InputTag>("phase2OTHitsInput"))},
+        : lstPixelSeedInputToken_{consumes(config.getParameter<edm::InputTag>("pixelSeedInput"))},
+          lstPhase2OTHitsInputToken_{consumes(config.getParameter<edm::InputTag>("phase2OTHitsInput"))},
           lstESToken_{esConsumes()},
           verbose_(config.getParameter<bool>("verbose")),
           nopLSDupClean_(config.getParameter<bool>("nopLSDupClean")),

--- a/RecoTracker/LSTCore/interface/Constants.h
+++ b/RecoTracker/LSTCore/interface/Constants.h
@@ -33,7 +33,7 @@ namespace lst {
   }
 
   // Named constants for pixelTypes
-  enum kPixelType { highPt = 0, lowPtPosCurv = 1, lowPtNegCurv = 2 };
+  enum PixelType : int8_t { kHighPt = 0, kLowPtPosCurv = 1, kLowPtNegCurv = 2 };
 
 // If a compile time flag does not define PT_CUT, default to 0.8 (GeV)
 #ifndef PT_CUT

--- a/RecoTracker/LSTCore/interface/Constants.h
+++ b/RecoTracker/LSTCore/interface/Constants.h
@@ -32,6 +32,9 @@ namespace lst {
                                                    alpaka_common::Vec1D(static_cast<alpaka_common::Idx>(nElements)));
   }
 
+  // Named constants for pixelTypes
+  enum kPixelType { highPt = 0, lowPtPosCurv = 1, lowPtNegCurv = 2 };
+
 // If a compile time flag does not define PT_CUT, default to 0.8 (GeV)
 #ifndef PT_CUT
   constexpr float PT_CUT = 0.8f;
@@ -52,7 +55,7 @@ namespace lst {
 
   constexpr unsigned int size_superbins = 45000;
 
-  //defining the constant host device variables right up here
+  // Defining the constant host device variables right up here
   // Currently pixel tracks treated as LSs with 2 double layers (IT layers 1+2 and 3+4) and 4 hits. To be potentially handled better in the future.
   struct Params_pLS {
     static constexpr int kLayers = 2, kHits = 4;

--- a/RecoTracker/LSTCore/interface/Constants.h
+++ b/RecoTracker/LSTCore/interface/Constants.h
@@ -33,7 +33,7 @@ namespace lst {
   }
 
   // Named constants for pixelTypes
-  enum PixelType : int8_t { kHighPt = 0, kLowPtPosCurv = 1, kLowPtNegCurv = 2 };
+  enum PixelType : int8_t { kInvalid = -1, kHighPt = 0, kLowPtPosCurv = 1, kLowPtNegCurv = 2 };
 
 // If a compile time flag does not define PT_CUT, default to 0.8 (GeV)
 #ifndef PT_CUT

--- a/RecoTracker/LSTCore/interface/EndcapGeometry.h
+++ b/RecoTracker/LSTCore/interface/EndcapGeometry.h
@@ -2,12 +2,8 @@
 #define RecoTracker_LSTCore_interface_EndcapGeometry_h
 
 #include <map>
-#include <iostream>
-#include <fstream>
-#include <sstream>
 #include <string>
 #include <vector>
-#include <stdexcept>
 
 namespace lst {
   class EndcapGeometry {

--- a/RecoTracker/LSTCore/interface/EndcapGeometryBuffer.h
+++ b/RecoTracker/LSTCore/interface/EndcapGeometryBuffer.h
@@ -49,8 +49,8 @@ namespace lst {
 
     inline EndcapGeometryDev const* data() const { return &data_; }
 
-    private:
-      EndcapGeometryDev data_;
+  private:
+    EndcapGeometryDev data_;
   };
 
 }  // namespace lst

--- a/RecoTracker/LSTCore/interface/EndcapGeometryBuffer.h
+++ b/RecoTracker/LSTCore/interface/EndcapGeometryBuffer.h
@@ -28,7 +28,6 @@ namespace lst {
   struct EndcapGeometryBuffer {
     Buf<TDev, unsigned int> geoMapDetId_buf;
     Buf<TDev, float> geoMapPhi_buf;
-    EndcapGeometryDev data_;
 
     EndcapGeometryBuffer(TDev const& dev, unsigned int nEndCapMap)
         : geoMapDetId_buf(allocBufWrapper<unsigned int>(dev, nEndCapMap)),
@@ -49,6 +48,9 @@ namespace lst {
     }
 
     inline EndcapGeometryDev const* data() const { return &data_; }
+
+    private:
+      EndcapGeometryDev data_;
   };
 
 }  // namespace lst

--- a/RecoTracker/LSTCore/interface/ModuleConnectionMap.h
+++ b/RecoTracker/LSTCore/interface/ModuleConnectionMap.h
@@ -1,12 +1,10 @@
 #ifndef RecoTracker_LSTCore_interface_ModuleConnectionMap_h
 #define RecoTracker_LSTCore_interface_ModuleConnectionMap_h
 
-#include <iostream>
-#include <fstream>
-#include <vector>
+#include <array>
 #include <map>
-#include <sstream>
-#include <algorithm>
+#include <string>
+#include <vector>
 
 namespace lst {
   class ModuleConnectionMap {

--- a/RecoTracker/LSTCore/interface/PixelMap.h
+++ b/RecoTracker/LSTCore/interface/PixelMap.h
@@ -17,7 +17,7 @@ namespace lst {
     std::vector<unsigned int> connectedPixelsIndexNeg;
     std::vector<unsigned int> connectedPixelsSizesNeg;
 
-    int* pixelType;
+    const int* pixelType;
 
     PixelMap(unsigned int sizef = size_superbins)
         : pixelModuleIndex(0),

--- a/RecoTracker/LSTCore/interface/TiltedGeometry.h
+++ b/RecoTracker/LSTCore/interface/TiltedGeometry.h
@@ -1,13 +1,9 @@
 #ifndef RecoTracker_LSTCore_interface_TiltedGeometry_h
 #define RecoTracker_LSTCore_interface_TiltedGeometry_h
 
-#include <vector>
 #include <map>
-#include <iostream>
-#include <fstream>
-#include <sstream>
 #include <string>
-#include <stdexcept>
+#include <vector>
 
 namespace lst {
   class TiltedGeometry {

--- a/RecoTracker/LSTCore/interface/alpaka/LST.h
+++ b/RecoTracker/LSTCore/interface/alpaka/LST.h
@@ -96,7 +96,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       std::vector<int> in_charge_vec_;
       std::vector<unsigned int> in_seedIdx_vec_;
       std::vector<int> in_superbin_vec_;
-      std::vector<int8_t> in_pixelType_vec_;
+      std::vector<::lst::PixelType> in_pixelType_vec_;
       std::vector<char> in_isQuad_vec_;
       std::vector<std::vector<unsigned int>> out_tc_hitIdxs_;
       std::vector<unsigned int> out_tc_len_;

--- a/RecoTracker/LSTCore/interface/alpaka/LST.h
+++ b/RecoTracker/LSTCore/interface/alpaka/LST.h
@@ -96,7 +96,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       std::vector<int> in_charge_vec_;
       std::vector<unsigned int> in_seedIdx_vec_;
       std::vector<int> in_superbin_vec_;
-      std::vector<int> in_pixelType_vec_;
+      std::vector<int8_t> in_pixelType_vec_;
       std::vector<char> in_isQuad_vec_;
       std::vector<std::vector<unsigned int>> out_tc_hitIdxs_;
       std::vector<unsigned int> out_tc_len_;

--- a/RecoTracker/LSTCore/interface/alpaka/LST.h
+++ b/RecoTracker/LSTCore/interface/alpaka/LST.h
@@ -96,7 +96,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       std::vector<int> in_charge_vec_;
       std::vector<unsigned int> in_seedIdx_vec_;
       std::vector<int> in_superbin_vec_;
-      std::vector<int8_t> in_pixelType_vec_;
+      std::vector<int> in_pixelType_vec_;
       std::vector<char> in_isQuad_vec_;
       std::vector<std::vector<unsigned int>> out_tc_hitIdxs_;
       std::vector<unsigned int> out_tc_len_;

--- a/RecoTracker/LSTCore/src/EndcapGeometry.cc
+++ b/RecoTracker/LSTCore/src/EndcapGeometry.cc
@@ -1,5 +1,10 @@
 #include "RecoTracker/LSTCore/interface/EndcapGeometry.h"
 
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <stdexcept>
+
 lst::EndcapGeometry::EndcapGeometry(std::string const& filename) { load(filename); }
 
 void lst::EndcapGeometry::load(std::string const& filename) {

--- a/RecoTracker/LSTCore/src/ModuleConnectionMap.cc
+++ b/RecoTracker/LSTCore/src/ModuleConnectionMap.cc
@@ -1,5 +1,10 @@
 #include "RecoTracker/LSTCore/interface/ModuleConnectionMap.h"
 
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <algorithm>
+
 lst::ModuleConnectionMap::ModuleConnectionMap() {}
 
 lst::ModuleConnectionMap::ModuleConnectionMap(std::string const& filename) { load(filename); }

--- a/RecoTracker/LSTCore/src/TiltedGeometry.cc
+++ b/RecoTracker/LSTCore/src/TiltedGeometry.cc
@@ -1,5 +1,10 @@
 #include "RecoTracker/LSTCore/interface/TiltedGeometry.h"
 
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <stdexcept>
+
 lst::TiltedGeometry::TiltedGeometry(std::string const& filename) { load(filename); }
 
 void lst::TiltedGeometry::load(std::string const& filename) {

--- a/RecoTracker/LSTCore/src/alpaka/Event.dev.cc
+++ b/RecoTracker/LSTCore/src/alpaka/Event.dev.cc
@@ -735,10 +735,12 @@ void Event::createPixelTriplets() {
 
   // TODO: check if a map/reduction to just eligible pLSs would speed up the kernel
   // the current selection still leaves a significant fraction of unmatchable pLSs
-  for (unsigned int i = 0; i < nInnerSegments; i++) { // loop over # pLS
-    int pixelType = pixelTypes[i]; // Get pixel type for this pLS
-    int superbin = superbins[i]; // Get superbin for this pixel
-    if ((superbin < 0) or (superbin >= (int)size_superbins) or ((pixelType != ::lst::kPixelType::highPt) and (pixelType != ::lst::kPixelType::lowPtPosCurv) and (pixelType != ::lst::kPixelType::lowPtNegCurv))) {
+  for (unsigned int i = 0; i < nInnerSegments; i++) {  // loop over # pLS
+    int pixelType = pixelTypes[i];                     // Get pixel type for this pLS
+    int superbin = superbins[i];                       // Get superbin for this pixel
+    if ((superbin < 0) or (superbin >= (int)size_superbins) or
+        ((pixelType != ::lst::kPixelType::highPt) and (pixelType != ::lst::kPixelType::lowPtPosCurv) and
+         (pixelType != ::lst::kPixelType::lowPtNegCurv))) {
       connectedPixelSize_host[i] = 0;
       connectedPixelIndex_host[i] = 0;
       continue;
@@ -931,9 +933,11 @@ void Event::createPixelQuintuplets() {
 
   // Loop over # pLS
   for (unsigned int i = 0; i < nInnerSegments; i++) {
-    int pixelType = pixelTypes[i]; // Get pixel type for this pLS
-    int superbin = superbins[i]; // Get superbin for this pixel
-    if ((superbin < 0) or (superbin >= (int)size_superbins) or ((pixelType != ::lst::kPixelType::highPt) and (pixelType != ::lst::kPixelType::lowPtPosCurv) and (pixelType != ::lst::kPixelType::lowPtNegCurv))) {
+    int pixelType = pixelTypes[i];  // Get pixel type for this pLS
+    int superbin = superbins[i];    // Get superbin for this pixel
+    if ((superbin < 0) or (superbin >= (int)size_superbins) or
+        ((pixelType != ::lst::kPixelType::highPt) and (pixelType != ::lst::kPixelType::lowPtPosCurv) and
+         (pixelType != ::lst::kPixelType::lowPtNegCurv))) {
       connectedPixelIndex_host[i] = 0;
       connectedPixelSize_host[i] = 0;
       continue;

--- a/RecoTracker/LSTCore/src/alpaka/Event.dev.cc
+++ b/RecoTracker/LSTCore/src/alpaka/Event.dev.cc
@@ -233,7 +233,7 @@ void Event::addPixelSegmentToEvent(std::vector<unsigned int> const& hitIndices0,
                                    std::vector<int> const& charge,
                                    std::vector<unsigned int> const& seedIdx,
                                    std::vector<int> const& superbin,
-                                   std::vector<int> const& pixelType,
+                                   std::vector<int8_t> const& pixelType,
                                    std::vector<char> const& isQuad) {
   unsigned int size = ptIn.size();
 
@@ -704,7 +704,7 @@ void Event::createPixelTriplets() {
   }
 
   auto superbins_buf = allocBufWrapper<int>(devHost, n_max_pixel_segments_per_module, queue);
-  auto pixelTypes_buf = allocBufWrapper<int>(devHost, n_max_pixel_segments_per_module, queue);
+  auto pixelTypes_buf = allocBufWrapper<int8_t>(devHost, n_max_pixel_segments_per_module, queue);
 
   alpaka::memcpy(queue, superbins_buf, segmentsBuffers->superbin_buf);
   alpaka::memcpy(queue, pixelTypes_buf, segmentsBuffers->pixelType_buf);
@@ -735,34 +735,39 @@ void Event::createPixelTriplets() {
 
   // TODO: check if a map/reduction to just eligible pLSs would speed up the kernel
   // the current selection still leaves a significant fraction of unmatchable pLSs
-  for (unsigned int i = 0; i < nInnerSegments; i++) {  // loop over # pLS
-    int pixelType = pixelTypes[i];                     // Get pixel type for this pLS
-    int superbin = superbins[i];                       // Get superbin for this pixel
+  for (unsigned int i = 0; i < nInnerSegments; i++) {                           // loop over # pLS
+    ::lst::PixelType pixelType = static_cast<::lst::PixelType>(pixelTypes[i]);  // Get pixel type for this pLS
+    int superbin = superbins[i];                                                // Get superbin for this pixel
     if ((superbin < 0) or (superbin >= (int)size_superbins) or
-        ((pixelType != ::lst::kPixelType::highPt) and (pixelType != ::lst::kPixelType::lowPtPosCurv) and
-         (pixelType != ::lst::kPixelType::lowPtNegCurv))) {
+        ((pixelType != ::lst::PixelType::kHighPt) and (pixelType != ::lst::PixelType::kLowPtPosCurv) and
+         (pixelType != ::lst::PixelType::kLowPtNegCurv))) {
       connectedPixelSize_host[i] = 0;
       connectedPixelIndex_host[i] = 0;
       continue;
     }
 
     // Used pixel type to select correct size-index arrays
-    if (pixelType == static_cast<int>(::lst::kPixelType::highPt)) {
-      connectedPixelSize_host[i] =
-          pixelMapping_.connectedPixelsSizes[superbin];  // number of connected modules to this pixel
-      auto connectedIdxBase = pixelMapping_.connectedPixelsIndex[superbin];
-      connectedPixelIndex_host[i] =
-          connectedIdxBase;  // index to get start of connected modules for this superbin in map
-    } else if (pixelType == static_cast<int>(::lst::kPixelType::lowPtPosCurv)) {
-      connectedPixelSize_host[i] =
-          pixelMapping_.connectedPixelsSizesPos[superbin];  // number of pixel connected modules
-      auto connectedIdxBase = pixelMapping_.connectedPixelsIndexPos[superbin] + pixelIndexOffsetPos;
-      connectedPixelIndex_host[i] = connectedIdxBase;  // index to get start of connected pixel modules
-    } else if (pixelType == static_cast<int>(::lst::kPixelType::lowPtNegCurv)) {
-      connectedPixelSize_host[i] =
-          pixelMapping_.connectedPixelsSizesNeg[superbin];  // number of pixel connected modules
-      auto connectedIdxBase = pixelMapping_.connectedPixelsIndexNeg[superbin] + pixelIndexOffsetNeg;
-      connectedPixelIndex_host[i] = connectedIdxBase;  // index to get start of connected pixel modules
+    unsigned int connectedIdxBase;
+    switch (pixelType) {
+      case ::lst::PixelType::kHighPt:
+        connectedPixelSize_host[i] =
+            pixelMapping_.connectedPixelsSizes[superbin];  // number of connected modules to this pixel
+        connectedIdxBase = pixelMapping_.connectedPixelsIndex[superbin];
+        connectedPixelIndex_host[i] =
+            connectedIdxBase;  // index to get start of connected modules for this superbin in map
+        break;
+      case ::lst::PixelType::kLowPtPosCurv:
+        connectedPixelSize_host[i] =
+            pixelMapping_.connectedPixelsSizesPos[superbin];  // number of pixel connected modules
+        connectedIdxBase = pixelMapping_.connectedPixelsIndexPos[superbin] + pixelIndexOffsetPos;
+        connectedPixelIndex_host[i] = connectedIdxBase;  // index to get start of connected pixel modules
+        break;
+      case ::lst::PixelType::kLowPtNegCurv:
+        connectedPixelSize_host[i] =
+            pixelMapping_.connectedPixelsSizesNeg[superbin];  // number of pixel connected modules
+        connectedIdxBase = pixelMapping_.connectedPixelsIndexNeg[superbin] + pixelIndexOffsetNeg;
+        connectedPixelIndex_host[i] = connectedIdxBase;  // index to get start of connected pixel modules
+        break;
     }
   }
 
@@ -902,7 +907,7 @@ void Event::createPixelQuintuplets() {
   }
 
   auto superbins_buf = allocBufWrapper<int>(devHost, n_max_pixel_segments_per_module, queue);
-  auto pixelTypes_buf = allocBufWrapper<int>(devHost, n_max_pixel_segments_per_module, queue);
+  auto pixelTypes_buf = allocBufWrapper<int8_t>(devHost, n_max_pixel_segments_per_module, queue);
 
   alpaka::memcpy(queue, superbins_buf, segmentsBuffers->superbin_buf);
   alpaka::memcpy(queue, pixelTypes_buf, segmentsBuffers->pixelType_buf);
@@ -933,30 +938,37 @@ void Event::createPixelQuintuplets() {
 
   // Loop over # pLS
   for (unsigned int i = 0; i < nInnerSegments; i++) {
-    int pixelType = pixelTypes[i];  // Get pixel type for this pLS
-    int superbin = superbins[i];    // Get superbin for this pixel
+    ::lst::PixelType pixelType = static_cast<::lst::PixelType>(pixelTypes[i]);  // Get pixel type for this pLS
+    int superbin = superbins[i];                                                // Get superbin for this pixel
     if ((superbin < 0) or (superbin >= (int)size_superbins) or
-        ((pixelType != ::lst::kPixelType::highPt) and (pixelType != ::lst::kPixelType::lowPtPosCurv) and
-         (pixelType != ::lst::kPixelType::lowPtNegCurv))) {
+        ((pixelType != ::lst::PixelType::kHighPt) and (pixelType != ::lst::PixelType::kLowPtPosCurv) and
+         (pixelType != ::lst::PixelType::kLowPtNegCurv))) {
       connectedPixelIndex_host[i] = 0;
       connectedPixelSize_host[i] = 0;
       continue;
     }
 
     // Used pixel type to select correct size-index arrays
-    if (pixelType == static_cast<int>(::lst::kPixelType::highPt)) {
-      connectedPixelSize_host[i] =
-          pixelMapping_.connectedPixelsSizes[superbin];  //number of connected modules to this pixel
-      unsigned int connectedIdxBase = pixelMapping_.connectedPixelsIndex[superbin];
-      connectedPixelIndex_host[i] = connectedIdxBase;
-    } else if (pixelType == static_cast<int>(::lst::kPixelType::lowPtPosCurv)) {
-      connectedPixelSize_host[i] = pixelMapping_.connectedPixelsSizesPos[superbin];  //number of pixel connected modules
-      unsigned int connectedIdxBase = pixelMapping_.connectedPixelsIndexPos[superbin] + pixelIndexOffsetPos;
-      connectedPixelIndex_host[i] = connectedIdxBase;
-    } else if (pixelType == static_cast<int>(::lst::kPixelType::lowPtNegCurv)) {
-      connectedPixelSize_host[i] = pixelMapping_.connectedPixelsSizesNeg[superbin];  //number of pixel connected modules
-      unsigned int connectedIdxBase = pixelMapping_.connectedPixelsIndexNeg[superbin] + pixelIndexOffsetNeg;
-      connectedPixelIndex_host[i] = connectedIdxBase;
+    unsigned int connectedIdxBase;
+    switch (pixelType) {
+      case ::lst::PixelType::kHighPt:
+        connectedPixelSize_host[i] =
+            pixelMapping_.connectedPixelsSizes[superbin];  //number of connected modules to this pixel
+        connectedIdxBase = pixelMapping_.connectedPixelsIndex[superbin];
+        connectedPixelIndex_host[i] = connectedIdxBase;
+        break;
+      case ::lst::PixelType::kLowPtPosCurv:
+        connectedPixelSize_host[i] =
+            pixelMapping_.connectedPixelsSizesPos[superbin];  //number of pixel connected modules
+        connectedIdxBase = pixelMapping_.connectedPixelsIndexPos[superbin] + pixelIndexOffsetPos;
+        connectedPixelIndex_host[i] = connectedIdxBase;
+        break;
+      case ::lst::PixelType::kLowPtNegCurv:
+        connectedPixelSize_host[i] =
+            pixelMapping_.connectedPixelsSizesNeg[superbin];  //number of pixel connected modules
+        connectedIdxBase = pixelMapping_.connectedPixelsIndexNeg[superbin] + pixelIndexOffsetNeg;
+        connectedPixelIndex_host[i] = connectedIdxBase;
+        break;
     }
   }
 

--- a/RecoTracker/LSTCore/src/alpaka/Event.dev.cc
+++ b/RecoTracker/LSTCore/src/alpaka/Event.dev.cc
@@ -233,7 +233,7 @@ void Event::addPixelSegmentToEvent(std::vector<unsigned int> const& hitIndices0,
                                    std::vector<int> const& charge,
                                    std::vector<unsigned int> const& seedIdx,
                                    std::vector<int> const& superbin,
-                                   std::vector<int8_t> const& pixelType,
+                                   std::vector<int> const& pixelType,
                                    std::vector<char> const& isQuad) {
   unsigned int size = ptIn.size();
 
@@ -704,7 +704,7 @@ void Event::createPixelTriplets() {
   }
 
   auto superbins_buf = allocBufWrapper<int>(devHost, n_max_pixel_segments_per_module, queue);
-  auto pixelTypes_buf = allocBufWrapper<int8_t>(devHost, n_max_pixel_segments_per_module, queue);
+  auto pixelTypes_buf = allocBufWrapper<int>(devHost, n_max_pixel_segments_per_module, queue);
 
   alpaka::memcpy(queue, superbins_buf, segmentsBuffers->superbin_buf);
   alpaka::memcpy(queue, pixelTypes_buf, segmentsBuffers->pixelType_buf);
@@ -735,28 +735,28 @@ void Event::createPixelTriplets() {
 
   // TODO: check if a map/reduction to just eligible pLSs would speed up the kernel
   // the current selection still leaves a significant fraction of unmatchable pLSs
-  for (unsigned int i = 0; i < nInnerSegments; i++) {  // loop over # pLS
-    int8_t pixelType = pixelTypes[i];                  // Get pixel type for this pLS
-    int superbin = superbins[i];                       // Get superbin for this pixel
-    if ((superbin < 0) or (superbin >= (int)size_superbins) or (pixelType > 2) or (pixelType < 0)) {
+  for (unsigned int i = 0; i < nInnerSegments; i++) { // loop over # pLS
+    int pixelType = pixelTypes[i]; // Get pixel type for this pLS
+    int superbin = superbins[i]; // Get superbin for this pixel
+    if ((superbin < 0) or (superbin >= (int)size_superbins) or ((pixelType != ::lst::kPixelType::highPt) and (pixelType != ::lst::kPixelType::lowPtPosCurv) and (pixelType != ::lst::kPixelType::lowPtNegCurv))) {
       connectedPixelSize_host[i] = 0;
       connectedPixelIndex_host[i] = 0;
       continue;
     }
 
     // Used pixel type to select correct size-index arrays
-    if (pixelType == 0) {
+    if (pixelType == static_cast<int>(::lst::kPixelType::highPt)) {
       connectedPixelSize_host[i] =
           pixelMapping_.connectedPixelsSizes[superbin];  // number of connected modules to this pixel
       auto connectedIdxBase = pixelMapping_.connectedPixelsIndex[superbin];
       connectedPixelIndex_host[i] =
           connectedIdxBase;  // index to get start of connected modules for this superbin in map
-    } else if (pixelType == 1) {
+    } else if (pixelType == static_cast<int>(::lst::kPixelType::lowPtPosCurv)) {
       connectedPixelSize_host[i] =
           pixelMapping_.connectedPixelsSizesPos[superbin];  // number of pixel connected modules
       auto connectedIdxBase = pixelMapping_.connectedPixelsIndexPos[superbin] + pixelIndexOffsetPos;
       connectedPixelIndex_host[i] = connectedIdxBase;  // index to get start of connected pixel modules
-    } else if (pixelType == 2) {
+    } else if (pixelType == static_cast<int>(::lst::kPixelType::lowPtNegCurv)) {
       connectedPixelSize_host[i] =
           pixelMapping_.connectedPixelsSizesNeg[superbin];  // number of pixel connected modules
       auto connectedIdxBase = pixelMapping_.connectedPixelsIndexNeg[superbin] + pixelIndexOffsetNeg;
@@ -900,7 +900,7 @@ void Event::createPixelQuintuplets() {
   }
 
   auto superbins_buf = allocBufWrapper<int>(devHost, n_max_pixel_segments_per_module, queue);
-  auto pixelTypes_buf = allocBufWrapper<int8_t>(devHost, n_max_pixel_segments_per_module, queue);
+  auto pixelTypes_buf = allocBufWrapper<int>(devHost, n_max_pixel_segments_per_module, queue);
 
   alpaka::memcpy(queue, superbins_buf, segmentsBuffers->superbin_buf);
   alpaka::memcpy(queue, pixelTypes_buf, segmentsBuffers->pixelType_buf);
@@ -931,24 +931,25 @@ void Event::createPixelQuintuplets() {
 
   // Loop over # pLS
   for (unsigned int i = 0; i < nInnerSegments; i++) {
-    int8_t pixelType = pixelTypes[i];  // Get pixel type for this pLS
-    int superbin = superbins[i];       // Get superbin for this pixel
-    if ((superbin < 0) or (superbin >= (int)::size_superbins) or (pixelType > 2) or (pixelType < 0)) {
+    int pixelType = pixelTypes[i]; // Get pixel type for this pLS
+    int superbin = superbins[i]; // Get superbin for this pixel
+    if ((superbin < 0) or (superbin >= (int)size_superbins) or ((pixelType != ::lst::kPixelType::highPt) and (pixelType != ::lst::kPixelType::lowPtPosCurv) and (pixelType != ::lst::kPixelType::lowPtNegCurv))) {
       connectedPixelIndex_host[i] = 0;
       connectedPixelSize_host[i] = 0;
       continue;
     }
+
     // Used pixel type to select correct size-index arrays
-    if (pixelType == 0) {
+    if (pixelType == static_cast<int>(::lst::kPixelType::highPt)) {
       connectedPixelSize_host[i] =
           pixelMapping_.connectedPixelsSizes[superbin];  //number of connected modules to this pixel
       unsigned int connectedIdxBase = pixelMapping_.connectedPixelsIndex[superbin];
       connectedPixelIndex_host[i] = connectedIdxBase;
-    } else if (pixelType == 1) {
+    } else if (pixelType == static_cast<int>(::lst::kPixelType::lowPtPosCurv)) {
       connectedPixelSize_host[i] = pixelMapping_.connectedPixelsSizesPos[superbin];  //number of pixel connected modules
       unsigned int connectedIdxBase = pixelMapping_.connectedPixelsIndexPos[superbin] + pixelIndexOffsetPos;
       connectedPixelIndex_host[i] = connectedIdxBase;
-    } else if (pixelType == 2) {
+    } else if (pixelType == static_cast<int>(::lst::kPixelType::lowPtNegCurv)) {
       connectedPixelSize_host[i] = pixelMapping_.connectedPixelsSizesNeg[superbin];  //number of pixel connected modules
       unsigned int connectedIdxBase = pixelMapping_.connectedPixelsIndexNeg[superbin] + pixelIndexOffsetNeg;
       connectedPixelIndex_host[i] = connectedIdxBase;

--- a/RecoTracker/LSTCore/src/alpaka/Event.h
+++ b/RecoTracker/LSTCore/src/alpaka/Event.h
@@ -128,7 +128,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                   std::vector<int> const& charge,
                                   std::vector<unsigned int> const& seedIdx,
                                   std::vector<int> const& superbin,
-                                  std::vector<int8_t> const& pixelType,
+                                  std::vector<::lst::PixelType> const& pixelType,
                                   std::vector<char> const& isQuad);
 
       void createMiniDoublets();

--- a/RecoTracker/LSTCore/src/alpaka/Event.h
+++ b/RecoTracker/LSTCore/src/alpaka/Event.h
@@ -128,7 +128,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                   std::vector<int> const& charge,
                                   std::vector<unsigned int> const& seedIdx,
                                   std::vector<int> const& superbin,
-                                  std::vector<int> const& pixelType,
+                                  std::vector<int8_t> const& pixelType,
                                   std::vector<char> const& isQuad);
 
       void createMiniDoublets();

--- a/RecoTracker/LSTCore/src/alpaka/Event.h
+++ b/RecoTracker/LSTCore/src/alpaka/Event.h
@@ -80,9 +80,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
       void initSync(bool verbose);
 
-      int* superbinCPU;
-      int8_t* pixelTypeCPU;
-
       const uint16_t nModules_;
       const uint16_t nLowerModules_;
       const unsigned int nPixels_;
@@ -131,7 +128,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                   std::vector<int> const& charge,
                                   std::vector<unsigned int> const& seedIdx,
                                   std::vector<int> const& superbin,
-                                  std::vector<int8_t> const& pixelType,
+                                  std::vector<int> const& pixelType,
                                   std::vector<char> const& isQuad);
 
       void createMiniDoublets();

--- a/RecoTracker/LSTCore/src/alpaka/LST.dev.cc
+++ b/RecoTracker/LSTCore/src/alpaka/LST.dev.cc
@@ -5,6 +5,7 @@
 using namespace ALPAKA_ACCELERATOR_NAMESPACE;
 
 #include "Math/Vector3D.h"
+#include "Math/VectorUtil.h"
 using XYZVector = ROOT::Math::XYZVector;
 
 namespace {
@@ -93,7 +94,8 @@ void ALPAKA_ACCELERATOR_NAMESPACE::lst::LST::prepareInput(std::vector<float> con
       XYZVector p3PCA(see_px[iSeed], see_py[iSeed], see_pz[iSeed]);
       XYZVector r3PCA(calculateR3FromPCA(p3PCA, see_dxy[iSeed], see_dz[iSeed]));
 
-      float pixelSegmentDeltaPhiChange = (r3LH - p3LH).phi();
+      // The charge could be used directly in the line below
+      float pixelSegmentDeltaPhiChange = ROOT::Math::VectorUtil::DeltaPhi(r3LH, p3LH);
       float etaErr = see_etaErr[iSeed];
       float px = p3LH.x();
       float py = p3LH.y();

--- a/RecoTracker/LSTCore/src/alpaka/LST.dev.cc
+++ b/RecoTracker/LSTCore/src/alpaka/LST.dev.cc
@@ -77,14 +77,13 @@ void ALPAKA_ACCELERATOR_NAMESPACE::lst::LST::prepareInput(std::vector<float> con
   std::vector<unsigned int> hitIdxs(ph2_detId.size());
 
   std::vector<int> superbin_vec;
-  std::vector<int8_t> pixelType_vec;
+  std::vector<int> pixelType_vec;
   std::vector<char> isQuad_vec;
   std::iota(hitIdxs.begin(), hitIdxs.end(), 0);
   const int hit_size = trkX.size();
 
   for (size_t iSeed = 0; iSeed < n_see; iSeed++) {
     XYZVector p3LH(see_stateTrajGlbPx[iSeed], see_stateTrajGlbPy[iSeed], see_stateTrajGlbPz[iSeed]);
-    XYZVector p3LH_helper(see_stateTrajGlbPx[iSeed], see_stateTrajGlbPy[iSeed], see_stateTrajGlbPz[iSeed]);
     float ptIn = p3LH.rho();
     float eta = p3LH.eta();
     float ptErr = see_ptErr[iSeed];
@@ -94,7 +93,7 @@ void ALPAKA_ACCELERATOR_NAMESPACE::lst::LST::prepareInput(std::vector<float> con
       XYZVector p3PCA(see_px[iSeed], see_py[iSeed], see_pz[iSeed]);
       XYZVector r3PCA(calculateR3FromPCA(p3PCA, see_dxy[iSeed], see_dz[iSeed]));
 
-      float pixelSegmentDeltaPhiChange = (r3LH - p3LH_helper).phi();  //FIXME: this looks like a bug
+      float pixelSegmentDeltaPhiChange = (r3LH - p3LH).phi();
       float etaErr = see_etaErr[iSeed];
       float px = p3LH.x();
       float py = p3LH.y();
@@ -104,12 +103,12 @@ void ALPAKA_ACCELERATOR_NAMESPACE::lst::LST::prepareInput(std::vector<float> con
       int pixtype = -1;
 
       if (ptIn >= 2.0)
-        pixtype = 0;
+        pixtype = static_cast<int>(::lst::kPixelType::highPt);
       else if (ptIn >= (0.8 - 2 * ptErr) and ptIn < 2.0) {
         if (pixelSegmentDeltaPhiChange >= 0)
-          pixtype = 1;
+          pixtype = static_cast<int>(::lst::kPixelType::lowPtPosCurv);
         else
-          pixtype = 2;
+          pixtype = static_cast<int>(::lst::kPixelType::lowPtNegCurv);
       } else
         continue;
 

--- a/RecoTracker/LSTCore/src/alpaka/LST.dev.cc
+++ b/RecoTracker/LSTCore/src/alpaka/LST.dev.cc
@@ -77,7 +77,7 @@ void ALPAKA_ACCELERATOR_NAMESPACE::lst::LST::prepareInput(std::vector<float> con
   std::vector<unsigned int> hitIdxs(ph2_detId.size());
 
   std::vector<int> superbin_vec;
-  std::vector<int> pixelType_vec;
+  std::vector<int8_t> pixelType_vec;
   std::vector<char> isQuad_vec;
   std::iota(hitIdxs.begin(), hitIdxs.end(), 0);
   const int hit_size = trkX.size();
@@ -103,12 +103,12 @@ void ALPAKA_ACCELERATOR_NAMESPACE::lst::LST::prepareInput(std::vector<float> con
       int pixtype = -1;
 
       if (ptIn >= 2.0)
-        pixtype = static_cast<int>(::lst::kPixelType::highPt);
+        pixtype = static_cast<int8_t>(::lst::PixelType::kHighPt);
       else if (ptIn >= (0.8 - 2 * ptErr) and ptIn < 2.0) {
         if (pixelSegmentDeltaPhiChange >= 0)
-          pixtype = static_cast<int>(::lst::kPixelType::lowPtPosCurv);
+          pixtype = static_cast<int8_t>(::lst::PixelType::kLowPtPosCurv);
         else
-          pixtype = static_cast<int>(::lst::kPixelType::lowPtNegCurv);
+          pixtype = static_cast<int8_t>(::lst::PixelType::kLowPtNegCurv);
       } else
         continue;
 

--- a/RecoTracker/LSTCore/src/alpaka/LST.dev.cc
+++ b/RecoTracker/LSTCore/src/alpaka/LST.dev.cc
@@ -95,7 +95,7 @@ void ALPAKA_ACCELERATOR_NAMESPACE::lst::LST::prepareInput(std::vector<float> con
       XYZVector r3PCA(calculateR3FromPCA(p3PCA, see_dxy[iSeed], see_dz[iSeed]));
 
       // The charge could be used directly in the line below
-      float pixelSegmentDeltaPhiChange = ROOT::Math::VectorUtil::DeltaPhi(r3LH, p3LH);
+      float pixelSegmentDeltaPhiChange = ROOT::Math::VectorUtil::DeltaPhi(p3LH, r3LH);
       float etaErr = see_etaErr[iSeed];
       float px = p3LH.x();
       float py = p3LH.y();

--- a/RecoTracker/LSTCore/src/alpaka/LST.dev.cc
+++ b/RecoTracker/LSTCore/src/alpaka/LST.dev.cc
@@ -77,7 +77,7 @@ void ALPAKA_ACCELERATOR_NAMESPACE::lst::LST::prepareInput(std::vector<float> con
   std::vector<unsigned int> hitIdxs(ph2_detId.size());
 
   std::vector<int> superbin_vec;
-  std::vector<int8_t> pixelType_vec;
+  std::vector<::lst::PixelType> pixelType_vec;
   std::vector<char> isQuad_vec;
   std::iota(hitIdxs.begin(), hitIdxs.end(), 0);
   const int hit_size = trkX.size();
@@ -100,15 +100,15 @@ void ALPAKA_ACCELERATOR_NAMESPACE::lst::LST::prepareInput(std::vector<float> con
       float pz = p3LH.z();
 
       int charge = see_q[iSeed];
-      int pixtype = -1;
+      ::lst::PixelType pixtype = ::lst::PixelType::kInvalid;
 
       if (ptIn >= 2.0)
-        pixtype = static_cast<int8_t>(::lst::PixelType::kHighPt);
+        pixtype = ::lst::PixelType::kHighPt;
       else if (ptIn >= (0.8 - 2 * ptErr) and ptIn < 2.0) {
         if (pixelSegmentDeltaPhiChange >= 0)
-          pixtype = static_cast<int8_t>(::lst::PixelType::kLowPtPosCurv);
+          pixtype = ::lst::PixelType::kLowPtPosCurv;
         else
-          pixtype = static_cast<int8_t>(::lst::PixelType::kLowPtNegCurv);
+          pixtype = ::lst::PixelType::kLowPtNegCurv;
       } else
         continue;
 

--- a/RecoTracker/LSTCore/src/alpaka/Segment.h
+++ b/RecoTracker/LSTCore/src/alpaka/Segment.h
@@ -31,7 +31,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     unsigned int* nSegments;             //number of segments per inner lower module
     unsigned int* totOccupancySegments;  //number of segments per inner lower module
     uint4* pLSHitsIdxs;
-    int8_t* pixelType;
+    ::lst::PixelType* pixelType;
     char* isQuad;
     char* isDup;
     bool* partOfPT5;
@@ -107,7 +107,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     Buf<TDev, unsigned int> nSegments_buf;
     Buf<TDev, unsigned int> totOccupancySegments_buf;
     Buf<TDev, uint4> pLSHitsIdxs_buf;
-    Buf<TDev, int8_t> pixelType_buf;
+    Buf<TDev, ::lst::PixelType> pixelType_buf;
     Buf<TDev, char> isQuad_buf;
     Buf<TDev, char> isDup_buf;
     Buf<TDev, bool> partOfPT5_buf;
@@ -150,7 +150,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
           nSegments_buf(allocBufWrapper<unsigned int>(devAccIn, nLowerModules + 1, queue)),
           totOccupancySegments_buf(allocBufWrapper<unsigned int>(devAccIn, nLowerModules + 1, queue)),
           pLSHitsIdxs_buf(allocBufWrapper<uint4>(devAccIn, maxPixelSegments, queue)),
-          pixelType_buf(allocBufWrapper<int8_t>(devAccIn, maxPixelSegments, queue)),
+          pixelType_buf(allocBufWrapper<::lst::PixelType>(devAccIn, maxPixelSegments, queue)),
           isQuad_buf(allocBufWrapper<char>(devAccIn, maxPixelSegments, queue)),
           isDup_buf(allocBufWrapper<char>(devAccIn, maxPixelSegments, queue)),
           partOfPT5_buf(allocBufWrapper<bool>(devAccIn, maxPixelSegments, queue)),

--- a/RecoTracker/LSTCore/src/alpaka/Segment.h
+++ b/RecoTracker/LSTCore/src/alpaka/Segment.h
@@ -31,7 +31,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     unsigned int* nSegments;             //number of segments per inner lower module
     unsigned int* totOccupancySegments;  //number of segments per inner lower module
     uint4* pLSHitsIdxs;
-    int* pixelType;
+    int8_t* pixelType;
     char* isQuad;
     char* isDup;
     bool* partOfPT5;
@@ -107,7 +107,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     Buf<TDev, unsigned int> nSegments_buf;
     Buf<TDev, unsigned int> totOccupancySegments_buf;
     Buf<TDev, uint4> pLSHitsIdxs_buf;
-    Buf<TDev, int> pixelType_buf;
+    Buf<TDev, int8_t> pixelType_buf;
     Buf<TDev, char> isQuad_buf;
     Buf<TDev, char> isDup_buf;
     Buf<TDev, bool> partOfPT5_buf;
@@ -150,7 +150,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
           nSegments_buf(allocBufWrapper<unsigned int>(devAccIn, nLowerModules + 1, queue)),
           totOccupancySegments_buf(allocBufWrapper<unsigned int>(devAccIn, nLowerModules + 1, queue)),
           pLSHitsIdxs_buf(allocBufWrapper<uint4>(devAccIn, maxPixelSegments, queue)),
-          pixelType_buf(allocBufWrapper<int>(devAccIn, maxPixelSegments, queue)),
+          pixelType_buf(allocBufWrapper<int8_t>(devAccIn, maxPixelSegments, queue)),
           isQuad_buf(allocBufWrapper<char>(devAccIn, maxPixelSegments, queue)),
           isDup_buf(allocBufWrapper<char>(devAccIn, maxPixelSegments, queue)),
           partOfPT5_buf(allocBufWrapper<bool>(devAccIn, maxPixelSegments, queue)),

--- a/RecoTracker/LSTCore/src/alpaka/Segment.h
+++ b/RecoTracker/LSTCore/src/alpaka/Segment.h
@@ -31,7 +31,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     unsigned int* nSegments;             //number of segments per inner lower module
     unsigned int* totOccupancySegments;  //number of segments per inner lower module
     uint4* pLSHitsIdxs;
-    int8_t* pixelType;
+    int* pixelType;
     char* isQuad;
     char* isDup;
     bool* partOfPT5;
@@ -107,7 +107,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     Buf<TDev, unsigned int> nSegments_buf;
     Buf<TDev, unsigned int> totOccupancySegments_buf;
     Buf<TDev, uint4> pLSHitsIdxs_buf;
-    Buf<TDev, int8_t> pixelType_buf;
+    Buf<TDev, int> pixelType_buf;
     Buf<TDev, char> isQuad_buf;
     Buf<TDev, char> isDup_buf;
     Buf<TDev, bool> partOfPT5_buf;
@@ -150,7 +150,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
           nSegments_buf(allocBufWrapper<unsigned int>(devAccIn, nLowerModules + 1, queue)),
           totOccupancySegments_buf(allocBufWrapper<unsigned int>(devAccIn, nLowerModules + 1, queue)),
           pLSHitsIdxs_buf(allocBufWrapper<uint4>(devAccIn, maxPixelSegments, queue)),
-          pixelType_buf(allocBufWrapper<int8_t>(devAccIn, maxPixelSegments, queue)),
+          pixelType_buf(allocBufWrapper<int>(devAccIn, maxPixelSegments, queue)),
           isQuad_buf(allocBufWrapper<char>(devAccIn, maxPixelSegments, queue)),
           isDup_buf(allocBufWrapper<char>(devAccIn, maxPixelSegments, queue)),
           partOfPT5_buf(allocBufWrapper<bool>(devAccIn, maxPixelSegments, queue)),

--- a/RecoTracker/LSTCore/standalone/bin/lst.cc
+++ b/RecoTracker/LSTCore/standalone/bin/lst.cc
@@ -338,7 +338,7 @@ void run_lst() {
   std::vector<std::vector<int>> out_charge_vec;
   std::vector<std::vector<unsigned int>> out_seedIdx_vec;
   std::vector<std::vector<int>> out_superbin_vec;
-  std::vector<std::vector<int8_t>> out_pixelType_vec;
+  std::vector<std::vector<::lst::PixelType>> out_pixelType_vec;
   std::vector<std::vector<char>> out_isQuad_vec;
   std::vector<int> evt_num;
   std::vector<TString> file_name;

--- a/RecoTracker/LSTCore/standalone/bin/lst.cc
+++ b/RecoTracker/LSTCore/standalone/bin/lst.cc
@@ -338,7 +338,7 @@ void run_lst() {
   std::vector<std::vector<int>> out_charge_vec;
   std::vector<std::vector<unsigned int>> out_seedIdx_vec;
   std::vector<std::vector<int>> out_superbin_vec;
-  std::vector<std::vector<int8_t>> out_pixelType_vec;
+  std::vector<std::vector<int>> out_pixelType_vec;
   std::vector<std::vector<char>> out_isQuad_vec;
   std::vector<int> evt_num;
   std::vector<TString> file_name;

--- a/RecoTracker/LSTCore/standalone/bin/lst.cc
+++ b/RecoTracker/LSTCore/standalone/bin/lst.cc
@@ -338,7 +338,7 @@ void run_lst() {
   std::vector<std::vector<int>> out_charge_vec;
   std::vector<std::vector<unsigned int>> out_seedIdx_vec;
   std::vector<std::vector<int>> out_superbin_vec;
-  std::vector<std::vector<int>> out_pixelType_vec;
+  std::vector<std::vector<int8_t>> out_pixelType_vec;
   std::vector<std::vector<char>> out_isQuad_vec;
   std::vector<int> evt_num;
   std::vector<TString> file_name;

--- a/RecoTracker/LSTCore/standalone/code/core/trkCore.cc
+++ b/RecoTracker/LSTCore/standalone/code/core/trkCore.cc
@@ -610,7 +610,7 @@ void addInputsToLineSegmentTrackingPreLoad(std::vector<std::vector<float>> &out_
                                            std::vector<std::vector<int>> &out_charge_vec,
                                            std::vector<std::vector<unsigned int>> &out_seedIdx_vec,
                                            std::vector<std::vector<int>> &out_superbin_vec,
-                                           std::vector<std::vector<int8_t>> &out_pixelType_vec,
+                                           std::vector<std::vector<::lst::PixelType>> &out_pixelType_vec,
                                            std::vector<std::vector<char>> &out_isQuad_vec) {
   unsigned int count = 0;
   auto n_see = trk.see_stateTrajGlbPx().size();
@@ -651,7 +651,7 @@ void addInputsToLineSegmentTrackingPreLoad(std::vector<std::vector<float>> &out_
   std::vector<unsigned int> hitIdxs(trk.ph2_detId().size());
 
   std::vector<int> superbin_vec;
-  std::vector<int8_t> pixelType_vec;
+  std::vector<::lst::PixelType> pixelType_vec;
   std::vector<char> isQuad_vec;
   std::iota(hitIdxs.begin(), hitIdxs.end(), 0);
   const int hit_size = trkX.size();
@@ -718,14 +718,14 @@ void addInputsToLineSegmentTrackingPreLoad(std::vector<std::vector<float>> &out_
       int charge = trk.see_q()[iSeed];
       unsigned int seedIdx = iSeed;
 
-      int pixtype = -1;
+      ::lst::PixelType pixtype = ::lst::PixelType::kInvalid;
       if (ptIn >= 2.0) {
-        pixtype = static_cast<int8_t>(::lst::PixelType::kHighPt);
+        pixtype = ::lst::PixelType::kHighPt;
       } else if (ptIn >= (PT_CUT - 2 * ptErr) and ptIn < 2.0) {
         if (pixelSegmentDeltaPhiChange >= 0) {
-          pixtype = static_cast<int8_t>(::lst::PixelType::kLowPtPosCurv);
+          pixtype = ::lst::PixelType::kLowPtPosCurv;
         } else {
-          pixtype = static_cast<int8_t>(::lst::PixelType::kLowPtNegCurv);
+          pixtype = ::lst::PixelType::kLowPtNegCurv;
         }
       } else {
         continue;
@@ -865,7 +865,7 @@ float addInputsToEventPreLoad(LSTEvent *event,
                               std::vector<int> charge_vec,
                               std::vector<unsigned int> seedIdx_vec,
                               std::vector<int> superbin_vec,
-                              std::vector<int8_t> pixelType_vec,
+                              std::vector<::lst::PixelType> pixelType_vec,
                               std::vector<char> isQuad_vec) {
   TStopwatch my_timer;
 

--- a/RecoTracker/LSTCore/standalone/code/core/trkCore.cc
+++ b/RecoTracker/LSTCore/standalone/code/core/trkCore.cc
@@ -710,6 +710,7 @@ void addInputsToLineSegmentTrackingPreLoad(std::vector<std::vector<float>> &out_
       TVector3 seedSD_r3 = r3LH;
       TVector3 seedSD_p3 = p3LH;
 
+      // The charge could be used directly in the line below
       float pixelSegmentDeltaPhiChange = r3LH.DeltaPhi(p3LH);
       float etaErr = trk.see_etaErr()[iSeed];
       float px = p3LH.X();

--- a/RecoTracker/LSTCore/standalone/code/core/trkCore.cc
+++ b/RecoTracker/LSTCore/standalone/code/core/trkCore.cc
@@ -610,7 +610,7 @@ void addInputsToLineSegmentTrackingPreLoad(std::vector<std::vector<float>> &out_
                                            std::vector<std::vector<int>> &out_charge_vec,
                                            std::vector<std::vector<unsigned int>> &out_seedIdx_vec,
                                            std::vector<std::vector<int>> &out_superbin_vec,
-                                           std::vector<std::vector<int8_t>> &out_pixelType_vec,
+                                           std::vector<std::vector<int>> &out_pixelType_vec,
                                            std::vector<std::vector<char>> &out_isQuad_vec) {
   unsigned int count = 0;
   auto n_see = trk.see_stateTrajGlbPx().size();
@@ -651,7 +651,7 @@ void addInputsToLineSegmentTrackingPreLoad(std::vector<std::vector<float>> &out_
   std::vector<unsigned int> hitIdxs(trk.ph2_detId().size());
 
   std::vector<int> superbin_vec;
-  std::vector<int8_t> pixelType_vec;
+  std::vector<int> pixelType_vec;
   std::vector<char> isQuad_vec;
   std::iota(hitIdxs.begin(), hitIdxs.end(), 0);
   const int hit_size = trkX.size();
@@ -718,17 +718,14 @@ void addInputsToLineSegmentTrackingPreLoad(std::vector<std::vector<float>> &out_
       int charge = trk.see_q()[iSeed];
       unsigned int seedIdx = iSeed;
 
-      // get pixel superbin
-      // int ptbin = -1;
       int pixtype = -1;
-      if (ptIn >= 2.0) { /*ptbin = 1;*/
-        pixtype = 0;
+      if (ptIn >= 2.0) {
+        pixtype = static_cast<int>(::lst::kPixelType::highPt);
       } else if (ptIn >= (PT_CUT - 2 * ptErr) and ptIn < 2.0) {
-        // ptbin = 0;
         if (pixelSegmentDeltaPhiChange >= 0) {
-          pixtype = 1;
+          pixtype = static_cast<int>(::lst::kPixelType::lowPtPosCurv);
         } else {
-          pixtype = 2;
+          pixtype = static_cast<int>(::lst::kPixelType::lowPtNegCurv);
         }
       } else {
         continue;
@@ -868,7 +865,7 @@ float addInputsToEventPreLoad(LSTEvent *event,
                               std::vector<int> charge_vec,
                               std::vector<unsigned int> seedIdx_vec,
                               std::vector<int> superbin_vec,
-                              std::vector<int8_t> pixelType_vec,
+                              std::vector<int> pixelType_vec,
                               std::vector<char> isQuad_vec) {
   TStopwatch my_timer;
 
@@ -1139,213 +1136,4 @@ void writeMetaData() {
   // Write the TRACKLOOPERDIR
   TNamed tracklooper_path("tracklooper_path", ana.track_looper_dir_path.Data());
   tracklooper_path.Write();
-}
-
-//  ---------------------------------- =========================================== ----------------------------------------------
-//  ---------------------------------- =========================================== ----------------------------------------------
-//  ---------------------------------- =========================================== ----------------------------------------------
-//  ---------------------------------- =========================================== ----------------------------------------------
-//  ---------------------------------- =========================================== ----------------------------------------------
-
-// DEPRECATED FUNCTIONS
-
-//__________________________________________________________________________________________
-[[deprecated]] float addInputsToLineSegmentTracking(LSTEvent &event, bool useOMP) {
-  TStopwatch my_timer;
-  if (ana.verbose >= 2)
-    std::cout << "Loading Inputs (i.e. outer tracker hits, and pixel line segements) to the Line Segment Tracking.... "
-              << std::endl;
-  my_timer.Start();
-
-  unsigned int count = 0;
-  std::vector<float> px_vec;
-  std::vector<float> py_vec;
-  std::vector<float> pz_vec;
-  std::vector<unsigned int> hitIndices_vec0;
-  std::vector<unsigned int> hitIndices_vec1;
-  std::vector<unsigned int> hitIndices_vec2;
-  std::vector<unsigned int> hitIndices_vec3;
-  std::vector<float> ptIn_vec;
-  std::vector<float> ptErr_vec;
-  std::vector<float> etaErr_vec;
-  std::vector<float> eta_vec;
-  std::vector<float> phi_vec;
-  std::vector<int> charge_vec;
-  std::vector<unsigned int> seedIdx_vec;
-  std::vector<float> deltaPhi_vec;
-  std::vector<float> trkX = trk.ph2_x();
-  std::vector<float> trkY = trk.ph2_y();
-  std::vector<float> trkZ = trk.ph2_z();
-  std::vector<unsigned int> hitId = trk.ph2_detId();
-  std::vector<unsigned int> hitIdxs(trk.ph2_detId().size());
-  std::vector<int> superbin_vec;
-  std::vector<int8_t> pixelType_vec;
-  std::vector<char> isQuad_vec;
-  std::iota(hitIdxs.begin(), hitIdxs.end(), 0);
-  const int hit_size = trkX.size();
-
-  for (size_t iSeed = 0; iSeed < trk.see_stateTrajGlbPx().size(); ++iSeed) {
-    bool good_seed_type = false;
-    if (trk.see_algo()[iSeed] == 4)
-      good_seed_type = true;
-    // if (trk.see_algo()[iSeed] == 5) good_seed_type = true;
-    // if (trk.see_algo()[iSeed] == 7) good_seed_type = true;
-    if (trk.see_algo()[iSeed] == 22)
-      good_seed_type = true;
-    // if (trk.see_algo()[iSeed] == 23) good_seed_type = true;
-    // if (trk.see_algo()[iSeed] == 24) good_seed_type = true;
-    if (not good_seed_type)
-      continue;
-
-    TVector3 p3LH(trk.see_stateTrajGlbPx()[iSeed], trk.see_stateTrajGlbPy()[iSeed], trk.see_stateTrajGlbPz()[iSeed]);
-    float ptIn = p3LH.Pt();
-    float ptErr = trk.see_ptErr()[iSeed];
-    float eta = p3LH.Eta();
-
-    if ((ptIn > 0.8 - 2 * ptErr)) {
-      TVector3 r3LH(trk.see_stateTrajGlbX()[iSeed], trk.see_stateTrajGlbY()[iSeed], trk.see_stateTrajGlbZ()[iSeed]);
-      TVector3 p3PCA(trk.see_px()[iSeed], trk.see_py()[iSeed], trk.see_pz()[iSeed]);
-      TVector3 r3PCA(calculateR3FromPCA(p3PCA, trk.see_dxy()[iSeed], trk.see_dz()[iSeed]));
-
-      TVector3 seedSD_mdRef_r3 = r3PCA;
-      TVector3 seedSD_mdOut_r3 = r3LH;
-      TVector3 seedSD_r3 = r3LH;
-      TVector3 seedSD_p3 = p3LH;
-
-      float pixelSegmentDeltaPhiChange = r3LH.DeltaPhi(p3LH);
-      float etaErr = trk.see_etaErr()[iSeed];
-      float px = p3LH.X();
-      float py = p3LH.Y();
-      float pz = p3LH.Z();
-      float phi = p3LH.Phi();
-      int charge = trk.see_q()[iSeed];
-      unsigned int seedIdx = iSeed;
-      // extra bit
-
-      // get pixel superbin
-      // int ptbin = -1;
-      int pixtype = -1;
-      if (ptIn >= 2.0) { /*ptbin = 1;*/
-        pixtype = 0;
-      } else if (ptIn >= (0.8 - 2 * ptErr) and ptIn < 2.0) {
-        // ptbin = 0;
-        if (pixelSegmentDeltaPhiChange >= 0) {
-          pixtype = 1;
-        } else {
-          pixtype = 2;
-        }
-      } else {
-        continue;
-      }
-
-      unsigned int hitIdx0 = hit_size + count;
-      count++;
-
-      unsigned int hitIdx1 = hit_size + count;
-      count++;
-
-      unsigned int hitIdx2 = hit_size + count;
-      count++;
-
-      unsigned int hitIdx3;
-      if (trk.see_hitIdx()[iSeed].size() <= 3) {
-        hitIdx3 = hitIdx2;
-      } else {
-        hitIdx3 = hit_size + count;
-        count++;
-      }
-
-      trkX.push_back(r3PCA.X());
-      trkY.push_back(r3PCA.Y());
-      trkZ.push_back(r3PCA.Z());
-      trkX.push_back(p3PCA.Pt());
-      float p3PCA_Eta = p3PCA.Eta();
-      trkY.push_back(p3PCA_Eta);
-      float p3PCA_Phi = p3PCA.Phi();
-      trkZ.push_back(p3PCA_Phi);
-      trkX.push_back(r3LH.X());
-      trkY.push_back(r3LH.Y());
-      trkZ.push_back(r3LH.Z());
-      hitId.push_back(1);
-      hitId.push_back(1);
-      hitId.push_back(1);
-      if (trk.see_hitIdx()[iSeed].size() > 3) {
-        trkX.push_back(r3LH.X());
-        trkY.push_back(trk.see_dxy()[iSeed]);
-        trkZ.push_back(trk.see_dz()[iSeed]);
-        hitId.push_back(1);
-      }
-      px_vec.push_back(px);
-      py_vec.push_back(py);
-      pz_vec.push_back(pz);
-
-      hitIndices_vec0.push_back(hitIdx0);
-      hitIndices_vec1.push_back(hitIdx1);
-      hitIndices_vec2.push_back(hitIdx2);
-      hitIndices_vec3.push_back(hitIdx3);
-      ptIn_vec.push_back(ptIn);
-      ptErr_vec.push_back(ptErr);
-      etaErr_vec.push_back(etaErr);
-      eta_vec.push_back(eta);
-      phi_vec.push_back(phi);
-      charge_vec.push_back(charge);
-      seedIdx_vec.push_back(seedIdx);
-      deltaPhi_vec.push_back(pixelSegmentDeltaPhiChange);
-
-      // For matching with sim tracks
-      hitIdxs.push_back(trk.see_hitIdx()[iSeed][0]);
-      hitIdxs.push_back(trk.see_hitIdx()[iSeed][1]);
-      hitIdxs.push_back(trk.see_hitIdx()[iSeed][2]);
-      char isQuad = false;
-      if (trk.see_hitIdx()[iSeed].size() > 3) {
-        isQuad = true;
-        hitIdxs.push_back(trk.see_hitIdx()[iSeed].size() > 3 ? trk.see_hitIdx()[iSeed][3] : trk.see_hitIdx()[iSeed][2]);
-      }
-      // if (pt < 0){ ptbin = 0;}
-      float neta = 25.;
-      float nphi = 72.;
-      float nz = 25.;
-      int etabin = (p3PCA_Eta + 2.6) / ((2 * 2.6) / neta);
-      int phibin = (p3PCA_Phi + 3.14159265358979323846) / ((2. * 3.14159265358979323846) / nphi);
-      int dzbin = (trk.see_dz()[iSeed] + 30) / (2 * 30 / nz);
-      int isuperbin =
-          /*(nz * nphi * neta) * ptbin + (removed since pt bin is determined by pixelType)*/ (nz * nphi) * etabin +
-          (nz)*phibin + dzbin;
-      // if(isuperbin<0 || isuperbin>=44900){printf("isuperbin %d %d %d %d %f\n",isuperbin,etabin,phibin,dzbin,p3PCA.Eta());}
-      superbin_vec.push_back(isuperbin);
-      pixelType_vec.push_back(pixtype);
-      isQuad_vec.push_back(isQuad);
-    }
-  }
-
-  event.addHitToEvent(trkX, trkY, trkZ, hitId, hitIdxs);
-  event.addPixelSegmentToEvent(hitIndices_vec0,
-                               hitIndices_vec1,
-                               hitIndices_vec2,
-                               hitIndices_vec3,
-                               deltaPhi_vec,
-                               ptIn_vec,
-                               ptErr_vec,
-                               px_vec,
-                               py_vec,
-                               pz_vec,
-                               eta_vec,
-                               etaErr_vec,
-                               phi_vec,
-                               charge_vec,
-                               seedIdx_vec,
-                               superbin_vec,
-                               pixelType_vec,
-                               isQuad_vec);
-
-  event.wait();  // device side event calls are asynchronous: wait to measure time or print
-  float hit_loading_elapsed = my_timer.RealTime();
-  if (ana.verbose >= 2)
-    std::cout << "Loading inputs processing time: " << hit_loading_elapsed << " secs" << std::endl;
-  return hit_loading_elapsed;
-}
-
-//__________________________________________________________________________________________
-[[deprecated]] float addInputsToLineSegmentTrackingUsingExplicitMemory(LSTEvent &event) {
-  return addInputsToLineSegmentTracking(event, true);
 }

--- a/RecoTracker/LSTCore/standalone/code/core/trkCore.cc
+++ b/RecoTracker/LSTCore/standalone/code/core/trkCore.cc
@@ -610,7 +610,7 @@ void addInputsToLineSegmentTrackingPreLoad(std::vector<std::vector<float>> &out_
                                            std::vector<std::vector<int>> &out_charge_vec,
                                            std::vector<std::vector<unsigned int>> &out_seedIdx_vec,
                                            std::vector<std::vector<int>> &out_superbin_vec,
-                                           std::vector<std::vector<int>> &out_pixelType_vec,
+                                           std::vector<std::vector<int8_t>> &out_pixelType_vec,
                                            std::vector<std::vector<char>> &out_isQuad_vec) {
   unsigned int count = 0;
   auto n_see = trk.see_stateTrajGlbPx().size();
@@ -651,7 +651,7 @@ void addInputsToLineSegmentTrackingPreLoad(std::vector<std::vector<float>> &out_
   std::vector<unsigned int> hitIdxs(trk.ph2_detId().size());
 
   std::vector<int> superbin_vec;
-  std::vector<int> pixelType_vec;
+  std::vector<int8_t> pixelType_vec;
   std::vector<char> isQuad_vec;
   std::iota(hitIdxs.begin(), hitIdxs.end(), 0);
   const int hit_size = trkX.size();
@@ -720,12 +720,12 @@ void addInputsToLineSegmentTrackingPreLoad(std::vector<std::vector<float>> &out_
 
       int pixtype = -1;
       if (ptIn >= 2.0) {
-        pixtype = static_cast<int>(::lst::kPixelType::highPt);
+        pixtype = static_cast<int8_t>(::lst::PixelType::kHighPt);
       } else if (ptIn >= (PT_CUT - 2 * ptErr) and ptIn < 2.0) {
         if (pixelSegmentDeltaPhiChange >= 0) {
-          pixtype = static_cast<int>(::lst::kPixelType::lowPtPosCurv);
+          pixtype = static_cast<int8_t>(::lst::PixelType::kLowPtPosCurv);
         } else {
-          pixtype = static_cast<int>(::lst::kPixelType::lowPtNegCurv);
+          pixtype = static_cast<int8_t>(::lst::PixelType::kLowPtNegCurv);
         }
       } else {
         continue;
@@ -865,7 +865,7 @@ float addInputsToEventPreLoad(LSTEvent *event,
                               std::vector<int> charge_vec,
                               std::vector<unsigned int> seedIdx_vec,
                               std::vector<int> superbin_vec,
-                              std::vector<int> pixelType_vec,
+                              std::vector<int8_t> pixelType_vec,
                               std::vector<char> isQuad_vec) {
   TStopwatch my_timer;
 

--- a/RecoTracker/LSTCore/standalone/code/core/trkCore.h
+++ b/RecoTracker/LSTCore/standalone/code/core/trkCore.h
@@ -68,7 +68,7 @@ void addInputsToLineSegmentTrackingPreLoad(std::vector<std::vector<float>> &out_
                                            std::vector<std::vector<int>> &out_charge_vec,
                                            std::vector<std::vector<unsigned int>> &out_seedIdx_vec,
                                            std::vector<std::vector<int>> &out_superbin_vec,
-                                           std::vector<std::vector<int8_t>> &out_pixelType_vec,
+                                           std::vector<std::vector<::lst::PixelType>> &out_pixelType_vec,
                                            std::vector<std::vector<char>> &out_isQuad_vec);
 
 float addInputsToEventPreLoad(LSTEvent *event,
@@ -94,7 +94,7 @@ float addInputsToEventPreLoad(LSTEvent *event,
                               std::vector<int> charge_vec,
                               std::vector<unsigned int> seedIdx_vec,
                               std::vector<int> superbin_vec,
-                              std::vector<int8_t> pixelType_vec,
+                              std::vector<::lst::PixelType> pixelType_vec,
                               std::vector<char> isQuad_vec);
 
 void printTimingInformation(std::vector<std::vector<float>> &timing_information, float fullTime, float fullavg);

--- a/RecoTracker/LSTCore/standalone/code/core/trkCore.h
+++ b/RecoTracker/LSTCore/standalone/code/core/trkCore.h
@@ -68,7 +68,7 @@ void addInputsToLineSegmentTrackingPreLoad(std::vector<std::vector<float>> &out_
                                            std::vector<std::vector<int>> &out_charge_vec,
                                            std::vector<std::vector<unsigned int>> &out_seedIdx_vec,
                                            std::vector<std::vector<int>> &out_superbin_vec,
-                                           std::vector<std::vector<int8_t>> &out_pixelType_vec,
+                                           std::vector<std::vector<int>> &out_pixelType_vec,
                                            std::vector<std::vector<char>> &out_isQuad_vec);
 
 float addInputsToEventPreLoad(LSTEvent *event,
@@ -94,7 +94,7 @@ float addInputsToEventPreLoad(LSTEvent *event,
                               std::vector<int> charge_vec,
                               std::vector<unsigned int> seedIdx_vec,
                               std::vector<int> superbin_vec,
-                              std::vector<int8_t> pixelType_vec,
+                              std::vector<int> pixelType_vec,
                               std::vector<char> isQuad_vec);
 
 void printTimingInformation(std::vector<std::vector<float>> &timing_information, float fullTime, float fullavg);

--- a/RecoTracker/LSTCore/standalone/code/core/trkCore.h
+++ b/RecoTracker/LSTCore/standalone/code/core/trkCore.h
@@ -68,7 +68,7 @@ void addInputsToLineSegmentTrackingPreLoad(std::vector<std::vector<float>> &out_
                                            std::vector<std::vector<int>> &out_charge_vec,
                                            std::vector<std::vector<unsigned int>> &out_seedIdx_vec,
                                            std::vector<std::vector<int>> &out_superbin_vec,
-                                           std::vector<std::vector<int>> &out_pixelType_vec,
+                                           std::vector<std::vector<int8_t>> &out_pixelType_vec,
                                            std::vector<std::vector<char>> &out_isQuad_vec);
 
 float addInputsToEventPreLoad(LSTEvent *event,
@@ -94,7 +94,7 @@ float addInputsToEventPreLoad(LSTEvent *event,
                               std::vector<int> charge_vec,
                               std::vector<unsigned int> seedIdx_vec,
                               std::vector<int> superbin_vec,
-                              std::vector<int> pixelType_vec,
+                              std::vector<int8_t> pixelType_vec,
                               std::vector<char> isQuad_vec);
 
 void printTimingInformation(std::vector<std::vector<float>> &timing_information, float fullTime, float fullavg);


### PR DESCRIPTION
Small and quick fixes to trim down the list of unresolved comments in the cmssw PR. It resolves:
- Simplify `consumes()`, `esConsumes()`, `produces()`:
  - https://github.com/cms-sw/cmssw/pull/45117#discussion_r1718844864
- Make some data members private (not all data members could be made private, and a comment was added about it to the gDoc with the comments to not be implemented):
  - https://github.com/cms-sw/cmssw/pull/45117#discussion_r1718856633
- Revise some `include`s:
  - https://github.com/cms-sw/cmssw/pull/45117#discussion_r1718855152
  - https://github.com/cms-sw/cmssw/pull/45117#discussion_r1718875123
  - https://github.com/cms-sw/cmssw/pull/45117#discussion_r1718878225
- Some work on `pixelType`:
  - https://github.com/cms-sw/cmssw/pull/45117#discussion_r1718876621
  - https://github.com/cms-sw/cmssw/pull/45117#discussion_r1718945419
  - https://github.com/cms-sw/cmssw/pull/45117#discussion_r1718959670