### PR TITLE
[DO NOT MERGE] Single iteration Patatrack and LST in HLT

### DIFF
--- a/Configuration/ProcessModifiers/python/seedingLST_cff.py
+++ b/Configuration/ProcessModifiers/python/seedingLST_cff.py
@@ -1,0 +1,5 @@
+import FWCore.ParameterSet.Config as cms
+
+# This modifier sets the LST (Phase-2 line segment tracking) used for track seeding
+# Needs to be used on top of the trackingLST modifier
+seedingLST = cms.Modifier()

--- a/Configuration/ProcessModifiers/python/singleIterPatatrack_cff.py
+++ b/Configuration/ProcessModifiers/python/singleIterPatatrack_cff.py
@@ -1,0 +1,6 @@
+import FWCore.ParameterSet.Config as cms
+
+# This modifier merges the initialStep and highPtTripletStep iterations
+# to a single iteration using Patatrack pixel tracks with >3 hits as seeds
+singleIterPatatrack = cms.Modifier()
+

--- a/DQMOffline/Trigger/python/TrackingMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/TrackingMonitoring_cff.py
@@ -118,6 +118,53 @@ phase2_tracker.toModify(iterHLTTracksMonitoringHLT,
                         TrackProducer    = 'hltGeneralTracks',
                         allTrackProducer = 'hltGeneralTracks')
 
+# LST track collections
+initialSteppTTCLSTTracksMonitoringHLT = trackingMonHLT.clone(
+    FolderName       = 'HLT/Tracking/initialStepTrackSelectionHighPuritypTTCLST',
+    TrackProducer    = 'hltInitialStepTrackSelectionHighPuritypTTCLST',
+    allTrackProducer = 'hltInitialStepTrackSelectionHighPuritypTTCLST',
+    doEffFromHitPatternVsPU   = False,
+    doEffFromHitPatternVsBX   = False,
+    doEffFromHitPatternVsLUMI = False
+)
+
+initialSteppLSTCLSTTracksMonitoringHLT = trackingMonHLT.clone(
+    FolderName       = 'HLT/Tracking/initialStepTrackSelectionHighPuritypLSTCLST',
+    TrackProducer    = 'hltInitialStepTrackSelectionHighPuritypLSTCLST',
+    allTrackProducer = 'hltInitialStepTrackSelectionHighPuritypLSTCLST',
+    doEffFromHitPatternVsPU   = False,
+    doEffFromHitPatternVsBX   = False,
+    doEffFromHitPatternVsLUMI = False
+)
+
+initialStepT5TCLSTTracksMonitoringHLT = trackingMonHLT.clone(
+    FolderName       = 'HLT/Tracking/initialStepTracksT5TCLST',
+    TrackProducer    = 'hltInitialStepTracksT5TCLST',
+    allTrackProducer = 'hltInitialStepTracksT5TCLST',
+    doEffFromHitPatternVsPU   = False,
+    doEffFromHitPatternVsBX   = False,
+    doEffFromHitPatternVsLUMI = False
+)
+
+highPtTripletSteppLSTCLSTTracksMonitoringHLT = trackingMonHLT.clone(
+    FolderName       = 'HLT/Tracking/highPtTripletStepTrackSelectionHighPuritypLSTCLST',
+    TrackProducer    = 'hltHighPtTripletStepTrackSelectionHighPuritypLSTCLST',
+    allTrackProducer = 'hltHighPtTripletStepTrackSelectionHighPuritypLSTCLST',
+    doEffFromHitPatternVsPU   = False,
+    doEffFromHitPatternVsBX   = False,
+    doEffFromHitPatternVsLUMI = False
+)
+
+highPtTripletStepTracksMonitoringHLT = trackingMonHLT.clone(
+    FolderName       = 'HLT/Tracking/highPtTripletStepTrackSelectionHighPurity',
+    TrackProducer    = 'hltHighPtTripletStepTrackSelectionHighPurity',
+    allTrackProducer = 'hltHighPtTripletStepTrackSelectionHighPurity',
+    doEffFromHitPatternVsPU   = False,
+    doEffFromHitPatternVsBX   = False,
+    doEffFromHitPatternVsLUMI = False
+)
+
+
 iter3TracksMonitoringHLT = trackingMonHLT.clone(
     FolderName       = 'HLT/Tracking/iter3Merged',
     TrackProducer    = 'hltIter3Merged',
@@ -250,6 +297,11 @@ trkHLTDQMSourceExtra = cms.Sequence(
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
 run3_common.toReplaceWith(trackingMonitorHLT, cms.Sequence(pixelTracksMonitoringHLT + iterHLTTracksMonitoringHLT + doubletRecoveryHPTracksMonitoringHLT )) # + iter0HPTracksMonitoringHLT ))
 phase2_tracker.toReplaceWith(trackingMonitorHLT, cms.Sequence(pixelTracksMonitoringHLT + iterHLTTracksMonitoringHLT))
+
+from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
+trackingLST.toReplaceWith(trackingMonitorHLT, cms.Sequence(pixelTracksMonitoringHLT + iterHLTTracksMonitoringHLT + initialSteppTTCLSTTracksMonitoringHLT + initialSteppLSTCLSTTracksMonitoringHLT + initialStepT5TCLSTTracksMonitoringHLT + highPtTripletStepTracksMonitoringHLT))
+from Configuration.ProcessModifiers.seedingLST_cff import seedingLST
+(seedingLST & trackingLST).toReplaceWith(trackingMonitorHLT, cms.Sequence(pixelTracksMonitoringHLT + iterHLTTracksMonitoringHLT + initialSteppTTCLSTTracksMonitoringHLT + initialStepT5TCLSTTracksMonitoringHLT + highPtTripletSteppLSTCLSTTracksMonitoringHLT))
 
 run3_common.toReplaceWith(trackingMonitorHLTall, cms.Sequence(pixelTracksMonitoringHLT + iter0TracksMonitoringHLT + iterHLTTracksMonitoringHLT))
 run3_common.toReplaceWith(egmTrackingMonitorHLT, cms.Sequence(gsfTracksMonitoringHLT))

--- a/HLTrigger/Configuration/python/HLT_75e33/eventsetup/hltESPModulesDevLST_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/eventsetup/hltESPModulesDevLST_cfi.py
@@ -1,0 +1,12 @@
+import FWCore.ParameterSet.Config as cms
+
+def _addProcessModulesDevLST(process):
+    process.hltESPModulesDevLST = cms.ESProducer('LSTModulesDevESProducer@alpaka',
+        appendToDataLabel = cms.string(''),
+        alpaka = cms.untracked.PSet(
+          backend = cms.untracked.string('')
+        )
+    )
+
+from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
+modifyConfigurationForTrackingLSTModulesDevLST_ = trackingLST.makeProcessModifier(_addProcessModulesDevLST)

--- a/HLTrigger/Configuration/python/HLT_75e33/eventsetup/hltESPTTRHBuilderWithoutRefit_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/eventsetup/hltESPTTRHBuilderWithoutRefit_cfi.py
@@ -1,0 +1,14 @@
+import FWCore.ParameterSet.Config as cms
+
+def _addProcessTTRHBuilderWithoutRefit(process):
+    process.hltESPTTRHBuilderWithoutRefit = cms.ESProducer("TkTransientTrackingRecHitBuilderESProducer",
+        ComponentName = cms.string('WithoutRefit'),
+        ComputeCoarseLocalPositionFromDisk = cms.bool(False),
+        Matcher = cms.string('Fake'),
+        Phase2StripCPE = cms.string(''),
+        PixelCPE = cms.string('Fake'),
+        StripCPE = cms.string('Fake')
+    )
+
+from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
+modifyConfigurationForTrackingLSTTTRHBuilderWithoutRefit_ = trackingLST.makeProcessModifier(_addProcessTTRHBuilderWithoutRefit)

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltGeneralTracks_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltGeneralTracks_cfi.py
@@ -24,3 +24,31 @@ hltGeneralTracks = cms.EDProducer("TrackListMerger",
     trackAlgoPriorityOrder = cms.string('trackAlgoPriorityOrder'),
     writeOnlyTrkQuals = cms.bool(False)
 )
+
+_hltGeneralTracksLST = hltGeneralTracks.clone(
+    TrackProducers = cms.VInputTag("hltInitialStepTrackSelectionHighPuritypTTCLST", "hltInitialStepTrackSelectionHighPuritypLSTCLST", "hltInitialStepTracksT5TCLST", "hltHighPtTripletStepTrackSelectionHighPurity"),
+    hasSelector = cms.vint32(0,0,0,0),
+    indivShareFrac = cms.vdouble(0.1,0.1,0.1,0.1),
+    selectedTrackQuals = cms.VInputTag(cms.InputTag("hltInitialStepTrackSelectionHighPuritypTTCLST"), cms.InputTag("hltInitialStepTrackSelectionHighPuritypLSTCLST"), cms.InputTag("hltInitialStepTracksT5TCLST"), cms.InputTag("hltHighPtTripletStepTrackSelectionHighPurity")),
+    setsToMerge = cms.VPSet(cms.PSet(
+        pQual = cms.bool(True),
+        tLists = cms.vint32(0,1,2,3)
+    ))
+)
+
+from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
+trackingLST.toReplaceWith(hltGeneralTracks, _hltGeneralTracksLST)
+
+_hltGeneralTracksLSTSeeding = hltGeneralTracks.clone(
+            TrackProducers = cms.VInputTag("hltInitialStepTrackSelectionHighPuritypTTCLST", "hltInitialStepTracksT5TCLST", "hltHighPtTripletStepTrackSelectionHighPuritypLSTCLST"),
+            hasSelector = cms.vint32(0,0,0),
+            indivShareFrac = cms.vdouble(0.1,0.1,0.1),
+            selectedTrackQuals = cms.VInputTag(cms.InputTag("hltInitialStepTrackSelectionHighPuritypTTCLST"), cms.InputTag("hltInitialStepTracksT5TCLST"), cms.InputTag("hltHighPtTripletStepTrackSelectionHighPuritypLSTCLST")),
+            setsToMerge = cms.VPSet(cms.PSet(
+               pQual = cms.bool(True),
+               tLists = cms.vint32(0,1,2)
+            ))
+    )
+
+from Configuration.ProcessModifiers.seedingLST_cff import seedingLST
+(seedingLST & trackingLST).toReplaceWith(hltGeneralTracks, _hltGeneralTracksLSTSeeding)

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltGeneralTracks_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltGeneralTracks_cfi.py
@@ -25,6 +25,20 @@ hltGeneralTracks = cms.EDProducer("TrackListMerger",
     writeOnlyTrkQuals = cms.bool(False)
 )
 
+_hltGeneralTracksSingleIterPatatrack = hltGeneralTracks.clone(
+    TrackProducers = cms.VInputTag("hltInitialStepTrackSelectionHighPurity"),
+    hasSelector = cms.vint32(0),
+    indivShareFrac = cms.vdouble(1.0),
+    selectedTrackQuals = cms.VInputTag(cms.InputTag("hltInitialStepTrackSelectionHighPurity")),
+    setsToMerge = cms.VPSet(cms.PSet(
+        pQual = cms.bool(True),
+        tLists = cms.vint32(0)
+    ))
+)
+
+from Configuration.ProcessModifiers.singleIterPatatrack_cff import singleIterPatatrack
+singleIterPatatrack.toReplaceWith(hltGeneralTracks, _hltGeneralTracksSingleIterPatatrack)
+
 _hltGeneralTracksLST = hltGeneralTracks.clone(
     TrackProducers = cms.VInputTag("hltInitialStepTrackSelectionHighPuritypTTCLST", "hltInitialStepTrackSelectionHighPuritypLSTCLST", "hltInitialStepTracksT5TCLST", "hltHighPtTripletStepTrackSelectionHighPurity"),
     hasSelector = cms.vint32(0,0,0,0),
@@ -38,6 +52,19 @@ _hltGeneralTracksLST = hltGeneralTracks.clone(
 
 from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
 trackingLST.toReplaceWith(hltGeneralTracks, _hltGeneralTracksLST)
+
+_hltGeneralTracksLSTSingleIterPatatrack = hltGeneralTracks.clone(
+    TrackProducers = cms.VInputTag("hltInitialStepTrackSelectionHighPuritypTTCLST", "hltInitialStepTrackSelectionHighPuritypLSTCLST", "hltInitialStepTracksT5TCLST"),
+    hasSelector = cms.vint32(0,0,0),
+    indivShareFrac = cms.vdouble(0.1,0.1,0.1),
+    selectedTrackQuals = cms.VInputTag(cms.InputTag("hltInitialStepTrackSelectionHighPuritypTTCLST"), cms.InputTag("hltInitialStepTrackSelectionHighPuritypLSTCLST"), cms.InputTag("hltInitialStepTracksT5TCLST")),
+    setsToMerge = cms.VPSet(cms.PSet(
+        pQual = cms.bool(True),
+        tLists = cms.vint32(0,1,2)
+    ))
+)
+
+(singleIterPatatrack & trackingLST).toReplaceWith(hltGeneralTracks, _hltGeneralTracksLSTSingleIterPatatrack)
 
 _hltGeneralTracksLSTSeeding = hltGeneralTracks.clone(
             TrackProducers = cms.VInputTag("hltInitialStepTrackSelectionHighPuritypTTCLST", "hltInitialStepTracksT5TCLST", "hltHighPtTripletStepTrackSelectionHighPuritypLSTCLST"),

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltHighPtTripletStepClusters_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltHighPtTripletStepClusters_cfi.py
@@ -12,3 +12,11 @@ hltHighPtTripletStepClusters = cms.EDProducer("TrackClusterRemoverPhase2",
     trackClassifier = cms.InputTag("","QualityMasks"),
     trajectories = cms.InputTag("hltInitialStepTrackSelectionHighPurity")
 )
+
+_hltHighPtTripletStepClustersLST = hltHighPtTripletStepClusters.clone(
+    trajectories = cms.InputTag("hltInitialStepSeedTracksLST")
+)
+
+from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
+trackingLST.toReplaceWith(hltHighPtTripletStepClusters, _hltHighPtTripletStepClustersLST)
+

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltHighPtTripletStepSeedTracksLST_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltHighPtTripletStepSeedTracksLST_cfi.py
@@ -1,0 +1,9 @@
+import FWCore.ParameterSet.Config as cms
+
+hltHighPtTripletStepSeedTracksLST = cms.EDProducer(
+    "TrackFromSeedProducer",
+    src = cms.InputTag("hltHighPtTripletStepSeeds"),
+    beamSpot = cms.InputTag("offlineBeamSpot"),
+    TTRHBuilder = cms.string("WithoutRefit")
+)
+

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltHighPtTripletStepTrackCandidatespLSTCLST_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltHighPtTripletStepTrackCandidatespLSTCLST_cfi.py
@@ -1,0 +1,5 @@
+import FWCore.ParameterSet.Config as cms
+
+from ..modules.hltHighPtTripletStepTrackCandidates_cfi import hltHighPtTripletStepTrackCandidates as _hltHighPtTripletStepTrackCandidates
+hltHighPtTripletStepTrackCandidatespLSTCLST = _hltHighPtTripletStepTrackCandidates.clone( src = cms.InputTag("hltInitialStepTrackCandidates:pLSTSsLST") )
+

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltHighPtTripletStepTrackCutClassifierpLSTCLST_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltHighPtTripletStepTrackCutClassifierpLSTCLST_cfi.py
@@ -1,0 +1,5 @@
+import FWCore.ParameterSet.Config as cms
+
+from ..modules.hltHighPtTripletStepTrackCutClassifier_cfi import hltHighPtTripletStepTrackCutClassifier as _hltHighPtTripletStepTrackCutClassifier
+hltHighPtTripletStepTrackCutClassifierpLSTCLST = _hltHighPtTripletStepTrackCutClassifier.clone( src = cms.InputTag("hltHighPtTripletStepTrackspLSTCLST") )
+

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltHighPtTripletStepTrackSelectionHighPuritypLSTCLST_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltHighPtTripletStepTrackSelectionHighPuritypLSTCLST_cfi.py
@@ -1,0 +1,9 @@
+import FWCore.ParameterSet.Config as cms
+
+from ..modules.hltHighPtTripletStepTrackSelectionHighPurity_cfi import hltHighPtTripletStepTrackSelectionHighPurity as _hltHighPtTripletStepTrackSelectionHighPurity
+hltHighPtTripletStepTrackSelectionHighPuritypLSTCLST = _hltHighPtTripletStepTrackSelectionHighPurity.clone(
+    originalMVAVals = cms.InputTag("hltHighPtTripletStepTrackCutClassifierpLSTCLST","MVAValues"),
+    originalQualVals = cms.InputTag("hltHighPtTripletStepTrackCutClassifierpLSTCLST","QualityMasks"),
+    originalSource = cms.InputTag("hltHighPtTripletStepTrackspLSTCLST")
+)
+

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltHighPtTripletStepTrackspLSTCLST_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltHighPtTripletStepTrackspLSTCLST_cfi.py
@@ -1,0 +1,5 @@
+import FWCore.ParameterSet.Config as cms
+
+from ..modules.hltHighPtTripletStepTracks_cfi import hltHighPtTripletStepTracks as _hltHighPtTripletStepTracks
+hltHighPtTripletStepTrackspLSTCLST = _hltHighPtTripletStepTracks.clone( src = cms.InputTag("hltHighPtTripletStepTrackCandidatespLSTCLST") )
+

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepSeedTracksLST_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepSeedTracksLST_cfi.py
@@ -1,0 +1,9 @@
+import FWCore.ParameterSet.Config as cms
+
+hltInitialStepSeedTracksLST = cms.EDProducer(
+    "TrackFromSeedProducer",
+    src = cms.InputTag("hltInitialStepSeeds"),
+    beamSpot = cms.InputTag("offlineBeamSpot"),
+    TTRHBuilder = cms.string("WithoutRefit")
+)
+

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepSeeds_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepSeeds_cfi.py
@@ -11,5 +11,9 @@ hltInitialStepSeeds = cms.EDProducer("SeedGeneratorFromProtoTracksEDProducer",
     originRadius = cms.double(0.1),
     useEventsWithNoVertex = cms.bool(True),
     usePV = cms.bool(False),
-    useProtoTrackKinematics = cms.bool(False)
+    useProtoTrackKinematics = cms.bool(False),
+    includeFourthHit = cms.bool(False)
 )
+
+from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
+trackingLST.toModify(hltInitialStepSeeds, includeFourthHit = cms.bool(True))

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrackCandidates_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrackCandidates_cfi.py
@@ -23,3 +23,27 @@ hltInitialStepTrackCandidates = cms.EDProducer("CkfTrackCandidateMaker",
     src = cms.InputTag("hltInitialStepSeeds"),
     useHitsSplitting = cms.bool(False)
 )
+
+_hltInitialStepTrackCandidatesLST = cms.EDProducer('LSTOutputConverter',
+    lstOutput = cms.InputTag('hltLST'),
+    phase2OTHits = cms.InputTag('hltPhase2OTHitsInputLST'),
+    lstPixelSeeds = cms.InputTag('hltPixelSeedInputLST'),
+    includeT5s = cms.bool(True),
+    includeNonpLSTSs = cms.bool(False),
+    propagatorAlong = cms.ESInputTag('', 'PropagatorWithMaterial'),
+    propagatorOpposite = cms.ESInputTag('', 'PropagatorWithMaterialOpposite'),
+    SeedCreatorPSet = cms.PSet(
+        ComponentName = cms.string('SeedFromConsecutiveHitsCreator'),
+        propagator = cms.string('PropagatorWithMaterial'),
+        SeedMomentumForBOFF = cms.double(5),
+        OriginTransverseErrorMultiplier = cms.double(1),
+        MinOneOverPtError = cms.double(1),
+        magneticField = cms.string(''),
+        TTRHBuilder = cms.string('WithTrackAngle'),
+        forceKinematicWithRegionDirection = cms.bool(False)
+    )
+)
+
+from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
+trackingLST.toReplaceWith(hltInitialStepTrackCandidates, _hltInitialStepTrackCandidatesLST)
+

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrackCandidates_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrackCandidates_cfi.py
@@ -47,3 +47,6 @@ _hltInitialStepTrackCandidatesLST = cms.EDProducer('LSTOutputConverter',
 from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
 trackingLST.toReplaceWith(hltInitialStepTrackCandidates, _hltInitialStepTrackCandidatesLST)
 
+from Configuration.ProcessModifiers.seedingLST_cff import seedingLST
+(seedingLST & trackingLST).toModify(hltInitialStepTrackCandidates, includeNonpLSTSs = cms.bool(True))
+

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrackCandidates_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrackCandidates_cfi.py
@@ -47,6 +47,3 @@ _hltInitialStepTrackCandidatesLST = cms.EDProducer('LSTOutputConverter',
 from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
 trackingLST.toReplaceWith(hltInitialStepTrackCandidates, _hltInitialStepTrackCandidatesLST)
 
-from Configuration.ProcessModifiers.seedingLST_cff import seedingLST
-(seedingLST & trackingLST).toModify(hltInitialStepTrackCandidates, includeNonpLSTSs = cms.bool(True))
-

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrackCutClassifierpLSTCLST_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrackCutClassifierpLSTCLST_cfi.py
@@ -1,0 +1,5 @@
+import FWCore.ParameterSet.Config as cms
+
+from ..modules.hltInitialStepTrackCutClassifier_cfi import hltInitialStepTrackCutClassifier as _hltInitialStepTrackCutClassifier
+hltInitialStepTrackCutClassifierpLSTCLST = _hltInitialStepTrackCutClassifier.clone( src = cms.InputTag("hltInitialStepTrackspLSTCLST") )
+

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrackCutClassifierpTTCLST_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrackCutClassifierpTTCLST_cfi.py
@@ -1,0 +1,5 @@
+import FWCore.ParameterSet.Config as cms
+
+from ..modules.hltInitialStepTrackCutClassifier_cfi import hltInitialStepTrackCutClassifier as _hltInitialStepTrackCutClassifier
+hltInitialStepTrackCutClassifierpTTCLST = _hltInitialStepTrackCutClassifier.clone( src = cms.InputTag("hltInitialStepTrackspTTCLST") )
+

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrackSelectionHighPuritypLSTCLST_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrackSelectionHighPuritypLSTCLST_cfi.py
@@ -1,0 +1,9 @@
+import FWCore.ParameterSet.Config as cms
+
+from ..modules.hltInitialStepTrackSelectionHighPurity_cfi import hltInitialStepTrackSelectionHighPurity as _hltInitialStepTrackSelectionHighPurity
+hltInitialStepTrackSelectionHighPuritypLSTCLST = _hltInitialStepTrackSelectionHighPurity.clone(
+    originalMVAVals = cms.InputTag("hltInitialStepTrackCutClassifierpLSTCLST","MVAValues"),
+    originalQualVals = cms.InputTag("hltInitialStepTrackCutClassifierpLSTCLST","QualityMasks"),
+    originalSource = cms.InputTag("hltInitialStepTrackspLSTCLST")
+)
+

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrackSelectionHighPuritypTTCLST_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrackSelectionHighPuritypTTCLST_cfi.py
@@ -1,0 +1,9 @@
+import FWCore.ParameterSet.Config as cms
+
+from ..modules.hltInitialStepTrackSelectionHighPurity_cfi import hltInitialStepTrackSelectionHighPurity as _hltInitialStepTrackSelectionHighPurity
+hltInitialStepTrackSelectionHighPuritypTTCLST = _hltInitialStepTrackSelectionHighPurity.clone(
+    originalMVAVals = cms.InputTag("hltInitialStepTrackCutClassifierpTTCLST","MVAValues"),
+    originalQualVals = cms.InputTag("hltInitialStepTrackCutClassifierpTTCLST","QualityMasks"),
+    originalSource = cms.InputTag("hltInitialStepTrackspTTCLST")
+)
+

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTracksT5TCLST_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTracksT5TCLST_cfi.py
@@ -1,0 +1,5 @@
+import FWCore.ParameterSet.Config as cms
+
+from ..modules.hltInitialStepTracks_cfi import hltInitialStepTracks as _hltInitialStepTracks
+hltInitialStepTracksT5TCLST = _hltInitialStepTracks.clone( src = cms.InputTag("hltInitialStepTrackCandidates:t5TCsLST") )
+

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrackspLSTCLST_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrackspLSTCLST_cfi.py
@@ -1,0 +1,5 @@
+import FWCore.ParameterSet.Config as cms
+
+from ..modules.hltInitialStepTracks_cfi import hltInitialStepTracks as _hltInitialStepTracks
+hltInitialStepTrackspLSTCLST = _hltInitialStepTracks.clone( src = cms.InputTag("hltInitialStepTrackCandidates:pLSTCsLST") )
+

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrackspTTCLST_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrackspTTCLST_cfi.py
@@ -1,0 +1,5 @@
+import FWCore.ParameterSet.Config as cms
+
+from ..modules.hltInitialStepTracks_cfi import hltInitialStepTracks as _hltInitialStepTracks
+hltInitialStepTrackspTTCLST = _hltInitialStepTracks.clone( src = cms.InputTag("hltInitialStepTrackCandidates:pTTCsLST") )
+

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltLST_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltLST_cfi.py
@@ -12,3 +12,8 @@ hltLST = cms.EDProducer('LSTProducer@alpaka',
     )
 )
 
+from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
+from Configuration.ProcessModifiers.seedingLST_cff import seedingLST
+(seedingLST & trackingLST).toModify(hltLST, nopLSDupClean = cms.bool(True),
+                                            tcpLSTriplets = cms.bool(True) )
+

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltLST_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltLST_cfi.py
@@ -1,0 +1,14 @@
+import FWCore.ParameterSet.Config as cms
+
+hltLST = cms.EDProducer('LSTProducer@alpaka',
+    pixelSeedInput = cms.InputTag('hltPixelSeedInputLST'),
+    phase2OTHitsInput = cms.InputTag('hltPhase2OTHitsInputLST'),
+    verbose = cms.bool(False),
+    nopLSDupClean = cms.bool(False),
+    tcpLSTriplets = cms.bool(False),
+    mightGet = cms.optional.untracked.vstring,
+    alpaka = cms.untracked.PSet(
+        backend = cms.untracked.string('')
+    )
+)
+

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltPhase2OTHitsInputLST_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltPhase2OTHitsInputLST_cfi.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+hltPhase2OTHitsInputLST = cms.EDProducer('LSTPhase2OTHitsInputProducer',
+    phase2OTRecHits = cms.InputTag('hltSiPhase2RecHits'),
+    mightGet = cms.optional.untracked.vstring
+)
+

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltPhase2PixelTracksSoA_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltPhase2PixelTracksSoA_cfi.py
@@ -41,3 +41,9 @@ hltPhase2PixelTracksSoA = cms.EDProducer('CAHitNtupletAlpakaPhase2@alpaka',
     # autoselect the alpaka backend
     alpaka = cms.untracked.PSet(backend = cms.untracked.string(''))
 )
+
+_hltPhase2PixelTracksSoASingleIterPatatrack = hltPhase2PixelTracksSoA.clone(minHitsPerNtuplet = cms.uint32(3))
+
+from Configuration.ProcessModifiers.singleIterPatatrack_cff import singleIterPatatrack
+singleIterPatatrack.toReplaceWith(hltPhase2PixelTracksSoA, _hltPhase2PixelTracksSoASingleIterPatatrack)
+

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltPixelSeedInputLST_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltPixelSeedInputLST_cfi.py
@@ -1,0 +1,10 @@
+import FWCore.ParameterSet.Config as cms
+
+hltPixelSeedInputLST = cms.EDProducer('LSTPixelSeedInputProducer',
+    beamSpot = cms.InputTag('offlineBeamSpot'),
+    seedTracks = cms.VInputTag(
+        'hltInitialStepSeedTracksLST',
+        'hltHighPtTripletStepSeedTracksLST'
+    )
+)
+

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltPixelSeedInputLST_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltPixelSeedInputLST_cfi.py
@@ -8,3 +8,10 @@ hltPixelSeedInputLST = cms.EDProducer('LSTPixelSeedInputProducer',
     )
 )
 
+_hltPixelSeedInputLSTSingleIterPatatrack = hltPixelSeedInputLST.clone(
+    seedTracks = cms.VInputTag('hltInitialStepSeedTracksLST')
+)
+
+from Configuration.ProcessModifiers.singleIterPatatrack_cff import singleIterPatatrack
+singleIterPatatrack.toReplaceWith(hltPixelSeedInputLST, _hltPixelSeedInputLSTSingleIterPatatrack)
+

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltSiPhase2RecHits_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltSiPhase2RecHits_cfi.py
@@ -1,0 +1,5 @@
+import FWCore.ParameterSet.Config as cms
+
+from RecoLocalTracker.Phase2TrackerRecHits.Phase2TrackerRecHits_cfi import siPhase2RecHits as _siPhase2RecHits
+hltSiPhase2RecHits = _siPhase2RecHits.clone( src = cms.InputTag("hltSiPhase2Clusters") )
+

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTHighPtTripletStepSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTHighPtTripletStepSequence_cfi.py
@@ -7,3 +7,16 @@ from ..modules.hltHighPtTripletStepTrackSelectionHighPurity_cfi import *
 from ..sequences.HLTHighPtTripletStepSeedingSequence_cfi import *
 
 HLTHighPtTripletStepSequence = cms.Sequence(HLTHighPtTripletStepSeedingSequence+hltHighPtTripletStepTrackCandidates+hltHighPtTripletStepTracks+hltHighPtTripletStepTrackCutClassifier+hltHighPtTripletStepTrackSelectionHighPurity)
+
+from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
+trackingLST.toReplaceWith(HLTHighPtTripletStepSequence, HLTHighPtTripletStepSequence.copyAndExclude([HLTHighPtTripletStepSeedingSequence]))
+
+from ..modules.hltHighPtTripletStepTrackCandidatespLSTCLST_cfi import *
+from ..modules.hltHighPtTripletStepTrackspLSTCLST_cfi import *
+from ..modules.hltHighPtTripletStepTrackCutClassifierpLSTCLST_cfi import *
+from ..modules.hltHighPtTripletStepTrackSelectionHighPuritypLSTCLST_cfi import *
+_HLTHighPtTripletStepSequenceLSTSeeding = cms.Sequence(hltHighPtTripletStepTrackCandidatespLSTCLST+hltHighPtTripletStepTrackspLSTCLST+hltHighPtTripletStepTrackCutClassifierpLSTCLST+hltHighPtTripletStepTrackSelectionHighPuritypLSTCLST)
+
+from Configuration.ProcessModifiers.seedingLST_cff import seedingLST
+(seedingLST & trackingLST).toReplaceWith(HLTHighPtTripletStepSequence, _HLTHighPtTripletStepSequenceLSTSeeding)
+

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTInitialStepSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTInitialStepSequence_cfi.py
@@ -7,3 +7,43 @@ from ..modules.hltInitialStepTracks_cfi import *
 from ..modules.hltInitialStepTrackSelectionHighPurity_cfi import *
 
 HLTInitialStepSequence = cms.Sequence(hltInitialStepSeeds+hltInitialStepTrackCandidates+hltInitialStepTracks+hltInitialStepTrackCutClassifier+hltInitialStepTrackSelectionHighPurity)
+
+from ..modules.hltInitialStepSeedTracksLST_cfi import *
+from ..sequences.HLTHighPtTripletStepSeedingSequence_cfi import *
+from ..modules.hltHighPtTripletStepSeedTracksLST_cfi import *
+from ..modules.hltPixelSeedInputLST_cfi import *
+from ..modules.hltSiPhase2RecHits_cfi import *
+from ..modules.hltPhase2OTHitsInputLST_cfi import *
+from ..modules.hltLST_cfi import *
+from ..modules.hltInitialStepTrackspTTCLST_cfi import *
+from ..modules.hltInitialStepTrackspLSTCLST_cfi import *
+from ..modules.hltInitialStepTracksT5TCLST_cfi import *
+from ..modules.hltInitialStepTrackCutClassifierpTTCLST_cfi import *
+from ..modules.hltInitialStepTrackCutClassifierpLSTCLST_cfi import *
+from ..modules.hltInitialStepTrackSelectionHighPuritypTTCLST_cfi import *
+from ..modules.hltInitialStepTrackSelectionHighPuritypLSTCLST_cfi import *
+_HLTInitialStepSequenceLST = cms.Sequence(
+     hltInitialStepSeeds
+    +hltInitialStepSeedTracksLST
+    +HLTHighPtTripletStepSeedingSequence
+    +hltHighPtTripletStepSeedTracksLST
+    +hltPixelSeedInputLST
+    +hltSiPhase2RecHits # Probably need to move elsewhere in the final setup
+    +hltPhase2OTHitsInputLST # Probably need to move elsewhere in the final setup
+    +hltLST
+    +hltInitialStepTrackCandidates
+    +hltInitialStepTrackspTTCLST
+    +hltInitialStepTrackspLSTCLST
+    +hltInitialStepTracksT5TCLST
+    +hltInitialStepTrackCutClassifierpTTCLST
+    +hltInitialStepTrackCutClassifierpLSTCLST
+    +hltInitialStepTrackSelectionHighPuritypTTCLST
+    +hltInitialStepTrackSelectionHighPuritypLSTCLST
+)
+
+from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
+trackingLST.toReplaceWith(HLTInitialStepSequence, _HLTInitialStepSequenceLST)
+
+from Configuration.ProcessModifiers.seedingLST_cff import seedingLST
+(seedingLST & trackingLST).toReplaceWith(HLTInitialStepSequence, _HLTInitialStepSequenceLST.copyAndExclude([hltInitialStepTrackspLSTCLST,hltInitialStepTrackCutClassifierpLSTCLST,hltInitialStepTrackSelectionHighPuritypLSTCLST]))
+

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTInitialStepSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTInitialStepSequence_cfi.py
@@ -44,6 +44,9 @@ _HLTInitialStepSequenceLST = cms.Sequence(
 from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
 trackingLST.toReplaceWith(HLTInitialStepSequence, _HLTInitialStepSequenceLST)
 
+from Configuration.ProcessModifiers.singleIterPatatrack_cff import singleIterPatatrack
+(singleIterPatatrack & trackingLST).toReplaceWith(HLTInitialStepSequence, HLTInitialStepSequence.copyAndExclude([HLTHighPtTripletStepSeedingSequence,hltHighPtTripletStepSeedTracksLST]))
+
 from Configuration.ProcessModifiers.seedingLST_cff import seedingLST
 (seedingLST & trackingLST).toReplaceWith(HLTInitialStepSequence, _HLTInitialStepSequenceLST.copyAndExclude([hltInitialStepTrackspLSTCLST,hltInitialStepTrackCutClassifierpLSTCLST,hltInitialStepTrackSelectionHighPuritypLSTCLST]))
 

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTTrackingV61Sequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTTrackingV61Sequence_cfi.py
@@ -10,3 +10,7 @@ from ..sequences.HLTItLocalRecoSequence_cfi import *
 from ..sequences.HLTOtLocalRecoSequence_cfi import *
 
 HLTTrackingV61Sequence = cms.Sequence((HLTItLocalRecoSequence+HLTOtLocalRecoSequence+hltTrackerClusterCheck+HLTPhase2PixelTracksSequence+hltPhase2PixelVertices+HLTInitialStepSequence+HLTHighPtTripletStepSequence+hltGeneralTracks))
+
+from Configuration.ProcessModifiers.singleIterPatatrack_cff import singleIterPatatrack
+singleIterPatatrack.toReplaceWith(HLTTrackingV61Sequence, HLTTrackingV61Sequence.copyAndExclude([HLTHighPtTripletStepSequence]))
+

--- a/HLTrigger/Configuration/python/HLT_75e33_cff.py
+++ b/HLTrigger/Configuration/python/HLT_75e33_cff.py
@@ -96,6 +96,9 @@ fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPPixelCPEFastPa
 fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPSiPixelCablingSoA_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPSiPixelGainCalibrationForHLTSoA_cfi")
 
+fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPModulesDevLST_cfi")
+fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPTTRHBuilderWithoutRefit_cfi")
+
 fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLT_AK4PFPuppiJet520_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLT_Diphoton30_23_IsoCaloId_L1Seeded_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLT_Diphoton30_23_IsoCaloId_Unseeded_cfi")

--- a/HLTrigger/Configuration/python/HLT_75e33_timing_cff.py
+++ b/HLTrigger/Configuration/python/HLT_75e33_timing_cff.py
@@ -101,6 +101,9 @@ fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPPixelCPEFastPa
 fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPSiPixelCablingSoA_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPSiPixelGainCalibrationForHLTSoA_cfi")
 
+fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPModulesDevLST_cfi")
+fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPTTRHBuilderWithoutRefit_cfi")
+
 fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLT_AK4PFPuppiJet520_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLT_Diphoton30_23_IsoCaloId_L1Seeded_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLT_DoubleEle23_12_Iso_L1Seeded_cfi")

--- a/HLTrigger/Configuration/python/HLT_75e33_timing_cff.py
+++ b/HLTrigger/Configuration/python/HLT_75e33_timing_cff.py
@@ -97,6 +97,10 @@ fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPKFTrajectorySm
 
 fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/trackdnn_source_cfi")
 
+fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPPixelCPEFastParams_cfi")
+fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPSiPixelCablingSoA_cfi")
+fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPSiPixelGainCalibrationForHLTSoA_cfi")
+
 fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLT_AK4PFPuppiJet520_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLT_Diphoton30_23_IsoCaloId_L1Seeded_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLT_DoubleEle23_12_Iso_L1Seeded_cfi")

--- a/RecoTracker/LSTCore/interface/Constants.h
+++ b/RecoTracker/LSTCore/interface/Constants.h
@@ -43,15 +43,15 @@ namespace lst {
   constexpr unsigned int max_blocks = 80;
   constexpr unsigned int max_connected_modules = 40;
 
-  constexpr unsigned int n_max_pixel_segments_per_module = 50000;
+  constexpr unsigned int n_max_pixel_segments_per_module = 500000;
 
   constexpr unsigned int n_max_pixel_md_per_modules = 2 * n_max_pixel_segments_per_module;
 
   constexpr unsigned int n_max_pixel_triplets = 5000;
   constexpr unsigned int n_max_pixel_quintuplets = 15000;
 
-  constexpr unsigned int n_max_pixel_track_candidates = 30000;
-  constexpr unsigned int n_max_nonpixel_track_candidates = 1000;
+  constexpr unsigned int n_max_pixel_track_candidates = 3000000;
+  constexpr unsigned int n_max_nonpixel_track_candidates = 100000;
 
   constexpr unsigned int size_superbins = 45000;
 

--- a/Validation/RecoTrack/python/HLTmultiTrackValidator_cff.py
+++ b/Validation/RecoTrack/python/HLTmultiTrackValidator_cff.py
@@ -36,3 +36,16 @@ def _modifyForPhase2(trackvalidator):
 
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 phase2_tracker.toModify(hltTrackValidator, _modifyForPhase2)
+
+def _modifyForPhase2LSTTracking(trackvalidator):
+    trackvalidator.label = ["hltGeneralTracks","hltInitialStepTrackSelectionHighPuritypTTCLST","hltInitialStepTrackSelectionHighPuritypLSTCLST","hltInitialStepTracksT5TCLST","hltHighPtTripletStepTrackSelectionHighPurity","hltPhase2PixelTracks"]
+
+from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
+trackingLST.toModify(hltTrackValidator, _modifyForPhase2LSTTracking)
+
+def _modifyForPhase2LSTSeeding(trackvalidator):
+    trackvalidator.label = ["hltGeneralTracks","hltInitialStepTrackSelectionHighPuritypTTCLST","hltInitialStepTracksT5TCLST","hltHighPtTripletStepTrackSelectionHighPuritypLSTCLST","hltPhase2PixelTracks"]
+
+from Configuration.ProcessModifiers.seedingLST_cff import seedingLST
+(seedingLST & trackingLST).toModify(hltTrackValidator, _modifyForPhase2LSTSeeding)
+


### PR DESCRIPTION
### PR description

This is a procModifier-based implementation of LST in HLT, based on top of `CMSSW_14_1_0_pre7` + cms-sw/cmssw#45117 + cms-sw/cmssw#45508. The target branch has been adapted accordingly to be able to make a clear comparison.
It is an adaptation/improvement over #63, which becomes moot in terms of LST (also mkFit would need to be re-implemented with the usage of procModifiers from that PR).
It tries to reuse the `trackingLST` procModifier, and it introduces a new one, `seedingLST`, which may become also useful for the offline setup in the near future.

The PR is not meant to be merged, as it will have to be rebased to whichever CMSSW version LST gets integrated. However, the developments are fairly decoupled from the rest of the framework and the rest of the LST code, so this PR should already be good enough for people to take a look and comment on the implementation details.

In terms of performance, this is shown in the "Tests on LST Configurations - Baseline vs. Patatrack+Legacy-seeded LST in InitialStep" section of [this presentation](https://docs.google.com/presentation/d/1VcJ9sitEUICM4FqHe_ghCJO7IoQ2aBtd1ckTuYVUnyQ/edit?usp=sharing).

### Instructions on how to run
```sh
cmsrel CMSSW_14_1_0_pre7
cd CMSSW_14_1_0_pre7/src
cmsenv
git cms-init
git cms-addpkg Configuration HLTrigger
git remote add SegLink git@github.com:SegmentLinking/cmssw.git
git fetch SegLink
git checkout CMSSW_14_1_0_pre7_LST_alpakaPatatrackInHLT_LSTInHLT_latest
scram b -j 16

# Rerun L1, needed because the HLT samples I am using are produced with 14_0_X
cmsDriver.py Phase2 -s L1,L1TrackTrigger \
--conditions auto:phase2_realistic_T33 \
--geometry Extended2026D110 \
--era Phase2C17I13M9 \
--eventcontent FEVTDEBUGHLT \
--datatier GEN-SIM-DIGI-RAW-MINIAOD \
--customise SLHCUpgradeSimulations/Configuration/aging.customise_aging_1000,Configuration/DataProcessing/Utils.addMonitoring,L1Trigger/Configuration/customisePhase2FEVTDEBUGHLT.customisePhase2FEVTDEBUGHLT,L1Trigger/Configuration/customisePhase2TTOn110.customisePhase2TTOn110 \
--filein /store/mc/Phase2Spring24DIGIRECOMiniAOD/TT_TuneCP5_14TeV-powheg-pythia8/GEN-SIM-DIGI-RAW-MINIAOD/PU200_AllTP_140X_mcRun4_realistic_v4-v1/2560000/11d1f6f0-5f03-421e-90c7-b5815197fc85.root \
--fileout file:output_Phase2_L1T.root \
--inputCommands="keep *, drop l1tPFJets_*_*_*, drop l1tTrackerMuons_l1tTkMuonsGmt*_*_HLT" \
--outputCommands="drop l1tTrackerMuons_l1tTkMuonsGmt*_*_HLT" \
--mc -n 100 --nThreads 1

# Rerun L1 emulator + HLT (needed for any sample)
# In terms of procModifiers:
#    None -> Legacy seeding, CKF building
#    alpaka -> Patatrack seeding
#    trackingLST -> LST building for the initialStep
#    seedingLST -> LST seeding for the hightPtTripletStep
cmsDriver.py Phase2 -s L1P2GT,HLT:75e33 --processName=HLTX \
--conditions auto:phase2_realistic_T33 \
--geometry Extended2026D110 \
--era Phase2C17I13M9 \
--eventcontent FEVTDEBUGHLT \
--customise SLHCUpgradeSimulations/Configuration/aging.customise_aging_1000 \
--filein file:output_Phase2_L1T.root \
--fileout file:Phase2_L1P2GT_HLT.root \
--inputCommands="keep *, drop *_hlt*_*_HLT, drop triggerTriggerFilterObjectWithRefs_l1t*_*_HLT" \
--outputCommands='keep *_*InitialStepTrack*LST*_*_*, keep *_*HighPtTripletStepTrack*_*_*' \
-n 100 --nThreads 10 \
--procModifiers alpaka,trackingLST,seedingLST

# procModifiers are important also for the validation step
# and should be consistent with the ones used above
cmsDriver.py DQM -s VALIDATION:hltMultiTrackValidation \
--conditions auto:phase2_realistic_T33 \
--geometry Extended2026D110 \
--era Phase2C17I13M9 \
--datatier DQMIO \
--eventcontent DQM \
--filein file:Phase2_L1P2GT_HLT.root \
--hltProcess HLTX \
--fileout DQM.root \
-n 100 --nThreads 10 --procModifiers alpaka,trackingLST,seedingLST

cmsDriver.py HARVEST -s HARVESTING:@trackingOnlyValidation+@trackingOnlyDQM+postProcessorHLTtrackingSequence \
--filein file:DQM.root \
--scenario pp \
--filetype DQM \
--conditions auto:phase2_realistic_T33 \
--mc -n 100

mv DQM_V0001_R000000001__Global__CMSSW_X_Y_Z__RECO.root configName.root
makeTrackValidationPlots.py configName.root --extended
```