### PR TITLE
Fix rzChisquared NaN's on CPU Backend

### DIFF
--- a/RecoTracker/LSTCore/src/alpaka/Quintuplet.h
+++ b/RecoTracker/LSTCore/src/alpaka/Quintuplet.h
@@ -6,6 +6,7 @@
 #include "RecoTracker/LSTCore/interface/alpaka/Constants.h"
 #include "RecoTracker/LSTCore/interface/Module.h"
 #include "RecoTracker/LSTCore/interface/EndcapGeometry.h"
+#include "FWCore/Utilities/interface/isFinite.h"
 
 #include "NeuralNetwork.h"
 #include "Segment.h"
@@ -555,9 +556,9 @@ namespace lst {
         float diffz1 = (solz1 - zsi) * 100;
         float diffz2 = (solz2 - zsi) * 100;
         // Alpaka : Needs to be moved over
-        if (alpaka::math::isnan(acc, diffz1))
+        if (edm::isNotFinite(diffz1))
           diffz = diffz2;
-        else if (alpaka::math::isnan(acc, diffz2))
+        else if (edm::isNotFinite(diffz2))
           diffz = diffz1;
         else {
           diffz = (alpaka::math::abs(acc, diffz1) < alpaka::math::abs(acc, diffz2)) ? diffz1 : diffz2;
@@ -604,7 +605,7 @@ namespace lst {
     // for set rzchi2 cut
     // if the 5 points are linear, helix calculation gives nan
     // Alpaka : Needs to be moved over
-    if (inner_pt > 100 || alpaka::math::isnan(acc, rzChiSquared)) {
+    if (inner_pt > 100 || edm::isNotFinite(rzChiSquared)) {
       float slope;
       if (moduleType1 == 0 and moduleType2 == 0 and moduleType3 == 1)  //PSPS2S
       {


### PR DESCRIPTION
Resolves an issue where on the CPU backend the ntuple would contain NaN values for some rzChisquared t5 values by switching alpaka::math::isnan to edm::isNotFinite.