### PR TITLE
[DO NOT MERGE] Single Iteration Patatrack and Patatrack-only-seeded LST in HLT

### DIFF
--- a/Configuration/ProcessModifiers/python/singleIterPatatrack_cff.py
+++ b/Configuration/ProcessModifiers/python/singleIterPatatrack_cff.py
@@ -1,0 +1,6 @@
+import FWCore.ParameterSet.Config as cms
+
+# This modifier merges the initialStep and highPtTripletStep iterations
+# to a single iteration using Patatrack pixel tracks with >3 hits as seeds
+singleIterPatatrack = cms.Modifier()
+

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltGeneralTracks_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltGeneralTracks_cfi.py
@@ -53,6 +53,19 @@ _hltGeneralTracksLST = hltGeneralTracks.clone(
 from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
 trackingLST.toReplaceWith(hltGeneralTracks, _hltGeneralTracksLST)
 
+_hltGeneralTracksLSTSingleIterPatatrack = hltGeneralTracks.clone(
+    TrackProducers = cms.VInputTag("hltInitialStepTrackSelectionHighPuritypTTCLST", "hltInitialStepTracksT5TCLST", "hltHighPtTripletStepTrackSelectionHighPurity"),
+    hasSelector = cms.vint32(0,0,0),
+    indivShareFrac = cms.vdouble(0.1,0.1,0.1),
+    selectedTrackQuals = cms.VInputTag(cms.InputTag("hltInitialStepTrackSelectionHighPuritypTTCLST"), cms.InputTag("hltInitialStepTracksT5TCLST"), cms.InputTag("hltHighPtTripletStepTrackSelectionHighPurity")),
+    setsToMerge = cms.VPSet(cms.PSet(
+        pQual = cms.bool(True),
+        tLists = cms.vint32(0,1,2)
+    ))
+)
+
+(singleIterPatatrack & trackingLST).toReplaceWith(hltGeneralTracks, _hltGeneralTracksLSTSingleIterPatatrack)
+
 _hltGeneralTracksLSTSeeding = hltGeneralTracks.clone(
             TrackProducers = cms.VInputTag("hltInitialStepTrackSelectionHighPuritypTTCLST", "hltInitialStepTracksT5TCLST", "hltHighPtTripletStepTrackSelectionHighPuritypLSTCLST"),
             hasSelector = cms.vint32(0,0,0),

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltGeneralTracks_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltGeneralTracks_cfi.py
@@ -25,6 +25,20 @@ hltGeneralTracks = cms.EDProducer("TrackListMerger",
     writeOnlyTrkQuals = cms.bool(False)
 )
 
+_hltGeneralTracksSingleIterPatatrack = hltGeneralTracks.clone(
+    TrackProducers = cms.VInputTag("hltInitialStepTrackSelectionHighPurity"),
+    hasSelector = cms.vint32(0),
+    indivShareFrac = cms.vdouble(1.0),
+    selectedTrackQuals = cms.VInputTag(cms.InputTag("hltInitialStepTrackSelectionHighPurity")),
+    setsToMerge = cms.VPSet(cms.PSet(
+        pQual = cms.bool(True),
+        tLists = cms.vint32(0)
+    ))
+)
+
+from Configuration.ProcessModifiers.singleIterPatatrack_cff import singleIterPatatrack
+singleIterPatatrack.toReplaceWith(hltGeneralTracks, _hltGeneralTracksSingleIterPatatrack)
+
 _hltGeneralTracksLST = hltGeneralTracks.clone(
     TrackProducers = cms.VInputTag("hltInitialStepTrackSelectionHighPuritypTTCLST", "hltInitialStepTrackSelectionHighPuritypLSTCLST", "hltInitialStepTracksT5TCLST", "hltHighPtTripletStepTrackSelectionHighPurity"),
     hasSelector = cms.vint32(0,0,0,0),

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltHighPtTripletStepClusters_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltHighPtTripletStepClusters_cfi.py
@@ -20,3 +20,10 @@ _hltHighPtTripletStepClustersLST = hltHighPtTripletStepClusters.clone(
 from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
 trackingLST.toReplaceWith(hltHighPtTripletStepClusters, _hltHighPtTripletStepClustersLST)
 
+_hltHighPtTripletStepClustersLSTSingleIterPatatrack = hltHighPtTripletStepClusters.clone(
+    trajectories = cms.InputTag("hltInitialStepTracksLST")
+)
+
+from Configuration.ProcessModifiers.singleIterPatatrack_cff import singleIterPatatrack
+(singleIterPatatrack & trackingLST).toReplaceWith(hltHighPtTripletStepClusters, _hltHighPtTripletStepClustersLSTSingleIterPatatrack)
+

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTracksLST_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTracksLST_cfi.py
@@ -1,0 +1,27 @@
+import FWCore.ParameterSet.Config as cms
+
+hltInitialStepTracksLST = cms.EDProducer("TrackListMerger",
+    Epsilon = cms.double(-0.001),
+    FoundHitBonus = cms.double(5.0),
+    LostHitPenalty = cms.double(5.0),
+    MaxNormalizedChisq = cms.double(1000.0),
+    MinFound = cms.int32(3),
+    MinPT = cms.double(0.9),
+    ShareFrac = cms.double(0.19),
+    TrackProducers = cms.VInputTag("hltInitialStepTrackSelectionHighPuritypTTCLST", "hltInitialStepTracksT5TCLST"),
+    allowFirstHitShare = cms.bool(True),
+    copyExtras = cms.untracked.bool(True),
+    copyMVA = cms.bool(False),
+    hasSelector = cms.vint32(0,0),
+    indivShareFrac = cms.vdouble(0.1,0.1),
+    makeReKeyedSeeds = cms.untracked.bool(False),
+    newQuality = cms.string('confirmed'),
+    selectedTrackQuals = cms.VInputTag(cms.InputTag("hltInitialStepTrackSelectionHighPuritypTTCLST"), cms.InputTag("hltInitialStepTracksT5TCLST")),
+    setsToMerge = cms.VPSet(cms.PSet(
+        pQual = cms.bool(True),
+        tLists = cms.vint32(0,1)
+    )),
+    trackAlgoPriorityOrder = cms.string('trackAlgoPriorityOrder'),
+    writeOnlyTrkQuals = cms.bool(False)
+)
+

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltPhase2PixelTracksSoA_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltPhase2PixelTracksSoA_cfi.py
@@ -41,3 +41,9 @@ hltPhase2PixelTracksSoA = cms.EDProducer('CAHitNtupletAlpakaPhase2@alpaka',
     # autoselect the alpaka backend
     alpaka = cms.untracked.PSet(backend = cms.untracked.string(''))
 )
+
+_hltPhase2PixelTracksSoASingleIterPatatrack = hltPhase2PixelTracksSoA.clone(minHitsPerNtuplet = cms.uint32(3))
+
+from Configuration.ProcessModifiers.singleIterPatatrack_cff import singleIterPatatrack
+singleIterPatatrack.toReplaceWith(hltPhase2PixelTracksSoA, _hltPhase2PixelTracksSoASingleIterPatatrack)
+

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltPixelSeedInputLST_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltPixelSeedInputLST_cfi.py
@@ -8,3 +8,10 @@ hltPixelSeedInputLST = cms.EDProducer('LSTPixelSeedInputProducer',
     )
 )
 
+_hltPixelSeedInputLSTSingleIterPatatrack = hltPixelSeedInputLST.clone(
+    seedTracks = cms.VInputTag('hltInitialStepSeedTracksLST')
+)
+
+from Configuration.ProcessModifiers.singleIterPatatrack_cff import singleIterPatatrack
+singleIterPatatrack.toReplaceWith(hltPixelSeedInputLST, _hltPixelSeedInputLSTSingleIterPatatrack)
+

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTHighPtTripletStepSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTHighPtTripletStepSequence_cfi.py
@@ -8,8 +8,9 @@ from ..sequences.HLTHighPtTripletStepSeedingSequence_cfi import *
 
 HLTHighPtTripletStepSequence = cms.Sequence(HLTHighPtTripletStepSeedingSequence+hltHighPtTripletStepTrackCandidates+hltHighPtTripletStepTracks+hltHighPtTripletStepTrackCutClassifier+hltHighPtTripletStepTrackSelectionHighPurity)
 
+from Configuration.ProcessModifiers.singleIterPatatrack_cff import singleIterPatatrack
 from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
-trackingLST.toReplaceWith(HLTHighPtTripletStepSequence, HLTHighPtTripletStepSequence.copyAndExclude([HLTHighPtTripletStepSeedingSequence]))
+((~singleIterPatatrack) & trackingLST).toReplaceWith(HLTHighPtTripletStepSequence, HLTHighPtTripletStepSequence.copyAndExclude([HLTHighPtTripletStepSeedingSequence]))
 
 from ..modules.hltHighPtTripletStepTrackCandidatespLSTCLST_cfi import *
 from ..modules.hltHighPtTripletStepTrackspLSTCLST_cfi import *
@@ -19,4 +20,9 @@ _HLTHighPtTripletStepSequenceLSTSeeding = cms.Sequence(hltHighPtTripletStepTrack
 
 from Configuration.ProcessModifiers.seedingLST_cff import seedingLST
 (seedingLST & trackingLST).toReplaceWith(HLTHighPtTripletStepSequence, _HLTHighPtTripletStepSequenceLSTSeeding)
+
+from ..modules.hltHighPtTripletStepClusters_cfi import *
+_HLTHighPtTripletStepSequenceLSTSeedingSingleIterPatatrack = cms.Sequence(hltHighPtTripletStepClusters+hltHighPtTripletStepTrackCandidatespLSTCLST+hltHighPtTripletStepTrackspLSTCLST+hltHighPtTripletStepTrackCutClassifierpLSTCLST+hltHighPtTripletStepTrackSelectionHighPuritypLSTCLST)
+
+(singleIterPatatrack & seedingLST & trackingLST).toReplaceWith(HLTHighPtTripletStepSequence, _HLTHighPtTripletStepSequenceLSTSeedingSingleIterPatatrack)
 

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTInitialStepSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTInitialStepSequence_cfi.py
@@ -44,6 +44,30 @@ _HLTInitialStepSequenceLST = cms.Sequence(
 from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
 trackingLST.toReplaceWith(HLTInitialStepSequence, _HLTInitialStepSequenceLST)
 
+from ..modules.hltInitialStepTracksLST_cfi import *
+_HLTInitialStepSequenceLSTSingleIterPatatrack = cms.Sequence(
+     hltInitialStepSeeds
+    +hltInitialStepSeedTracksLST
+    +hltPixelSeedInputLST
+    +hltSiPhase2RecHits # Probably need to move elsewhere in the final setup
+    +hltPhase2OTHitsInputLST # Probably need to move elsewhere in the final setup
+    +hltLST
+    +hltInitialStepTrackCandidates
+    +hltInitialStepTrackspTTCLST
+    +hltInitialStepTrackspLSTCLST
+    +hltInitialStepTracksT5TCLST
+    +hltInitialStepTrackCutClassifierpTTCLST
+    +hltInitialStepTrackCutClassifierpLSTCLST
+    +hltInitialStepTrackSelectionHighPuritypTTCLST
+    +hltInitialStepTrackSelectionHighPuritypLSTCLST
+    +hltInitialStepTracksLST
+)
+
+from Configuration.ProcessModifiers.singleIterPatatrack_cff import singleIterPatatrack
+(singleIterPatatrack & trackingLST).toReplaceWith(HLTInitialStepSequence, _HLTInitialStepSequenceLSTSingleIterPatatrack)
+
 from Configuration.ProcessModifiers.seedingLST_cff import seedingLST
 (seedingLST & trackingLST).toReplaceWith(HLTInitialStepSequence, _HLTInitialStepSequenceLST.copyAndExclude([hltInitialStepTrackspLSTCLST,hltInitialStepTrackCutClassifierpLSTCLST,hltInitialStepTrackSelectionHighPuritypLSTCLST]))
+
+(singleIterPatatrack & seedingLST & trackingLST).toReplaceWith(HLTInitialStepSequence, _HLTInitialStepSequenceLSTSingleIterPatatrack.copyAndExclude([hltInitialStepTrackspLSTCLST,hltInitialStepTrackCutClassifierpLSTCLST,hltInitialStepTrackSelectionHighPuritypLSTCLST]))
 

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTTrackingV61Sequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTTrackingV61Sequence_cfi.py
@@ -10,3 +10,7 @@ from ..sequences.HLTItLocalRecoSequence_cfi import *
 from ..sequences.HLTOtLocalRecoSequence_cfi import *
 
 HLTTrackingV61Sequence = cms.Sequence((HLTItLocalRecoSequence+HLTOtLocalRecoSequence+hltTrackerClusterCheck+HLTPhase2PixelTracksSequence+hltPhase2PixelVertices+HLTInitialStepSequence+HLTHighPtTripletStepSequence+hltGeneralTracks))
+
+from Configuration.ProcessModifiers.singleIterPatatrack_cff import singleIterPatatrack
+singleIterPatatrack.toReplaceWith(HLTTrackingV61Sequence, HLTTrackingV61Sequence.copyAndExclude([HLTHighPtTripletStepSequence]))
+

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTTrackingV61Sequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTTrackingV61Sequence_cfi.py
@@ -12,5 +12,6 @@ from ..sequences.HLTOtLocalRecoSequence_cfi import *
 HLTTrackingV61Sequence = cms.Sequence((HLTItLocalRecoSequence+HLTOtLocalRecoSequence+hltTrackerClusterCheck+HLTPhase2PixelTracksSequence+hltPhase2PixelVertices+HLTInitialStepSequence+HLTHighPtTripletStepSequence+hltGeneralTracks))
 
 from Configuration.ProcessModifiers.singleIterPatatrack_cff import singleIterPatatrack
-singleIterPatatrack.toReplaceWith(HLTTrackingV61Sequence, HLTTrackingV61Sequence.copyAndExclude([HLTHighPtTripletStepSequence]))
+from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
+(singleIterPatatrack & ~trackingLST).toReplaceWith(HLTTrackingV61Sequence, HLTTrackingV61Sequence.copyAndExclude([HLTHighPtTripletStepSequence]))
 


### PR DESCRIPTION
As per title, with the single iteration seeded by >3 hit Patatrack pixel tracks being controlled by the newly introduced `singleIterPatatrack` procModifier.

This is a follow up on PR #94, the same description on the PR also holds for this one.

In terms of performance, this is shown in the "Tests on LST Configurations - Baseline vs. Patatrack-only-seeded LST in InitialStep" section of [this presentation](https://docs.google.com/presentation/d/1VcJ9sitEUICM4FqHe_ghCJO7IoQ2aBtd1ckTuYVUnyQ/edit?usp=sharing).