### PR TITLE
Fix wrong code format

### DIFF
--- a/RecoTracker/LSTCore/standalone/code/rooutil/cxxopts.h
+++ b/RecoTracker/LSTCore/standalone/code/rooutil/cxxopts.h
@@ -238,7 +238,7 @@ namespace cxxopts {
   class Option_syntax_exception : public OptionParseException {
   public:
     Option_syntax_exception(const std::string& text)
-        : OptionParseException(u8"Argument " + LQUOTE + text + RQUOTE + u8" starts with a - but has incorrect syntax") {}
+        : OptionParseException("Argument " + LQUOTE + text + RQUOTE + " starts with a - but has incorrect syntax") {}
   };
 
   class Option_not_exists_exception : public OptionParseException {


### PR DESCRIPTION
This partial reverts https://github.com/SegmentLinking/cmssw/commit/992947d8d5a766089dd9e088c184bf71e95958ca, according to https://github.com/SegmentLinking/cmssw/pull/92#discussion_r1817445317, to fix the standalone compilation problems in #103.

Tested locally and it compiles ok.