### PR TITLE
Check pT5's in T5 Duplicate Cleaning Before TC

### DIFF
--- a/RecoTracker/LSTCore/src/alpaka/Kernels.h
+++ b/RecoTracker/LSTCore/src/alpaka/Kernels.h
@@ -220,7 +220,7 @@ namespace lst {
 
           for (unsigned int ix1 = 0; ix1 < nQuintuplets_lowmod1; ix1 += 1) {
             unsigned int ix = quintupletModuleIndices_lowmod1 + ix1;
-            if (quintupletsInGPU.partOfPT5[ix] || (quintupletsInGPU.isDup[ix] & 1))
+            if (quintupletsInGPU.isDup[ix] & 1)
               continue;
 
             for (unsigned int jx1 = 0; jx1 < nQuintuplets_lowmod2; jx1++) {
@@ -228,7 +228,7 @@ namespace lst {
               if (ix == jx)
                 continue;
 
-              if (quintupletsInGPU.partOfPT5[jx] || (quintupletsInGPU.isDup[jx] & 1))
+              if (quintupletsInGPU.isDup[jx] & 1)
                 continue;
 
               float eta1 = __H2F(quintupletsInGPU.eta[ix]);

--- a/RecoTracker/LSTCore/src/alpaka/Kernels.h
+++ b/RecoTracker/LSTCore/src/alpaka/Kernels.h
@@ -223,12 +223,19 @@ namespace lst {
             if (quintupletsInGPU.isDup[ix] & 1)
               continue;
 
+            bool isPT5_ix = quintupletsInGPU.partOfPT5[ix];
+
             for (unsigned int jx1 = 0; jx1 < nQuintuplets_lowmod2; jx1++) {
               unsigned int jx = quintupletModuleIndices_lowmod2 + jx1;
               if (ix == jx)
                 continue;
 
               if (quintupletsInGPU.isDup[jx] & 1)
+                continue;
+
+              bool isPT5_jx = quintupletsInGPU.partOfPT5[jx];
+
+              if (isPT5_ix && isPT5_jx)
                 continue;
 
               float eta1 = __H2F(quintupletsInGPU.eta[ix]);

--- a/RecoTracker/LSTCore/src/alpaka/Kernels.h
+++ b/RecoTracker/LSTCore/src/alpaka/Kernels.h
@@ -259,9 +259,9 @@ namespace lst {
               int nMatched = checkHitsT5(ix, jx, quintupletsInGPU);
               const int minNHitsForDup_T5 = 5;
               if (dR2 < 0.001f || nMatched >= minNHitsForDup_T5) {
-                if (score_rphisum1 > score_rphisum2) {
+                if (isPT5_jx || score_rphisum1 > score_rphisum2) {
                   rmQuintupletFromMemory(quintupletsInGPU, ix, true);
-                } else if (score_rphisum1 < score_rphisum2) {
+                } else if (isPT5_ix || score_rphisum1 < score_rphisum2) {
                   rmQuintupletFromMemory(quintupletsInGPU, jx, true);
                 } else {
                   rmQuintupletFromMemory(quintupletsInGPU, (ix < jx ? ix : jx), true);


### PR DESCRIPTION
This PR fixes the duplicate rate increase issue that occurs when I try to replace the rz chi-squared cut with the DNN.

<img src="https://github.com/user-attachments/assets/6b0211a1-4b59-48d8-afe8-66b65d3e759b" width="350">
<img src="https://github.com/user-attachments/assets/51975431-9eae-434a-915e-2f31150edfbb" width="350">


Current Timing
<img width="1415" alt="Screenshot 2024-11-01 at 4 10 54 PM" src="https://github.com/user-attachments/assets/16f0f817-40e5-49a1-9277-1aebda7871c9">

This PR Timing
<img width="1415" alt="Screenshot 2024-11-01 at 4 14 02 PM" src="https://github.com/user-attachments/assets/2eb20778-4c48-4378-b850-b196e143a318">
