### PR TITLE
FP16_Base compilation fixes

### DIFF
--- a/RecoTracker/LSTCore/interface/Common.h
+++ b/RecoTracker/LSTCore/interface/Common.h
@@ -44,7 +44,7 @@ namespace lst {
 #if defined(FP16_Base)
 #define __F2H __float2half
 #define __H2F __half2float
-  typedef __half float FPX;
+  typedef __half FPX;
 #else
 #define __F2H
 #define __H2F

--- a/RecoTracker/LSTCore/standalone/code/core/write_lst_ntuple.cc
+++ b/RecoTracker/LSTCore/standalone/code/core/write_lst_ntuple.cc
@@ -905,7 +905,7 @@ std::tuple<float, float, float, std::vector<unsigned int>, std::vector<unsigned 
   unsigned int Hit_8 = hits[8];
 
   // T5 radius is average of the inner and outer radius
-  const float pt = quintuplets.innerRadius()[T5] * k2Rinv1GeVf * 2;
+  const float pt = __H2F(quintuplets.innerRadius()[T5]) * k2Rinv1GeVf * 2;
 
   // T5 eta and phi are computed using outer and innermost hits
   lst_math::Hit hitA(trk.ph2_x()[Hit_0], trk.ph2_y()[Hit_0], trk.ph2_z()[Hit_0]);


### PR DESCRIPTION
I tested by adding ` -DFP16_Base` to RecoTracker/LSTCore/standalone/Makefile (in `ALPAKA_CUDA`) and RecoTracker/LSTCore/standalone/LST/Makefile (in `ALPAKACUDA`) as well as ROCM.

ref before this PR
<img width="858" alt="image" src="https://github.com/user-attachments/assets/1a31c86a-8be5-4042-b751-3f6b47aa4a7e">
with the changes in Makefile:
<img width="842" alt="image" src="https://github.com/user-attachments/assets/58261448-b7c7-414e-a1c7-36c130f925c1">

There is a hint that the code is a bit faster. 

The memory reduction is probably more important currently.

