### PR TITLE
Remove unnecessary CopyToDevice + small fixes

### DIFF
--- a/RecoTracker/LSTCore/interface/LSTESData.h
+++ b/RecoTracker/LSTCore/interface/LSTESData.h
@@ -8,7 +8,6 @@
 
 #include "HeterogeneousCore/AlpakaInterface/interface/CopyToDevice.h"
 
-#include <filesystem>
 #include <memory>
 
 namespace lst {

--- a/RecoTracker/LSTCore/interface/PixelMap.h
+++ b/RecoTracker/LSTCore/interface/PixelMap.h
@@ -17,8 +17,6 @@ namespace lst {
     std::vector<unsigned int> connectedPixelsIndexNeg;
     std::vector<unsigned int> connectedPixelsSizesNeg;
 
-    const int* pixelType;
-
     PixelMap(unsigned int sizef = size_superbins)
         : pixelModuleIndex(0),
           connectedPixelsIndex(sizef),

--- a/RecoTracker/LSTCore/src/LSTESData.cc
+++ b/RecoTracker/LSTCore/src/LSTESData.cc
@@ -88,7 +88,7 @@ std::unique_ptr<lst::LSTESData<alpaka_common::DevHost>> lst::loadAndFillESHost()
   ::loadMapsHost(pLStoLayer, endcapGeometry, tiltedGeometry, moduleConnectionMap);
 
   auto endcapGeometryDev =
-      std::make_unique<EndcapGeometryDevHostCollection>(endcapGeometry.nEndCapMap, cms::alpakatools::host());
+      std::make_shared<EndcapGeometryDevHostCollection>(endcapGeometry.nEndCapMap, cms::alpakatools::host());
   std::memcpy(endcapGeometryDev->view().geoMapDetId(),
               endcapGeometry.geoMapDetId_buf.data(),
               endcapGeometry.nEndCapMap * sizeof(unsigned int));

--- a/RecoTracker/LSTCore/src/LSTESData.cc
+++ b/RecoTracker/LSTCore/src/LSTESData.cc
@@ -6,6 +6,8 @@
 
 #include "ModuleMethods.h"
 
+#include <filesystem>
+
 namespace {
   std::string geometryDataDir() {
     const char* path_lst_base = std::getenv("LST_BASE");

--- a/RecoTracker/LSTCore/src/ModuleMethods.h
+++ b/RecoTracker/LSTCore/src/ModuleMethods.h
@@ -218,7 +218,7 @@ namespace lst {
     nModules = counter;
   }
 
-  inline std::unique_ptr<ModulesHostCollection> loadModulesFromFile(MapPLStoLayer const& pLStoLayer,
+  inline std::shared_ptr<ModulesHostCollection> loadModulesFromFile(MapPLStoLayer const& pLStoLayer,
                                                                     const char* moduleMetaDataFilePath,
                                                                     uint16_t& nModules,
                                                                     uint16_t& nLowerModules,
@@ -241,7 +241,7 @@ namespace lst {
 
     std::array<int, 2> const modules_sizes{{static_cast<int>(nModules), static_cast<int>(nPixels)}};
 
-    auto modulesHC = std::make_unique<ModulesHostCollection>(modules_sizes, cms::alpakatools::host());
+    auto modulesHC = std::make_shared<ModulesHostCollection>(modules_sizes, cms::alpakatools::host());
 
     auto modules_view = modulesHC->view<ModulesSoA>();
 

--- a/RecoTracker/LSTCore/src/alpaka/MiniDoublet.h
+++ b/RecoTracker/LSTCore/src/alpaka/MiniDoublet.h
@@ -85,7 +85,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     mds.outerLowEdgeY()[idx] = hits.lowEdgeYs()[outerHitIndex];
   }
 
-  ALPAKA_FN_ACC ALPAKA_FN_INLINE float isTighterTiltedModules(ModulesConst modules, uint16_t moduleIndex) {
+  ALPAKA_FN_ACC ALPAKA_FN_INLINE bool isTighterTiltedModules(ModulesConst modules, uint16_t moduleIndex) {
     // The "tighter" tilted modules are the subset of tilted modules that have smaller spacing
     // This is the same as what was previously considered as"isNormalTiltedModules"
     // See Figure 9.1 of https://cds.cern.ch/record/2272264/files/CMS-TDR-014.pdf


### PR DESCRIPTION
I addressed the following comments:

- https://github.com/cms-sw/cmssw/pull/45117#discussion_r1833227743 (move include)
- https://github.com/cms-sw/cmssw/pull/45117#discussion_r1833245889 (unnecessary CopyToDevice specialization)
- https://github.com/cms-sw/cmssw/pull/45117#discussion_r1833246174 (unnecessary CopyToDevice specialization)
- https://github.com/cms-sw/cmssw/pull/45117#discussion_r1833249693 (unused data member)
- https://github.com/cms-sw/cmssw/pull/45117#discussion_r1833298923 (wrong return type)

The CI currently fails because there is a typo in the PortableMultiCollection CopyToDevice definition, which will be fixed in https://github.com/cms-sw/cmssw/pull/46636