### PR TITLE
batch9 of updates for LST integration in CMSSW

### DIFF
--- a/RecoTracker/LST/interface/LSTOutput.h
+++ b/RecoTracker/LST/interface/LSTOutput.h
@@ -4,6 +4,8 @@
 #include <memory>
 #include <vector>
 
+#include "RecoTracker/LSTCore/interface/Common.h"
+
 class LSTOutput {
 public:
   LSTOutput() = default;
@@ -16,7 +18,7 @@ public:
         seedIdx_(std::move(seedIdx)),
         trackCandidateType_(std::move(trackCandidateType)) {}
 
-  enum LSTTCType { T5 = 4, pT3 = 5, pT5 = 7, pLS = 8 };
+  using LSTTCType = lst::LSTObjType;
 
   // Hit indices of each of the LST track candidates.
   std::vector<std::vector<unsigned int>> const& hitIdx() const { return hitIdx_; }
@@ -25,7 +27,7 @@ public:
   // Index of the pixel track associated to each of the LST track candidates.
   // If not associated to a pixel track, which is the case for T5s, it defaults to -1.
   std::vector<int> const& seedIdx() const { return seedIdx_; }
-  // LSTTCType as per the enum above.
+  // LSTTCType from RecoTracker/LSTCore/interface/Common.h
   std::vector<short> const& trackCandidateType() const { return trackCandidateType_; }
 
 private:

--- a/RecoTracker/LST/python/lstProducerTask_cff.py
+++ b/RecoTracker/LST/python/lstProducerTask_cff.py
@@ -4,5 +4,4 @@ from RecoTracker.LST.lstProducer_cfi import lstProducer
 
 from RecoTracker.LST.lstModulesDevESProducer_cfi import lstModulesDevESProducer
 
-# not scheduled task to get the framework to hide the producer
 lstProducerTask = cms.Task(lstModulesDevESProducer, lstProducer)

--- a/RecoTracker/LSTCore/interface/Common.h
+++ b/RecoTracker/LSTCore/interface/Common.h
@@ -44,7 +44,7 @@ namespace lst {
 #if defined(FP16_Base)
 #define __F2H __float2half
 #define __H2F __half2float
-  typedef __half float FPX;
+  typedef __half FPX;
 #else
 #define __F2H
 #define __H2F

--- a/RecoTracker/LSTCore/interface/LSTESData.h
+++ b/RecoTracker/LSTCore/interface/LSTESData.h
@@ -8,7 +8,6 @@
 
 #include "HeterogeneousCore/AlpakaInterface/interface/CopyToDevice.h"
 
-#include <filesystem>
 #include <memory>
 
 namespace lst {
@@ -19,8 +18,9 @@ namespace lst {
     uint16_t nLowerModules;
     unsigned int nPixels;
     unsigned int nEndCapMap;
-    std::unique_ptr<const PortableMultiCollection<TDev, ModulesSoA, ModulesPixelSoA>> modules;
-    std::unique_ptr<const PortableCollection<EndcapGeometryDevSoA, TDev>> endcapGeometry;
+    // Using shared_ptr so that for the serial backend all streams can use the same data
+    std::shared_ptr<const PortableMultiCollection<TDev, ModulesSoA, ModulesPixelSoA>> modules;
+    std::shared_ptr<const PortableCollection<EndcapGeometryDevSoA, TDev>> endcapGeometry;
     // Host-side object that is shared between the LSTESData<TDev> objects for different devices
     std::shared_ptr<const PixelMap> pixelMapping;
 
@@ -28,8 +28,8 @@ namespace lst {
               uint16_t const& nLowerModulesIn,
               unsigned int const& nPixelsIn,
               unsigned int const& nEndCapMapIn,
-              std::unique_ptr<const PortableMultiCollection<TDev, ModulesSoA, ModulesPixelSoA>> modulesIn,
-              std::unique_ptr<const PortableCollection<EndcapGeometryDevSoA, TDev>> endcapGeometryIn,
+              std::shared_ptr<const PortableMultiCollection<TDev, ModulesSoA, ModulesPixelSoA>> modulesIn,
+              std::shared_ptr<const PortableCollection<EndcapGeometryDevSoA, TDev>> endcapGeometryIn,
               std::shared_ptr<const PixelMap> const& pixelMappingIn)
         : nModules(nModulesIn),
           nLowerModules(nLowerModulesIn),
@@ -46,41 +46,25 @@ namespace lst {
 
 namespace cms::alpakatools {
 
-  // The templated definition in CMSSW doesn't work when using CPU as the device
-  template <>
-  struct CopyToDevice<PortableHostCollection<lst::EndcapGeometryDevSoA>> {
-    template <typename TQueue>
-    static auto copyAsync(TQueue& queue, PortableHostCollection<lst::EndcapGeometryDevSoA> const& srcData) {
-      using TDevice = typename alpaka::trait::DevType<TQueue>::type;
-      PortableCollection<lst::EndcapGeometryDevSoA, TDevice> dstData(srcData->metadata().size(), queue);
-      alpaka::memcpy(queue, dstData.buffer(), srcData.buffer());
-      return dstData;
-    }
-  };
-
-  template <>
-  struct CopyToDevice<PortableHostMultiCollection<lst::ModulesSoA, lst::ModulesPixelSoA>> {
-    template <typename TQueue>
-    static auto copyAsync(TQueue& queue,
-                          PortableHostMultiCollection<lst::ModulesSoA, lst::ModulesPixelSoA> const& srcData) {
-      using TDevice = typename alpaka::trait::DevType<TQueue>::type;
-      PortableMultiCollection<TDevice, lst::ModulesSoA, lst::ModulesPixelSoA> dstData(srcData.sizes(), queue);
-      alpaka::memcpy(queue, dstData.buffer(), srcData.buffer());
-      return dstData;
-    }
-  };
-
   template <>
   struct CopyToDevice<lst::LSTESData<alpaka_common::DevHost>> {
     template <typename TQueue>
     static lst::LSTESData<alpaka::Dev<TQueue>> copyAsync(TQueue& queue,
                                                          lst::LSTESData<alpaka_common::DevHost> const& srcData) {
-      auto deviceModules =
-          std::make_unique<PortableMultiCollection<alpaka::Dev<TQueue>, lst::ModulesSoA, lst::ModulesPixelSoA>>(
-              CopyToDevice<PortableHostMultiCollection<lst::ModulesSoA, lst::ModulesPixelSoA>>::copyAsync(
-                  queue, *srcData.modules));
-      auto deviceEndcapGeometry = std::make_unique<PortableCollection<lst::EndcapGeometryDevSoA, alpaka::Dev<TQueue>>>(
-          CopyToDevice<PortableHostCollection<lst::EndcapGeometryDevSoA>>::copyAsync(queue, *srcData.endcapGeometry));
+      using TDev = alpaka::Dev<TQueue>;
+      std::shared_ptr<const PortableMultiCollection<TDev, lst::ModulesSoA, lst::ModulesPixelSoA>> deviceModules;
+      std::shared_ptr<const PortableCollection<lst::EndcapGeometryDevSoA, TDev>> deviceEndcapGeometry;
+
+      if constexpr (std::is_same_v<TDev, alpaka_common::DevHost>) {
+        deviceModules = srcData.modules;
+        deviceEndcapGeometry = srcData.endcapGeometry;
+      } else {
+        deviceModules = std::make_shared<PortableMultiCollection<TDev, lst::ModulesSoA, lst::ModulesPixelSoA>>(
+            CopyToDevice<PortableHostMultiCollection<lst::ModulesSoA, lst::ModulesPixelSoA>>::copyAsync(
+                queue, *srcData.modules));
+        deviceEndcapGeometry = std::make_shared<PortableCollection<lst::EndcapGeometryDevSoA, TDev>>(
+            CopyToDevice<PortableHostCollection<lst::EndcapGeometryDevSoA>>::copyAsync(queue, *srcData.endcapGeometry));
+      }
 
       return lst::LSTESData<alpaka::Dev<TQueue>>(srcData.nModules,
                                                  srcData.nLowerModules,

--- a/RecoTracker/LSTCore/interface/PixelMap.h
+++ b/RecoTracker/LSTCore/interface/PixelMap.h
@@ -17,8 +17,6 @@ namespace lst {
     std::vector<unsigned int> connectedPixelsIndexNeg;
     std::vector<unsigned int> connectedPixelsSizesNeg;
 
-    const int* pixelType;
-
     PixelMap(unsigned int sizef = size_superbins)
         : pixelModuleIndex(0),
           connectedPixelsIndex(sizef),

--- a/RecoTracker/LSTCore/src/LSTESData.cc
+++ b/RecoTracker/LSTCore/src/LSTESData.cc
@@ -6,6 +6,8 @@
 
 #include "ModuleMethods.h"
 
+#include <filesystem>
+
 namespace {
   std::string geometryDataDir() {
     const char* path_lst_base = std::getenv("LST_BASE");
@@ -88,7 +90,7 @@ std::unique_ptr<lst::LSTESData<alpaka_common::DevHost>> lst::loadAndFillESHost()
   ::loadMapsHost(pLStoLayer, endcapGeometry, tiltedGeometry, moduleConnectionMap);
 
   auto endcapGeometryDev =
-      std::make_unique<EndcapGeometryDevHostCollection>(endcapGeometry.nEndCapMap, cms::alpakatools::host());
+      std::make_shared<EndcapGeometryDevHostCollection>(endcapGeometry.nEndCapMap, cms::alpakatools::host());
   std::memcpy(endcapGeometryDev->view().geoMapDetId(),
               endcapGeometry.geoMapDetId_buf.data(),
               endcapGeometry.nEndCapMap * sizeof(unsigned int));

--- a/RecoTracker/LSTCore/src/ModuleMethods.h
+++ b/RecoTracker/LSTCore/src/ModuleMethods.h
@@ -218,7 +218,7 @@ namespace lst {
     nModules = counter;
   }
 
-  inline std::unique_ptr<ModulesHostCollection> loadModulesFromFile(MapPLStoLayer const& pLStoLayer,
+  inline std::shared_ptr<ModulesHostCollection> loadModulesFromFile(MapPLStoLayer const& pLStoLayer,
                                                                     const char* moduleMetaDataFilePath,
                                                                     uint16_t& nModules,
                                                                     uint16_t& nLowerModules,
@@ -241,7 +241,7 @@ namespace lst {
 
     std::array<int, 2> const modules_sizes{{static_cast<int>(nModules), static_cast<int>(nPixels)}};
 
-    auto modulesHC = std::make_unique<ModulesHostCollection>(modules_sizes, cms::alpakatools::host());
+    auto modulesHC = std::make_shared<ModulesHostCollection>(modules_sizes, cms::alpakatools::host());
 
     auto modules_view = modulesHC->view<ModulesSoA>();
 

--- a/RecoTracker/LSTCore/src/alpaka/LSTEvent.dev.cc
+++ b/RecoTracker/LSTCore/src/alpaka/LSTEvent.dev.cc
@@ -22,18 +22,14 @@ void LSTEvent::initSync() {
 
   //reset the arrays
   for (int i = 0; i < 6; i++) {
-    n_hits_by_layer_barrel_[i] = 0;
     n_minidoublets_by_layer_barrel_[i] = 0;
     n_segments_by_layer_barrel_[i] = 0;
     n_triplets_by_layer_barrel_[i] = 0;
-    n_trackCandidates_by_layer_barrel_[i] = 0;
     n_quintuplets_by_layer_barrel_[i] = 0;
     if (i < 5) {
-      n_hits_by_layer_endcap_[i] = 0;
       n_minidoublets_by_layer_endcap_[i] = 0;
       n_segments_by_layer_endcap_[i] = 0;
       n_triplets_by_layer_endcap_[i] = 0;
-      n_trackCandidates_by_layer_endcap_[i] = 0;
       n_quintuplets_by_layer_endcap_[i] = 0;
     }
   }
@@ -43,18 +39,14 @@ void LSTEvent::resetEventSync() {
   alpaka::wait(queue_);  // synchronize to reset consistently
   //reset the arrays
   for (int i = 0; i < 6; i++) {
-    n_hits_by_layer_barrel_[i] = 0;
     n_minidoublets_by_layer_barrel_[i] = 0;
     n_segments_by_layer_barrel_[i] = 0;
     n_triplets_by_layer_barrel_[i] = 0;
-    n_trackCandidates_by_layer_barrel_[i] = 0;
     n_quintuplets_by_layer_barrel_[i] = 0;
     if (i < 5) {
-      n_hits_by_layer_endcap_[i] = 0;
       n_minidoublets_by_layer_endcap_[i] = 0;
       n_segments_by_layer_endcap_[i] = 0;
       n_triplets_by_layer_endcap_[i] = 0;
-      n_trackCandidates_by_layer_endcap_[i] = 0;
       n_quintuplets_by_layer_endcap_[i] = 0;
     }
   }
@@ -1266,29 +1258,6 @@ void LSTEvent::addTripletsToEventExplicit() {
     }
   }
 }
-
-unsigned int LSTEvent::getNumberOfHits() {
-  unsigned int hits = 0;
-  for (auto& it : n_hits_by_layer_barrel_) {
-    hits += it;
-  }
-  for (auto& it : n_hits_by_layer_endcap_) {
-    hits += it;
-  }
-
-  return hits;
-}
-
-unsigned int LSTEvent::getNumberOfHitsByLayer(unsigned int layer) {
-  if (layer == 6)
-    return n_hits_by_layer_barrel_[layer];
-  else
-    return n_hits_by_layer_barrel_[layer] + n_hits_by_layer_endcap_[layer];
-}
-
-unsigned int LSTEvent::getNumberOfHitsByLayerBarrel(unsigned int layer) { return n_hits_by_layer_barrel_[layer]; }
-
-unsigned int LSTEvent::getNumberOfHitsByLayerEndcap(unsigned int layer) { return n_hits_by_layer_endcap_[layer]; }
 
 unsigned int LSTEvent::getNumberOfMiniDoublets() {
   unsigned int miniDoublets = 0;

--- a/RecoTracker/LSTCore/src/alpaka/LSTEvent.h
+++ b/RecoTracker/LSTCore/src/alpaka/LSTEvent.h
@@ -37,16 +37,12 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
   private:
     Queue& queue_;
 
-    std::array<unsigned int, 6> n_hits_by_layer_barrel_{};
-    std::array<unsigned int, 5> n_hits_by_layer_endcap_{};
     std::array<unsigned int, 6> n_minidoublets_by_layer_barrel_{};
     std::array<unsigned int, 5> n_minidoublets_by_layer_endcap_{};
     std::array<unsigned int, 6> n_segments_by_layer_barrel_{};
     std::array<unsigned int, 5> n_segments_by_layer_endcap_{};
     std::array<unsigned int, 6> n_triplets_by_layer_barrel_{};
     std::array<unsigned int, 5> n_triplets_by_layer_endcap_{};
-    std::array<unsigned int, 6> n_trackCandidates_by_layer_barrel_{};
-    std::array<unsigned int, 5> n_trackCandidates_by_layer_endcap_{};
     std::array<unsigned int, 6> n_quintuplets_by_layer_barrel_{};
     std::array<unsigned int, 5> n_quintuplets_by_layer_endcap_{};
     unsigned int nTotalSegments_;
@@ -139,11 +135,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     void addQuintupletsToEventExplicit();
     void addTripletsToEventExplicit();
     void resetObjectsInModule();
-
-    unsigned int getNumberOfHits();
-    unsigned int getNumberOfHitsByLayer(unsigned int layer);
-    unsigned int getNumberOfHitsByLayerBarrel(unsigned int layer);
-    unsigned int getNumberOfHitsByLayerEndcap(unsigned int layer);
 
     unsigned int getNumberOfMiniDoublets();
     unsigned int getNumberOfMiniDoubletsByLayer(unsigned int layer);

--- a/RecoTracker/LSTCore/src/alpaka/MiniDoublet.h
+++ b/RecoTracker/LSTCore/src/alpaka/MiniDoublet.h
@@ -85,7 +85,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     mds.outerLowEdgeY()[idx] = hits.lowEdgeYs()[outerHitIndex];
   }
 
-  ALPAKA_FN_ACC ALPAKA_FN_INLINE float isTighterTiltedModules(ModulesConst modules, uint16_t moduleIndex) {
+  ALPAKA_FN_ACC ALPAKA_FN_INLINE bool isTighterTiltedModules(ModulesConst modules, uint16_t moduleIndex) {
     // The "tighter" tilted modules are the subset of tilted modules that have smaller spacing
     // This is the same as what was previously considered as"isNormalTiltedModules"
     // See Figure 9.1 of https://cds.cern.ch/record/2272264/files/CMS-TDR-014.pdf

--- a/RecoTracker/LSTCore/src/alpaka/Segment.h
+++ b/RecoTracker/LSTCore/src/alpaka/Segment.h
@@ -15,7 +15,7 @@
 
 namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
 
-  ALPAKA_FN_ACC ALPAKA_FN_INLINE float isTighterTiltedModules_seg(ModulesConst modules, unsigned int moduleIndex) {
+  ALPAKA_FN_ACC ALPAKA_FN_INLINE bool isTighterTiltedModules_seg(ModulesConst modules, unsigned int moduleIndex) {
     // The "tighter" tilted modules are the subset of tilted modules that have smaller spacing
     // This is the same as what was previously considered as"isNormalTiltedModules"
     // See Figure 9.1 of https://cds.cern.ch/record/2272264/files/CMS-TDR-014.pdf
@@ -29,7 +29,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
                                   ((side == PosZ) && (((layer == 2) && (rod < 8)) || ((layer == 1) && (rod < 4)))));
   }
 
-  ALPAKA_FN_ACC ALPAKA_FN_INLINE float isTighterTiltedModules_seg(short subdet, short layer, short side, short rod) {
+  ALPAKA_FN_ACC ALPAKA_FN_INLINE bool isTighterTiltedModules_seg(short subdet, short layer, short side, short rod) {
     // The "tighter" tilted modules are the subset of tilted modules that have smaller spacing
     // This is the same as what was previously considered as"isNormalTiltedModules"
     // See Figure 9.1 of https://cds.cern.ch/record/2272264/files/CMS-TDR-014.pdf

--- a/RecoTracker/LSTCore/standalone/code/core/write_lst_ntuple.cc
+++ b/RecoTracker/LSTCore/standalone/code/core/write_lst_ntuple.cc
@@ -905,7 +905,7 @@ std::tuple<float, float, float, std::vector<unsigned int>, std::vector<unsigned 
   unsigned int Hit_8 = hits[8];
 
   // T5 radius is average of the inner and outer radius
-  const float pt = quintuplets.innerRadius()[T5] * k2Rinv1GeVf * 2;
+  const float pt = __H2F(quintuplets.innerRadius()[T5]) * k2Rinv1GeVf * 2;
 
   // T5 eta and phi are computed using outer and innermost hits
   lst_math::Hit hitA(trk.ph2_x()[Hit_0], trk.ph2_y()[Hit_0], trk.ph2_z()[Hit_0]);


### PR DESCRIPTION
#### 4b27e43926a94b14ecf323e44d07608b2768140e
- fix compilation when FP16 is enabled
- function return type float -> bool following https://github.com/cms-sw/cmssw/pull/45117#discussion_r1833298923

#### ef05b08c60a50787ddd42de484731565fd7767b1
- remove unused arrays following https://github.com/cms-sw/cmssw/pull/45117#discussion_r1750009731 and https://github.com/cms-sw/cmssw/pull/45117#discussion_r1750009570
- catch-up update in `LSTTCType` to be formally the same as `LSTObjType` (itself introduced in an earlier batch)

#### 45aef12d9b8b0581819be6fd51474000dd060aca
Remove unnecessary CopyToDevice + small fixes: 
- https://github.com/cms-sw/cmssw/pull/45117#discussion_r1833227743 (move include)
- https://github.com/cms-sw/cmssw/pull/45117#discussion_r1833245889 (unnecessary CopyToDevice specialization)
- https://github.com/cms-sw/cmssw/pull/45117#discussion_r1833246174 (unnecessary CopyToDevice specialization)
- https://github.com/cms-sw/cmssw/pull/45117#discussion_r1833249693 (unused data member)
- https://github.com/cms-sw/cmssw/pull/45117#discussion_r1833298923 (wrong return type)

