### PR TITLE
batch10 of updates for LST integration in CMSSW 

### DIFF
--- a/Configuration/PyReleaseValidation/README.md
+++ b/Configuration/PyReleaseValidation/README.md
@@ -65,8 +65,8 @@ The offsets currently in use are:
 * 0.7: trackingMkFit modifier
 * 0.701: DisplacedRegionalStep tracking iteration for Run-3
 * 0.702: trackingMkFit modifier for Phase-2 (initialStep only)
-* 0.703: LST tracking, initialStep+HighPtTripletStep only, on CPU
-* 0.704: LST tracking, initialStep+HighPtTripletStep only, on GPU
+* 0.703: LST tracking (Phase-2 only), initialStep+HighPtTripletStep only, on CPU
+* 0.704: LST tracking (Phase-2 only), initialStep+HighPtTripletStep only, on GPU
 * 0.75: HLT phase-2 timing menu
 * 0.751: HLT phase-2 timing menu Alpaka variant
 * 0.752: HLT phase-2 timing menu ticl_v5 variant

--- a/Configuration/PyReleaseValidation/python/relval_Run4.py
+++ b/Configuration/PyReleaseValidation/python/relval_Run4.py
@@ -37,7 +37,7 @@ numWFIB.extend([31234.0]) #Run4D114
 numWFIB.extend([32034.0]) #Run4D115
 
 # Temporary placement for LST workflow to workaround PR conflicts - to be formatted and placed in an upcoming PR
-numWFIB.extend([24834.703,24834.704]) #2026D98 LST tracking (initialStep+HighPtTripletStep only): CPU, GPU
+numWFIB.extend([24834.703]) #Run4D98 LST tracking (initialStep+HighPtTripletStep only)
 
 #Additional sample for short matrix and IB
 #Default Phase-2 Det NoPU

--- a/Configuration/PyReleaseValidation/python/relval_gpu.py
+++ b/Configuration/PyReleaseValidation/python/relval_gpu.py
@@ -72,6 +72,8 @@ numWFIB = [
            # Run4, Alpaka-based noPU
            29634.402, 29634.403, 29634.404, 29634.406,
            29661.402,
+           # Run4, Alpaka-based noPU GPU LST tracking D98
+           24834.704,
 
            # Run4, Alpaka-based PU
            29834.402, 29834.403, 29834.404


### PR DESCRIPTION
move 24834.704 from relval_Run4 to to relval_gpu; update description/comment
to address
- https://github.com/cms-sw/cmssw/pull/45117#discussion_r1846213397  : move 24834.704 from relval_Run4 to to relval_gpu
- https://github.com/cms-sw/cmssw/pull/45117#discussion_r1844143282 to mention in README that LST is Phase-2
- https://github.com/cms-sw/cmssw/pull/45117#discussion_r1844129351 update comment from 2026 to Run4

