### PR TITLE
Single iteration Patatrack and LST in Phase 2 HLT

### DIFF
--- a/Configuration/ProcessModifiers/python/seedingLST_cff.py
+++ b/Configuration/ProcessModifiers/python/seedingLST_cff.py
@@ -1,0 +1,5 @@
+import FWCore.ParameterSet.Config as cms
+
+# This modifier sets the LST (Phase-2 line segment tracking) used for track seeding
+# Needs to be used on top of the trackingLST modifier
+seedingLST = cms.Modifier()

--- a/Configuration/ProcessModifiers/python/singleIterPatatrack_cff.py
+++ b/Configuration/ProcessModifiers/python/singleIterPatatrack_cff.py
@@ -1,0 +1,6 @@
+import FWCore.ParameterSet.Config as cms
+
+# This modifier merges the initialStep and highPtTripletStep iterations
+# to a single iteration using Patatrack pixel tracks with >3 hits as seeds
+singleIterPatatrack = cms.Modifier()
+

--- a/Configuration/ProcessModifiers/python/singleIterPatatrack_cff.py
+++ b/Configuration/ProcessModifiers/python/singleIterPatatrack_cff.py
@@ -3,4 +3,3 @@ import FWCore.ParameterSet.Config as cms
 # This modifier merges the initialStep and highPtTripletStep iterations
 # to a single iteration using Patatrack pixel tracks with >3 hits as seeds
 singleIterPatatrack = cms.Modifier()
-

--- a/Configuration/PyReleaseValidation/README.md
+++ b/Configuration/PyReleaseValidation/README.md
@@ -70,6 +70,9 @@ The offsets currently in use are:
 * 0.75: HLT phase-2 timing menu
 * 0.751: HLT phase-2 timing menu Alpaka variant
 * 0.752: HLT phase-2 timing menu ticl_v5 variant
+* 0.753: HLT phase-2 timing menu Alpaka, single tracking iteration variant
+* 0.754: HLT phase-2 timing menu Alpaka, single tracking iteration, LST building variant
+* 0.755: HLT phase-2 timing menu Alpaka, LST building variant
 * 0.78: Complete L1 workflow
 * 0.8: BPH Parking (Run-2)
 * 0.81: Running also HeavyFlavor DQM
@@ -91,7 +94,6 @@ The offsets currently in use are:
 * 0.633: ECAL phase2 Trigger Primitive
 * 0.634: ECAL phase2 Trigger Primitive + component-method based digis
 * 0.635: ECAL phase2 Trigger Primitive + component-method based finely-sampled waveforms
-* 0.75: Phase-2 HLT Timing menu
 * 0.91: Track DNN modifier
 * 0.97: Premixing stage1
 * 0.98: Premixing stage2

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -2128,6 +2128,30 @@ upgradeWFs['HLTTiming75e33TiclV5'].step2 = {
     '--procModifiers': 'ticl_v5'
 }
 
+upgradeWFs['HLTTiming75e33AlpakaSingleIter'] = deepcopy(upgradeWFs['HLTTiming75e33'])
+upgradeWFs['HLTTiming75e33AlpakaSingleIter'].suffix = '_HLT75e33TimingAlpakaSingleIter'
+upgradeWFs['HLTTiming75e33AlpakaSingleIter'].offset = 0.753
+upgradeWFs['HLTTiming75e33AlpakaSingleIter'].step2 = {
+    '-s':'DIGI:pdigi_valid,L1TrackTrigger,L1,L1P2GT,DIGI2RAW,HLT:75e33_timing',
+    '--procModifiers': 'alpaka,singleIterPatatrack'
+}
+
+upgradeWFs['HLTTiming75e33AlpakaSingleIterLST'] = deepcopy(upgradeWFs['HLTTiming75e33'])
+upgradeWFs['HLTTiming75e33AlpakaSingleIterLST'].suffix = '_HLT75e33TimingAlpakaSingleIterLST'
+upgradeWFs['HLTTiming75e33AlpakaSingleIterLST'].offset = 0.754
+upgradeWFs['HLTTiming75e33AlpakaSingleIterLST'].step2 = {
+    '-s':'DIGI:pdigi_valid,L1TrackTrigger,L1,L1P2GT,DIGI2RAW,HLT:75e33_timing',
+    '--procModifiers': 'alpaka,singleIterPatatrack,trackingLST'
+}
+
+upgradeWFs['HLTTiming75e33AlpakaLST'] = deepcopy(upgradeWFs['HLTTiming75e33'])
+upgradeWFs['HLTTiming75e33AlpakaLST'].suffix = '_HLT75e33TimingAlpakaLST'
+upgradeWFs['HLTTiming75e33AlpakaLST'].offset = 0.755
+upgradeWFs['HLTTiming75e33AlpakaLST'].step2 = {
+    '-s':'DIGI:pdigi_valid,L1TrackTrigger,L1,L1P2GT,DIGI2RAW,HLT:75e33_timing',
+    '--procModifiers': 'alpaka,trackingLST'
+}
+
 
 class UpgradeWorkflow_HLTwDIGI75e33(UpgradeWorkflow):
     def setup_(self, step, stepName, stepDict, k, properties):

--- a/HLTrigger/Configuration/python/HLT_75e33/eventsetup/hltESPModulesDevLST_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/eventsetup/hltESPModulesDevLST_cfi.py
@@ -1,0 +1,12 @@
+import FWCore.ParameterSet.Config as cms
+
+def _addProcessModulesDevLST(process):
+    process.hltESPModulesDevLST = cms.ESProducer('LSTModulesDevESProducer@alpaka',
+        appendToDataLabel = cms.string(''),
+        alpaka = cms.untracked.PSet(
+          backend = cms.untracked.string('')
+        )
+    )
+
+from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
+modifyConfigurationForTrackingLSTModulesDevLST_ = trackingLST.makeProcessModifier(_addProcessModulesDevLST)

--- a/HLTrigger/Configuration/python/HLT_75e33/eventsetup/hltESPModulesDevLST_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/eventsetup/hltESPModulesDevLST_cfi.py
@@ -4,7 +4,7 @@ def _addProcessModulesDevLST(process):
     process.hltESPModulesDevLST = cms.ESProducer('LSTModulesDevESProducer@alpaka',
         appendToDataLabel = cms.string(''),
         alpaka = cms.untracked.PSet(
-          backend = cms.untracked.string('')
+            backend = cms.untracked.string('')
         )
     )
 

--- a/HLTrigger/Configuration/python/HLT_75e33/eventsetup/hltESPTTRHBuilderWithTrackAngle_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/eventsetup/hltESPTTRHBuilderWithTrackAngle_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-hltTTRBWR = cms.ESProducer("TkTransientTrackingRecHitBuilderESProducer",
-    ComponentName = cms.string('hltESPTTRHBWithTrackAngle'),
+hltESPTTRHBuilderWithTrackAngle = cms.ESProducer("TkTransientTrackingRecHitBuilderESProducer",
+    ComponentName = cms.string('hltESPTTRHBuilderWithTrackAngle'),
     ComputeCoarseLocalPositionFromDisk = cms.bool(False),
     Matcher = cms.string('StandardMatcher'),
     Phase2StripCPE = cms.string('Phase2StripCPE'),

--- a/HLTrigger/Configuration/python/HLT_75e33/eventsetup/hltESPTTRHBuilderWithoutRefit_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/eventsetup/hltESPTTRHBuilderWithoutRefit_cfi.py
@@ -1,0 +1,14 @@
+import FWCore.ParameterSet.Config as cms
+
+def _addProcessTTRHBuilderWithoutRefit(process):
+    process.hltESPTTRHBuilderWithoutRefit = cms.ESProducer("TkTransientTrackingRecHitBuilderESProducer",
+        ComponentName = cms.string('WithoutRefit'),
+        ComputeCoarseLocalPositionFromDisk = cms.bool(False),
+        Matcher = cms.string('Fake'),
+        Phase2StripCPE = cms.string(''),
+        PixelCPE = cms.string('Fake'),
+        StripCPE = cms.string('Fake')
+    )
+
+from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
+modifyConfigurationForTrackingLSTTTRHBuilderWithoutRefit_ = trackingLST.makeProcessModifier(_addProcessTTRHBuilderWithoutRefit)

--- a/HLTrigger/Configuration/python/HLT_75e33/eventsetup/hltESPTTRHBuilderWithoutRefit_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/eventsetup/hltESPTTRHBuilderWithoutRefit_cfi.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 def _addProcessTTRHBuilderWithoutRefit(process):
     process.hltESPTTRHBuilderWithoutRefit = cms.ESProducer("TkTransientTrackingRecHitBuilderESProducer",
-        ComponentName = cms.string('WithoutRefit'),
+        ComponentName = cms.string('hltESPTTRHBuilderWithoutRefit'),
         ComputeCoarseLocalPositionFromDisk = cms.bool(False),
         Matcher = cms.string('Fake'),
         Phase2StripCPE = cms.string(''),

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltGeneralTracks_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltGeneralTracks_cfi.py
@@ -24,3 +24,58 @@ hltGeneralTracks = cms.EDProducer("TrackListMerger",
     trackAlgoPriorityOrder = cms.string('trackAlgoPriorityOrder'),
     writeOnlyTrkQuals = cms.bool(False)
 )
+
+_hltGeneralTracksSingleIterPatatrack = hltGeneralTracks.clone(
+    TrackProducers = ["hltInitialStepTrackSelectionHighPurity"],
+    hasSelector = [0],
+    indivShareFrac = [1.0],
+    selectedTrackQuals = ["hltInitialStepTrackSelectionHighPurity"],
+    setsToMerge = [cms.PSet(
+        pQual = cms.bool(True),
+        tLists = cms.vint32(0)
+    )]
+)
+
+from Configuration.ProcessModifiers.singleIterPatatrack_cff import singleIterPatatrack
+singleIterPatatrack.toReplaceWith(hltGeneralTracks, _hltGeneralTracksSingleIterPatatrack)
+
+_hltGeneralTracksLST = hltGeneralTracks.clone(
+    TrackProducers = ["hltInitialStepTrackSelectionHighPuritypTTCLST", "hltInitialStepTrackSelectionHighPuritypLSTCLST", "hltInitialStepTracksT5TCLST", "hltHighPtTripletStepTrackSelectionHighPurity"],
+    hasSelector = [0,0,0,0],
+    indivShareFrac = [0.1,0.1,0.1,0.1],
+    selectedTrackQuals = ["hltInitialStepTrackSelectionHighPuritypTTCLST", "hltInitialStepTrackSelectionHighPuritypLSTCLST", "hltInitialStepTracksT5TCLST", "hltHighPtTripletStepTrackSelectionHighPurity"],
+    setsToMerge = [cms.PSet(
+        pQual = cms.bool(True),
+        tLists = cms.vint32(0,1,2,3)
+    )]
+)
+
+from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
+trackingLST.toReplaceWith(hltGeneralTracks, _hltGeneralTracksLST)
+
+_hltGeneralTracksLSTSingleIterPatatrack = hltGeneralTracks.clone(
+    TrackProducers = ["hltInitialStepTrackSelectionHighPuritypTTCLST", "hltInitialStepTrackSelectionHighPuritypLSTCLST", "hltInitialStepTracksT5TCLST"],
+    hasSelector = [0,0,0],
+    indivShareFrac = [0.1,0.1,0.1],
+    selectedTrackQuals = ["hltInitialStepTrackSelectionHighPuritypTTCLST", "hltInitialStepTrackSelectionHighPuritypLSTCLST", "hltInitialStepTracksT5TCLST"],
+    setsToMerge = [cms.PSet(
+        pQual = cms.bool(True),
+        tLists = cms.vint32(0,1,2)
+    )]
+)
+
+(singleIterPatatrack & trackingLST).toReplaceWith(hltGeneralTracks, _hltGeneralTracksLSTSingleIterPatatrack)
+
+_hltGeneralTracksLSTSeeding = hltGeneralTracks.clone(
+            TrackProducers = ["hltInitialStepTrackSelectionHighPuritypTTCLST", "hltInitialStepTracksT5TCLST", "hltHighPtTripletStepTrackSelectionHighPuritypLSTCLST"],
+            hasSelector = [0,0,0],
+            indivShareFrac = [0.1,0.1,0.1],
+            selectedTrackQuals = ["hltInitialStepTrackSelectionHighPuritypTTCLST", "hltInitialStepTracksT5TCLST", "hltHighPtTripletStepTrackSelectionHighPuritypLSTCLST"],
+            setsToMerge = [cms.PSet(
+               pQual = cms.bool(True),
+               tLists = cms.vint32(0,1,2)
+            )]
+    )
+
+from Configuration.ProcessModifiers.seedingLST_cff import seedingLST
+(seedingLST & trackingLST).toReplaceWith(hltGeneralTracks, _hltGeneralTracksLSTSeeding)

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltHighPtTripletStepClusters_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltHighPtTripletStepClusters_cfi.py
@@ -19,4 +19,3 @@ _hltHighPtTripletStepClustersLST = hltHighPtTripletStepClusters.clone(
 
 from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
 trackingLST.toReplaceWith(hltHighPtTripletStepClusters, _hltHighPtTripletStepClustersLST)
-

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltHighPtTripletStepClusters_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltHighPtTripletStepClusters_cfi.py
@@ -12,3 +12,11 @@ hltHighPtTripletStepClusters = cms.EDProducer("TrackClusterRemoverPhase2",
     trackClassifier = cms.InputTag("","QualityMasks"),
     trajectories = cms.InputTag("hltInitialStepTrackSelectionHighPurity")
 )
+
+_hltHighPtTripletStepClustersLST = hltHighPtTripletStepClusters.clone(
+    trajectories = "hltInitialStepSeedTracksLST"
+)
+
+from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
+trackingLST.toReplaceWith(hltHighPtTripletStepClusters, _hltHighPtTripletStepClustersLST)
+

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltHighPtTripletStepSeedTracksLST_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltHighPtTripletStepSeedTracksLST_cfi.py
@@ -4,6 +4,5 @@ hltHighPtTripletStepSeedTracksLST = cms.EDProducer(
     "TrackFromSeedProducer",
     src = cms.InputTag("hltHighPtTripletStepSeeds"),
     beamSpot = cms.InputTag("hltOnlineBeamSpot"),
-    TTRHBuilder = cms.string("WithoutRefit")
+    TTRHBuilder = cms.string("hltESPTTRHBuilderWithoutRefit")
 )
-

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltHighPtTripletStepSeedTracksLST_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltHighPtTripletStepSeedTracksLST_cfi.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 hltHighPtTripletStepSeedTracksLST = cms.EDProducer(
     "TrackFromSeedProducer",
     src = cms.InputTag("hltHighPtTripletStepSeeds"),
-    beamSpot = cms.InputTag("offlineBeamSpot"),
+    beamSpot = cms.InputTag("hltOnlineBeamSpot"),
     TTRHBuilder = cms.string("WithoutRefit")
 )
 

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltHighPtTripletStepSeedTracksLST_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltHighPtTripletStepSeedTracksLST_cfi.py
@@ -1,0 +1,9 @@
+import FWCore.ParameterSet.Config as cms
+
+hltHighPtTripletStepSeedTracksLST = cms.EDProducer(
+    "TrackFromSeedProducer",
+    src = cms.InputTag("hltHighPtTripletStepSeeds"),
+    beamSpot = cms.InputTag("offlineBeamSpot"),
+    TTRHBuilder = cms.string("WithoutRefit")
+)
+

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltHighPtTripletStepTrackCandidatespLSTCLST_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltHighPtTripletStepTrackCandidatespLSTCLST_cfi.py
@@ -2,4 +2,3 @@ import FWCore.ParameterSet.Config as cms
 
 from ..modules.hltHighPtTripletStepTrackCandidates_cfi import hltHighPtTripletStepTrackCandidates as _hltHighPtTripletStepTrackCandidates
 hltHighPtTripletStepTrackCandidatespLSTCLST = _hltHighPtTripletStepTrackCandidates.clone( src = "hltInitialStepTrackCandidates:pLSTSsLST" )
-

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltHighPtTripletStepTrackCandidatespLSTCLST_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltHighPtTripletStepTrackCandidatespLSTCLST_cfi.py
@@ -1,0 +1,5 @@
+import FWCore.ParameterSet.Config as cms
+
+from ..modules.hltHighPtTripletStepTrackCandidates_cfi import hltHighPtTripletStepTrackCandidates as _hltHighPtTripletStepTrackCandidates
+hltHighPtTripletStepTrackCandidatespLSTCLST = _hltHighPtTripletStepTrackCandidates.clone( src = "hltInitialStepTrackCandidates:pLSTSsLST" )
+

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltHighPtTripletStepTrackCutClassifierpLSTCLST_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltHighPtTripletStepTrackCutClassifierpLSTCLST_cfi.py
@@ -1,0 +1,5 @@
+import FWCore.ParameterSet.Config as cms
+
+from ..modules.hltHighPtTripletStepTrackCutClassifier_cfi import hltHighPtTripletStepTrackCutClassifier as _hltHighPtTripletStepTrackCutClassifier
+hltHighPtTripletStepTrackCutClassifierpLSTCLST = _hltHighPtTripletStepTrackCutClassifier.clone( src = "hltHighPtTripletStepTrackspLSTCLST" )
+

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltHighPtTripletStepTrackCutClassifierpLSTCLST_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltHighPtTripletStepTrackCutClassifierpLSTCLST_cfi.py
@@ -2,4 +2,3 @@ import FWCore.ParameterSet.Config as cms
 
 from ..modules.hltHighPtTripletStepTrackCutClassifier_cfi import hltHighPtTripletStepTrackCutClassifier as _hltHighPtTripletStepTrackCutClassifier
 hltHighPtTripletStepTrackCutClassifierpLSTCLST = _hltHighPtTripletStepTrackCutClassifier.clone( src = "hltHighPtTripletStepTrackspLSTCLST" )
-

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltHighPtTripletStepTrackSelectionHighPuritypLSTCLST_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltHighPtTripletStepTrackSelectionHighPuritypLSTCLST_cfi.py
@@ -6,4 +6,3 @@ hltHighPtTripletStepTrackSelectionHighPuritypLSTCLST = _hltHighPtTripletStepTrac
     originalQualVals = "hltHighPtTripletStepTrackCutClassifierpLSTCLST:QualityMasks",
     originalSource = "hltHighPtTripletStepTrackspLSTCLST"
 )
-

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltHighPtTripletStepTrackSelectionHighPuritypLSTCLST_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltHighPtTripletStepTrackSelectionHighPuritypLSTCLST_cfi.py
@@ -1,0 +1,9 @@
+import FWCore.ParameterSet.Config as cms
+
+from ..modules.hltHighPtTripletStepTrackSelectionHighPurity_cfi import hltHighPtTripletStepTrackSelectionHighPurity as _hltHighPtTripletStepTrackSelectionHighPurity
+hltHighPtTripletStepTrackSelectionHighPuritypLSTCLST = _hltHighPtTripletStepTrackSelectionHighPurity.clone(
+    originalMVAVals = "hltHighPtTripletStepTrackCutClassifierpLSTCLST:MVAValues",
+    originalQualVals = "hltHighPtTripletStepTrackCutClassifierpLSTCLST:QualityMasks",
+    originalSource = "hltHighPtTripletStepTrackspLSTCLST"
+)
+

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltHighPtTripletStepTrackspLSTCLST_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltHighPtTripletStepTrackspLSTCLST_cfi.py
@@ -1,0 +1,5 @@
+import FWCore.ParameterSet.Config as cms
+
+from ..modules.hltHighPtTripletStepTracks_cfi import hltHighPtTripletStepTracks as _hltHighPtTripletStepTracks
+hltHighPtTripletStepTrackspLSTCLST = _hltHighPtTripletStepTracks.clone( src = "hltHighPtTripletStepTrackCandidatespLSTCLST" )
+

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltHighPtTripletStepTrackspLSTCLST_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltHighPtTripletStepTrackspLSTCLST_cfi.py
@@ -2,4 +2,3 @@ import FWCore.ParameterSet.Config as cms
 
 from ..modules.hltHighPtTripletStepTracks_cfi import hltHighPtTripletStepTracks as _hltHighPtTripletStepTracks
 hltHighPtTripletStepTrackspLSTCLST = _hltHighPtTripletStepTracks.clone( src = "hltHighPtTripletStepTrackCandidatespLSTCLST" )
-

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepSeedTracksLST_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepSeedTracksLST_cfi.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 hltInitialStepSeedTracksLST = cms.EDProducer(
     "TrackFromSeedProducer",
     src = cms.InputTag("hltInitialStepSeeds"),
-    beamSpot = cms.InputTag("offlineBeamSpot"),
+    beamSpot = cms.InputTag("hltOnlineBeamSpot"),
     TTRHBuilder = cms.string("WithoutRefit")
 )
 

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepSeedTracksLST_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepSeedTracksLST_cfi.py
@@ -4,6 +4,5 @@ hltInitialStepSeedTracksLST = cms.EDProducer(
     "TrackFromSeedProducer",
     src = cms.InputTag("hltInitialStepSeeds"),
     beamSpot = cms.InputTag("hltOnlineBeamSpot"),
-    TTRHBuilder = cms.string("WithoutRefit")
+    TTRHBuilder = cms.string("hltESPTTRHBuilderWithoutRefit")
 )
-

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepSeedTracksLST_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepSeedTracksLST_cfi.py
@@ -1,0 +1,9 @@
+import FWCore.ParameterSet.Config as cms
+
+hltInitialStepSeedTracksLST = cms.EDProducer(
+    "TrackFromSeedProducer",
+    src = cms.InputTag("hltInitialStepSeeds"),
+    beamSpot = cms.InputTag("offlineBeamSpot"),
+    TTRHBuilder = cms.string("WithoutRefit")
+)
+

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepSeeds_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepSeeds_cfi.py
@@ -11,5 +11,9 @@ hltInitialStepSeeds = cms.EDProducer("SeedGeneratorFromProtoTracksEDProducer",
     originRadius = cms.double(0.1),
     useEventsWithNoVertex = cms.bool(True),
     usePV = cms.bool(False),
-    useProtoTrackKinematics = cms.bool(False)
+    useProtoTrackKinematics = cms.bool(False),
+    includeFourthHit = cms.bool(False)
 )
+
+from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
+trackingLST.toModify(hltInitialStepSeeds, includeFourthHit = True)

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrackCandidates_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrackCandidates_cfi.py
@@ -46,4 +46,3 @@ _hltInitialStepTrackCandidatesLST = cms.EDProducer('LSTOutputConverter',
 
 from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
 trackingLST.toReplaceWith(hltInitialStepTrackCandidates, _hltInitialStepTrackCandidatesLST)
-

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrackCandidates_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrackCandidates_cfi.py
@@ -23,3 +23,27 @@ hltInitialStepTrackCandidates = cms.EDProducer("CkfTrackCandidateMaker",
     src = cms.InputTag("hltInitialStepSeeds"),
     useHitsSplitting = cms.bool(False)
 )
+
+_hltInitialStepTrackCandidatesLST = cms.EDProducer('LSTOutputConverter',
+    lstOutput = cms.InputTag('hltLST'),
+    phase2OTHits = cms.InputTag('hltPhase2OTHitsInputLST'),
+    lstPixelSeeds = cms.InputTag('hltPixelSeedInputLST'),
+    includeT5s = cms.bool(True),
+    includeNonpLSTSs = cms.bool(False),
+    propagatorAlong = cms.ESInputTag('', 'PropagatorWithMaterial'),
+    propagatorOpposite = cms.ESInputTag('', 'PropagatorWithMaterialOpposite'),
+    SeedCreatorPSet = cms.PSet(
+        ComponentName = cms.string('SeedFromConsecutiveHitsCreator'),
+        propagator = cms.string('PropagatorWithMaterial'),
+        SeedMomentumForBOFF = cms.double(5),
+        OriginTransverseErrorMultiplier = cms.double(1),
+        MinOneOverPtError = cms.double(1),
+        magneticField = cms.string(''),
+        TTRHBuilder = cms.string('WithTrackAngle'),
+        forceKinematicWithRegionDirection = cms.bool(False)
+    )
+)
+
+from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
+trackingLST.toReplaceWith(hltInitialStepTrackCandidates, _hltInitialStepTrackCandidatesLST)
+

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrackCutClassifierpLSTCLST_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrackCutClassifierpLSTCLST_cfi.py
@@ -2,4 +2,3 @@ import FWCore.ParameterSet.Config as cms
 
 from ..modules.hltInitialStepTrackCutClassifier_cfi import hltInitialStepTrackCutClassifier as _hltInitialStepTrackCutClassifier
 hltInitialStepTrackCutClassifierpLSTCLST = _hltInitialStepTrackCutClassifier.clone( src = "hltInitialStepTrackspLSTCLST" )
-

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrackCutClassifierpLSTCLST_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrackCutClassifierpLSTCLST_cfi.py
@@ -1,0 +1,5 @@
+import FWCore.ParameterSet.Config as cms
+
+from ..modules.hltInitialStepTrackCutClassifier_cfi import hltInitialStepTrackCutClassifier as _hltInitialStepTrackCutClassifier
+hltInitialStepTrackCutClassifierpLSTCLST = _hltInitialStepTrackCutClassifier.clone( src = "hltInitialStepTrackspLSTCLST" )
+

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrackCutClassifierpTTCLST_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrackCutClassifierpTTCLST_cfi.py
@@ -1,0 +1,5 @@
+import FWCore.ParameterSet.Config as cms
+
+from ..modules.hltInitialStepTrackCutClassifier_cfi import hltInitialStepTrackCutClassifier as _hltInitialStepTrackCutClassifier
+hltInitialStepTrackCutClassifierpTTCLST = _hltInitialStepTrackCutClassifier.clone( src = "hltInitialStepTrackspTTCLST" )
+

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrackCutClassifierpTTCLST_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrackCutClassifierpTTCLST_cfi.py
@@ -2,4 +2,3 @@ import FWCore.ParameterSet.Config as cms
 
 from ..modules.hltInitialStepTrackCutClassifier_cfi import hltInitialStepTrackCutClassifier as _hltInitialStepTrackCutClassifier
 hltInitialStepTrackCutClassifierpTTCLST = _hltInitialStepTrackCutClassifier.clone( src = "hltInitialStepTrackspTTCLST" )
-

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrackSelectionHighPuritypLSTCLST_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrackSelectionHighPuritypLSTCLST_cfi.py
@@ -6,4 +6,3 @@ hltInitialStepTrackSelectionHighPuritypLSTCLST = _hltInitialStepTrackSelectionHi
     originalQualVals = "hltInitialStepTrackCutClassifierpLSTCLST:QualityMasks",
     originalSource = "hltInitialStepTrackspLSTCLST"
 )
-

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrackSelectionHighPuritypLSTCLST_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrackSelectionHighPuritypLSTCLST_cfi.py
@@ -1,0 +1,9 @@
+import FWCore.ParameterSet.Config as cms
+
+from ..modules.hltInitialStepTrackSelectionHighPurity_cfi import hltInitialStepTrackSelectionHighPurity as _hltInitialStepTrackSelectionHighPurity
+hltInitialStepTrackSelectionHighPuritypLSTCLST = _hltInitialStepTrackSelectionHighPurity.clone(
+    originalMVAVals = "hltInitialStepTrackCutClassifierpLSTCLST:MVAValues",
+    originalQualVals = "hltInitialStepTrackCutClassifierpLSTCLST:QualityMasks",
+    originalSource = "hltInitialStepTrackspLSTCLST"
+)
+

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrackSelectionHighPuritypTTCLST_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrackSelectionHighPuritypTTCLST_cfi.py
@@ -1,0 +1,9 @@
+import FWCore.ParameterSet.Config as cms
+
+from ..modules.hltInitialStepTrackSelectionHighPurity_cfi import hltInitialStepTrackSelectionHighPurity as _hltInitialStepTrackSelectionHighPurity
+hltInitialStepTrackSelectionHighPuritypTTCLST = _hltInitialStepTrackSelectionHighPurity.clone(
+    originalMVAVals = "hltInitialStepTrackCutClassifierpTTCLST:MVAValues",
+    originalQualVals = "hltInitialStepTrackCutClassifierpTTCLST:QualityMasks",
+    originalSource = "hltInitialStepTrackspTTCLST"
+)
+

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrackSelectionHighPuritypTTCLST_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrackSelectionHighPuritypTTCLST_cfi.py
@@ -6,4 +6,3 @@ hltInitialStepTrackSelectionHighPuritypTTCLST = _hltInitialStepTrackSelectionHig
     originalQualVals = "hltInitialStepTrackCutClassifierpTTCLST:QualityMasks",
     originalSource = "hltInitialStepTrackspTTCLST"
 )
-

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTracksT5TCLST_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTracksT5TCLST_cfi.py
@@ -1,0 +1,5 @@
+import FWCore.ParameterSet.Config as cms
+
+from ..modules.hltInitialStepTracks_cfi import hltInitialStepTracks as _hltInitialStepTracks
+hltInitialStepTracksT5TCLST = _hltInitialStepTracks.clone( src = "hltInitialStepTrackCandidates:t5TCsLST" )
+

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTracksT5TCLST_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTracksT5TCLST_cfi.py
@@ -2,4 +2,3 @@ import FWCore.ParameterSet.Config as cms
 
 from ..modules.hltInitialStepTracks_cfi import hltInitialStepTracks as _hltInitialStepTracks
 hltInitialStepTracksT5TCLST = _hltInitialStepTracks.clone( src = "hltInitialStepTrackCandidates:t5TCsLST" )
-

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrackspLSTCLST_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrackspLSTCLST_cfi.py
@@ -1,0 +1,5 @@
+import FWCore.ParameterSet.Config as cms
+
+from ..modules.hltInitialStepTracks_cfi import hltInitialStepTracks as _hltInitialStepTracks
+hltInitialStepTrackspLSTCLST = _hltInitialStepTracks.clone( src = "hltInitialStepTrackCandidates:pLSTCsLST" )
+

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrackspLSTCLST_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrackspLSTCLST_cfi.py
@@ -2,4 +2,3 @@ import FWCore.ParameterSet.Config as cms
 
 from ..modules.hltInitialStepTracks_cfi import hltInitialStepTracks as _hltInitialStepTracks
 hltInitialStepTrackspLSTCLST = _hltInitialStepTracks.clone( src = "hltInitialStepTrackCandidates:pLSTCsLST" )
-

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrackspTTCLST_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrackspTTCLST_cfi.py
@@ -1,0 +1,5 @@
+import FWCore.ParameterSet.Config as cms
+
+from ..modules.hltInitialStepTracks_cfi import hltInitialStepTracks as _hltInitialStepTracks
+hltInitialStepTrackspTTCLST = _hltInitialStepTracks.clone( src = "hltInitialStepTrackCandidates:pTTCsLST" )
+

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrackspTTCLST_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrackspTTCLST_cfi.py
@@ -2,4 +2,3 @@ import FWCore.ParameterSet.Config as cms
 
 from ..modules.hltInitialStepTracks_cfi import hltInitialStepTracks as _hltInitialStepTracks
 hltInitialStepTrackspTTCLST = _hltInitialStepTracks.clone( src = "hltInitialStepTrackCandidates:pTTCsLST" )
-

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltLST_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltLST_cfi.py
@@ -1,0 +1,19 @@
+import FWCore.ParameterSet.Config as cms
+
+hltLST = cms.EDProducer('LSTProducer@alpaka',
+    pixelSeedInput = cms.InputTag('hltPixelSeedInputLST'),
+    phase2OTHitsInput = cms.InputTag('hltPhase2OTHitsInputLST'),
+    verbose = cms.bool(False),
+    nopLSDupClean = cms.bool(False),
+    tcpLSTriplets = cms.bool(False),
+    mightGet = cms.optional.untracked.vstring,
+    alpaka = cms.untracked.PSet(
+        backend = cms.untracked.string('')
+    )
+)
+
+from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
+from Configuration.ProcessModifiers.seedingLST_cff import seedingLST
+(seedingLST & trackingLST).toModify(hltLST, nopLSDupClean = True,
+                                            tcpLSTriplets = True )
+

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltLST_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltLST_cfi.py
@@ -16,4 +16,3 @@ from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
 from Configuration.ProcessModifiers.seedingLST_cff import seedingLST
 (seedingLST & trackingLST).toModify(hltLST, nopLSDupClean = True,
                                             tcpLSTriplets = True )
-

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltPhase2OTHitsInputLST_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltPhase2OTHitsInputLST_cfi.py
@@ -4,4 +4,3 @@ hltPhase2OTHitsInputLST = cms.EDProducer('LSTPhase2OTHitsInputProducer',
     phase2OTRecHits = cms.InputTag('hltSiPhase2RecHits'),
     mightGet = cms.optional.untracked.vstring
 )
-

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltPhase2OTHitsInputLST_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltPhase2OTHitsInputLST_cfi.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+hltPhase2OTHitsInputLST = cms.EDProducer('LSTPhase2OTHitsInputProducer',
+    phase2OTRecHits = cms.InputTag('hltSiPhase2RecHits'),
+    mightGet = cms.optional.untracked.vstring
+)
+

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltPhase2PixelTracksSoA_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltPhase2PixelTracksSoA_cfi.py
@@ -41,3 +41,9 @@ hltPhase2PixelTracksSoA = cms.EDProducer('CAHitNtupletAlpakaPhase2@alpaka',
     # autoselect the alpaka backend
     alpaka = cms.untracked.PSet(backend = cms.untracked.string(''))
 )
+
+_hltPhase2PixelTracksSoASingleIterPatatrack = hltPhase2PixelTracksSoA.clone( minHitsPerNtuplet = 3 )
+
+from Configuration.ProcessModifiers.singleIterPatatrack_cff import singleIterPatatrack
+singleIterPatatrack.toReplaceWith(hltPhase2PixelTracksSoA, _hltPhase2PixelTracksSoASingleIterPatatrack)
+

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltPhase2PixelTracksSoA_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltPhase2PixelTracksSoA_cfi.py
@@ -46,4 +46,3 @@ _hltPhase2PixelTracksSoASingleIterPatatrack = hltPhase2PixelTracksSoA.clone( min
 
 from Configuration.ProcessModifiers.singleIterPatatrack_cff import singleIterPatatrack
 singleIterPatatrack.toReplaceWith(hltPhase2PixelTracksSoA, _hltPhase2PixelTracksSoASingleIterPatatrack)
-

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltPixelSeedInputLST_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltPixelSeedInputLST_cfi.py
@@ -14,4 +14,3 @@ _hltPixelSeedInputLSTSingleIterPatatrack = hltPixelSeedInputLST.clone(
 
 from Configuration.ProcessModifiers.singleIterPatatrack_cff import singleIterPatatrack
 singleIterPatatrack.toReplaceWith(hltPixelSeedInputLST, _hltPixelSeedInputLSTSingleIterPatatrack)
-

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltPixelSeedInputLST_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltPixelSeedInputLST_cfi.py
@@ -1,0 +1,17 @@
+import FWCore.ParameterSet.Config as cms
+
+hltPixelSeedInputLST = cms.EDProducer('LSTPixelSeedInputProducer',
+    beamSpot = cms.InputTag('offlineBeamSpot'),
+    seedTracks = cms.VInputTag(
+        'hltInitialStepSeedTracksLST',
+        'hltHighPtTripletStepSeedTracksLST'
+    )
+)
+
+_hltPixelSeedInputLSTSingleIterPatatrack = hltPixelSeedInputLST.clone(
+    seedTracks = ['hltInitialStepSeedTracksLST']
+)
+
+from Configuration.ProcessModifiers.singleIterPatatrack_cff import singleIterPatatrack
+singleIterPatatrack.toReplaceWith(hltPixelSeedInputLST, _hltPixelSeedInputLSTSingleIterPatatrack)
+

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltPixelSeedInputLST_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltPixelSeedInputLST_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 hltPixelSeedInputLST = cms.EDProducer('LSTPixelSeedInputProducer',
-    beamSpot = cms.InputTag('offlineBeamSpot'),
+    beamSpot = cms.InputTag('hltOnlineBeamSpot'),
     seedTracks = cms.VInputTag(
         'hltInitialStepSeedTracksLST',
         'hltHighPtTripletStepSeedTracksLST'

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltSiPhase2Clusters_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltSiPhase2Clusters_cfi.py
@@ -1,4 +1,11 @@
 import FWCore.ParameterSet.Config as cms
 
-from RecoLocalTracker.SiPhase2Clusterizer.phase2TrackerClusterizer_cfi import siPhase2Clusters as _siPhase2Clusters
-hltSiPhase2Clusters = _siPhase2Clusters.clone()
+# Clusterizer options
+hltSiPhase2Clusters = cms.EDProducer('Phase2TrackerClusterizer',
+    src = cms.InputTag("mix", "Tracker"),
+    maxClusterSize = cms.uint32(0), # was 8
+    maxNumberClusters = cms.uint32(0)
+)
+
+from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
+premix_stage2.toModify(hltSiPhase2Clusters, src = "mixData:Tracker")

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltSiPhase2RecHits_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltSiPhase2RecHits_cfi.py
@@ -1,0 +1,5 @@
+import FWCore.ParameterSet.Config as cms
+
+from RecoLocalTracker.Phase2TrackerRecHits.Phase2TrackerRecHits_cfi import siPhase2RecHits as _siPhase2RecHits
+hltSiPhase2RecHits = _siPhase2RecHits.clone( src = "hltSiPhase2Clusters" )
+

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltSiPhase2RecHits_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltSiPhase2RecHits_cfi.py
@@ -1,5 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-from RecoLocalTracker.Phase2TrackerRecHits.Phase2TrackerRecHits_cfi import siPhase2RecHits as _siPhase2RecHits
-hltSiPhase2RecHits = _siPhase2RecHits.clone( src = "hltSiPhase2Clusters" )
-
+# RecHits options
+hltSiPhase2RecHits = cms.EDProducer("Phase2TrackerRecHits",
+  src = cms.InputTag("hltSiPhase2Clusters"),
+  Phase2StripCPE = cms.ESInputTag("phase2StripCPEESProducer", "Phase2StripCPE")
+)

--- a/HLTrigger/Configuration/python/HLT_75e33/psets/HLTPSetTrajectoryBuilderForGsfElectrons_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/psets/HLTPSetTrajectoryBuilderForGsfElectrons_cfi.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 HLTPSetTrajectoryBuilderForGsfElectrons = cms.PSet(
     ComponentType = cms.string('CkfTrajectoryBuilder'),
-    TTRHBuilder = cms.string('hltESPTTRHBWithTrackAngle'),
+    TTRHBuilder = cms.string('hltESPTTRHBuilderWithTrackAngle'),
     alwaysUseInvalidHits = cms.bool(True),
     estimator = cms.string('hltESPChi2ChargeMeasurementEstimator2000'),
     intermediateCleaning = cms.bool(False),

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTHighPtTripletStepSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTHighPtTripletStepSequence_cfi.py
@@ -30,4 +30,3 @@ _HLTHighPtTripletStepSequenceLSTSeeding = cms.Sequence(
 
 from Configuration.ProcessModifiers.seedingLST_cff import seedingLST
 (seedingLST & trackingLST).toReplaceWith(HLTHighPtTripletStepSequence, _HLTHighPtTripletStepSequenceLSTSeeding)
-

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTHighPtTripletStepSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTHighPtTripletStepSequence_cfi.py
@@ -6,7 +6,13 @@ from ..modules.hltHighPtTripletStepTracks_cfi import *
 from ..modules.hltHighPtTripletStepTrackSelectionHighPurity_cfi import *
 from ..sequences.HLTHighPtTripletStepSeedingSequence_cfi import *
 
-HLTHighPtTripletStepSequence = cms.Sequence(HLTHighPtTripletStepSeedingSequence+hltHighPtTripletStepTrackCandidates+hltHighPtTripletStepTracks+hltHighPtTripletStepTrackCutClassifier+hltHighPtTripletStepTrackSelectionHighPurity)
+HLTHighPtTripletStepSequence = cms.Sequence(
+     HLTHighPtTripletStepSeedingSequence
+    +hltHighPtTripletStepTrackCandidates
+    +hltHighPtTripletStepTracks
+    +hltHighPtTripletStepTrackCutClassifier
+    +hltHighPtTripletStepTrackSelectionHighPurity
+)
 
 from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
 trackingLST.toReplaceWith(HLTHighPtTripletStepSequence, HLTHighPtTripletStepSequence.copyAndExclude([HLTHighPtTripletStepSeedingSequence]))
@@ -15,7 +21,12 @@ from ..modules.hltHighPtTripletStepTrackCandidatespLSTCLST_cfi import *
 from ..modules.hltHighPtTripletStepTrackspLSTCLST_cfi import *
 from ..modules.hltHighPtTripletStepTrackCutClassifierpLSTCLST_cfi import *
 from ..modules.hltHighPtTripletStepTrackSelectionHighPuritypLSTCLST_cfi import *
-_HLTHighPtTripletStepSequenceLSTSeeding = cms.Sequence(hltHighPtTripletStepTrackCandidatespLSTCLST+hltHighPtTripletStepTrackspLSTCLST+hltHighPtTripletStepTrackCutClassifierpLSTCLST+hltHighPtTripletStepTrackSelectionHighPuritypLSTCLST)
+_HLTHighPtTripletStepSequenceLSTSeeding = cms.Sequence(
+     hltHighPtTripletStepTrackCandidatespLSTCLST
+    +hltHighPtTripletStepTrackspLSTCLST
+    +hltHighPtTripletStepTrackCutClassifierpLSTCLST
+    +hltHighPtTripletStepTrackSelectionHighPuritypLSTCLST
+)
 
 from Configuration.ProcessModifiers.seedingLST_cff import seedingLST
 (seedingLST & trackingLST).toReplaceWith(HLTHighPtTripletStepSequence, _HLTHighPtTripletStepSequenceLSTSeeding)

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTHighPtTripletStepSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTHighPtTripletStepSequence_cfi.py
@@ -7,3 +7,16 @@ from ..modules.hltHighPtTripletStepTrackSelectionHighPurity_cfi import *
 from ..sequences.HLTHighPtTripletStepSeedingSequence_cfi import *
 
 HLTHighPtTripletStepSequence = cms.Sequence(HLTHighPtTripletStepSeedingSequence+hltHighPtTripletStepTrackCandidates+hltHighPtTripletStepTracks+hltHighPtTripletStepTrackCutClassifier+hltHighPtTripletStepTrackSelectionHighPurity)
+
+from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
+trackingLST.toReplaceWith(HLTHighPtTripletStepSequence, HLTHighPtTripletStepSequence.copyAndExclude([HLTHighPtTripletStepSeedingSequence]))
+
+from ..modules.hltHighPtTripletStepTrackCandidatespLSTCLST_cfi import *
+from ..modules.hltHighPtTripletStepTrackspLSTCLST_cfi import *
+from ..modules.hltHighPtTripletStepTrackCutClassifierpLSTCLST_cfi import *
+from ..modules.hltHighPtTripletStepTrackSelectionHighPuritypLSTCLST_cfi import *
+_HLTHighPtTripletStepSequenceLSTSeeding = cms.Sequence(hltHighPtTripletStepTrackCandidatespLSTCLST+hltHighPtTripletStepTrackspLSTCLST+hltHighPtTripletStepTrackCutClassifierpLSTCLST+hltHighPtTripletStepTrackSelectionHighPuritypLSTCLST)
+
+from Configuration.ProcessModifiers.seedingLST_cff import seedingLST
+(seedingLST & trackingLST).toReplaceWith(HLTHighPtTripletStepSequence, _HLTHighPtTripletStepSequenceLSTSeeding)
+

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTInitialStepSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTInitialStepSequence_cfi.py
@@ -7,3 +7,46 @@ from ..modules.hltInitialStepTracks_cfi import *
 from ..modules.hltInitialStepTrackSelectionHighPurity_cfi import *
 
 HLTInitialStepSequence = cms.Sequence(hltInitialStepSeeds+hltInitialStepTrackCandidates+hltInitialStepTracks+hltInitialStepTrackCutClassifier+hltInitialStepTrackSelectionHighPurity)
+
+from ..modules.hltInitialStepSeedTracksLST_cfi import *
+from ..sequences.HLTHighPtTripletStepSeedingSequence_cfi import *
+from ..modules.hltHighPtTripletStepSeedTracksLST_cfi import *
+from ..modules.hltPixelSeedInputLST_cfi import *
+from ..modules.hltSiPhase2RecHits_cfi import *
+from ..modules.hltPhase2OTHitsInputLST_cfi import *
+from ..modules.hltLST_cfi import *
+from ..modules.hltInitialStepTrackspTTCLST_cfi import *
+from ..modules.hltInitialStepTrackspLSTCLST_cfi import *
+from ..modules.hltInitialStepTracksT5TCLST_cfi import *
+from ..modules.hltInitialStepTrackCutClassifierpTTCLST_cfi import *
+from ..modules.hltInitialStepTrackCutClassifierpLSTCLST_cfi import *
+from ..modules.hltInitialStepTrackSelectionHighPuritypTTCLST_cfi import *
+from ..modules.hltInitialStepTrackSelectionHighPuritypLSTCLST_cfi import *
+_HLTInitialStepSequenceLST = cms.Sequence(
+     hltInitialStepSeeds
+    +hltInitialStepSeedTracksLST
+    +HLTHighPtTripletStepSeedingSequence
+    +hltHighPtTripletStepSeedTracksLST
+    +hltPixelSeedInputLST
+    +hltSiPhase2RecHits # Probably need to move elsewhere in the final setup
+    +hltPhase2OTHitsInputLST # Probably need to move elsewhere in the final setup
+    +hltLST
+    +hltInitialStepTrackCandidates
+    +hltInitialStepTrackspTTCLST
+    +hltInitialStepTrackspLSTCLST
+    +hltInitialStepTracksT5TCLST
+    +hltInitialStepTrackCutClassifierpTTCLST
+    +hltInitialStepTrackCutClassifierpLSTCLST
+    +hltInitialStepTrackSelectionHighPuritypTTCLST
+    +hltInitialStepTrackSelectionHighPuritypLSTCLST
+)
+
+from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
+trackingLST.toReplaceWith(HLTInitialStepSequence, _HLTInitialStepSequenceLST)
+
+from Configuration.ProcessModifiers.singleIterPatatrack_cff import singleIterPatatrack
+(singleIterPatatrack & trackingLST).toReplaceWith(HLTInitialStepSequence, HLTInitialStepSequence.copyAndExclude([HLTHighPtTripletStepSeedingSequence,hltHighPtTripletStepSeedTracksLST]))
+
+from Configuration.ProcessModifiers.seedingLST_cff import seedingLST
+(seedingLST & trackingLST).toReplaceWith(HLTInitialStepSequence, _HLTInitialStepSequenceLST.copyAndExclude([hltInitialStepTrackspLSTCLST,hltInitialStepTrackCutClassifierpLSTCLST,hltInitialStepTrackSelectionHighPuritypLSTCLST]))
+

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTInitialStepSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTInitialStepSequence_cfi.py
@@ -49,4 +49,3 @@ from Configuration.ProcessModifiers.singleIterPatatrack_cff import singleIterPat
 
 from Configuration.ProcessModifiers.seedingLST_cff import seedingLST
 (seedingLST & trackingLST).toReplaceWith(HLTInitialStepSequence, _HLTInitialStepSequenceLST.copyAndExclude([hltInitialStepTrackspLSTCLST,hltInitialStepTrackCutClassifierpLSTCLST,hltInitialStepTrackSelectionHighPuritypLSTCLST]))
-

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTTrackingV61Sequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTTrackingV61Sequence_cfi.py
@@ -13,4 +13,3 @@ HLTTrackingV61Sequence = cms.Sequence((HLTItLocalRecoSequence+HLTOtLocalRecoSequ
 
 from Configuration.ProcessModifiers.singleIterPatatrack_cff import singleIterPatatrack
 singleIterPatatrack.toReplaceWith(HLTTrackingV61Sequence, HLTTrackingV61Sequence.copyAndExclude([HLTHighPtTripletStepSequence]))
-

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTTrackingV61Sequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTTrackingV61Sequence_cfi.py
@@ -10,3 +10,7 @@ from ..sequences.HLTItLocalRecoSequence_cfi import *
 from ..sequences.HLTOtLocalRecoSequence_cfi import *
 
 HLTTrackingV61Sequence = cms.Sequence((HLTItLocalRecoSequence+HLTOtLocalRecoSequence+hltTrackerClusterCheck+HLTPhase2PixelTracksSequence+hltPhase2PixelVertices+HLTInitialStepSequence+HLTHighPtTripletStepSequence+hltGeneralTracks))
+
+from Configuration.ProcessModifiers.singleIterPatatrack_cff import singleIterPatatrack
+singleIterPatatrack.toReplaceWith(HLTTrackingV61Sequence, HLTTrackingV61Sequence.copyAndExclude([HLTHighPtTripletStepSequence]))
+

--- a/HLTrigger/Configuration/python/HLT_75e33_cff.py
+++ b/HLTrigger/Configuration/python/HLT_75e33_cff.py
@@ -96,6 +96,9 @@ fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPPixelCPEFastPa
 fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPSiPixelCablingSoA_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPSiPixelGainCalibrationForHLTSoA_cfi")
 
+fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPModulesDevLST_cfi")
+fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPTTRHBuilderWithoutRefit_cfi")
+
 fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLT_AK4PFPuppiJet520_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLT_Diphoton30_23_IsoCaloId_L1Seeded_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLT_Diphoton30_23_IsoCaloId_Unseeded_cfi")

--- a/HLTrigger/Configuration/python/HLT_75e33_cff.py
+++ b/HLTrigger/Configuration/python/HLT_75e33_cff.py
@@ -84,7 +84,7 @@ fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltPhase2L3MuonIniti
 fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltPhase2L3MuonPixelTrackCleanerBySharedHits_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltPhase2L3MuonTrackAlgoPriorityOrder_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltPixelTracksCleanerBySharedHits_cfi")
-fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltTTRBWR_cfi")
+fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPTTRHBuilderWithTrackAngle_cfi")
 
 fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPKFFittingSmootherForL2Muon_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPKFTrajectoryFitterForL2Muon_cfi")

--- a/HLTrigger/Configuration/python/HLT_75e33_timing_cff.py
+++ b/HLTrigger/Configuration/python/HLT_75e33_timing_cff.py
@@ -101,6 +101,9 @@ fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPPixelCPEFastPa
 fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPSiPixelCablingSoA_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPSiPixelGainCalibrationForHLTSoA_cfi")
 
+fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPModulesDevLST_cfi")
+fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPTTRHBuilderWithoutRefit_cfi")
+
 fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLT_AK4PFPuppiJet520_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLT_Diphoton30_23_IsoCaloId_L1Seeded_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLT_DoubleEle23_12_Iso_L1Seeded_cfi")

--- a/HLTrigger/Configuration/python/HLT_75e33_timing_cff.py
+++ b/HLTrigger/Configuration/python/HLT_75e33_timing_cff.py
@@ -89,7 +89,7 @@ fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltPhase2L3MuonIniti
 fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltPhase2L3MuonPixelTrackCleanerBySharedHits_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltPhase2L3MuonTrackAlgoPriorityOrder_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltPixelTracksCleanerBySharedHits_cfi")
-fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltTTRBWR_cfi")
+fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPTTRHBuilderWithTrackAngle_cfi")
 
 fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPKFFittingSmootherForL2Muon_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPKFTrajectoryFitterForL2Muon_cfi")

--- a/RecoTracker/LSTCore/interface/Common.h
+++ b/RecoTracker/LSTCore/interface/Common.h
@@ -28,15 +28,15 @@ namespace lst {
   constexpr unsigned int max_blocks = 80;
   constexpr unsigned int max_connected_modules = 40;
 
-  constexpr unsigned int n_max_pixel_segments_per_module = 50000;
+  constexpr unsigned int n_max_pixel_segments_per_module = 500000;
 
   constexpr unsigned int n_max_pixel_md_per_modules = 2 * n_max_pixel_segments_per_module;
 
   constexpr unsigned int n_max_pixel_triplets = 5000;
   constexpr unsigned int n_max_pixel_quintuplets = 15000;
 
-  constexpr unsigned int n_max_pixel_track_candidates = 30000;
-  constexpr unsigned int n_max_nonpixel_track_candidates = 1000;
+  constexpr unsigned int n_max_pixel_track_candidates = 300000;
+  constexpr unsigned int n_max_nonpixel_track_candidates = 10000;
 
   constexpr unsigned int size_superbins = 45000;
 


### PR DESCRIPTION
### PR description

This is a procModifier-based implementation of LST in HLT, based on top of `CMSSW_14_2_0_pre4`.
It reuses the `trackingLST` procModifier to enable LST track building, and it introduces a new one, `seedingLST`, which is not too useful for the HLT currently but it may become useful also for the offline setup in the near future.
Another modifier, `singleIterPatatrack` is introduced and it allows HLT to run only one iteration of tracking based on Patatrack pixel seeds. It works both with CKF and with LST building (when combined with the procModifier above).

In terms of performance, this is described in [this presentation](https://docs.google.com/presentation/d/14B1xW43xQNVifW9fkeRpKg49Ht5ilTOmEzesE0rXySE/edit?usp=sharing).

### Instructions on how to run
```sh
cmsrel CMSSW_14_2_0_pre4
cd CMSSW_14_2_0_pre4/src
cmsenv
git cms-init
git cms-addpkg Configuration HLTrigger
git remote add SegLink git@github.com:SegmentLinking/cmssw.git
git fetch SegLink
git checkout CMSSW_14_2_0_pre4_singleIter_LST_HLT
scram b -j 16

# Rerun L1, needed because the HLT samples I am using are produced with 14_0_X
cmsDriver.py Phase2 -s L1,L1TrackTrigger \
--conditions auto:phase2_realistic_T33 \
--geometry ExtendedRun4D110 \
--era Phase2C17I13M9 \
--eventcontent FEVTDEBUGHLT \
--datatier GEN-SIM-DIGI-RAW-MINIAOD \
--customise SLHCUpgradeSimulations/Configuration/aging.customise_aging_1000,Configuration/DataProcessing/Utils.addMonitoring,L1Trigger/Configuration/customisePhase2FEVTDEBUGHLT.customisePhase2FEVTDEBUGHLT,L1Trigger/Configuration/customisePhase2TTOn110.customisePhase2TTOn110 \
--filein /store/mc/Phase2Spring24DIGIRECOMiniAOD/TT_TuneCP5_14TeV-powheg-pythia8/GEN-SIM-DIGI-RAW-MINIAOD/PU200_AllTP_140X_mcRun4_realistic_v4-v1/2560000/11d1f6f0-5f03-421e-90c7-b5815197fc85.root \
--fileout file:output_Phase2_L1T.root \
--inputCommands="keep *, drop l1tPFJets_*_*_*, drop l1tTrackerMuons_l1tTkMuonsGmt*_*_HLT" \
--outputCommands="drop l1tTrackerMuons_l1tTkMuonsGmt*_*_HLT" \
--mc -n 100 --nThreads 10

# Rerun L1 emulator + HLT (needed for any sample)
# In terms of procModifiers:
#    None -> Legacy seeding, CKF building
#    alpaka -> Patatrack seeding
#    singleIterPatatrack -> Single iteration tracking
#    trackingLST -> LST building for the initialStep
#    seedingLST -> LST seeding for the hightPtTripletStep
cmsDriver.py Phase2 -s L1P2GT,HLT:75e33 --processName=HLTX \
--conditions auto:phase2_realistic_T33 \
--geometry ExtendedRun4D110 \
--era Phase2C17I13M9 \
--eventcontent FEVTDEBUGHLT \
--customise SLHCUpgradeSimulations/Configuration/aging.customise_aging_1000 \
--filein file:output_Phase2_L1T.root \
--fileout file:Phase2_L1P2GT_HLT.root \
--inputCommands="keep *, drop *_hlt*_*_HLT, drop triggerTriggerFilterObjectWithRefs_l1t*_*_HLT" \
--outputCommands='keep *_*InitialStepTrack*LST*_*_*, keep *_*HighPtTripletStepTrack*_*_*' \
-n 100 --nThreads 10 \
--procModifiers alpaka,trackingLST,seedingLST

# procModifiers are important also for the validation step
# and should be consistent with the ones used above
cmsDriver.py DQM -s VALIDATION:hltMultiTrackValidation \
--conditions auto:phase2_realistic_T33 \
--geometry ExtendedRun4D110 \
--era Phase2C17I13M9 \
--datatier DQMIO \
--eventcontent DQM \
--filein file:Phase2_L1P2GT_HLT.root \
--hltProcess HLTX \
--fileout DQM.root \
-n 100 --nThreads 10 --procModifiers alpaka,trackingLST,seedingLST

cmsDriver.py HARVEST -s HARVESTING:@trackingOnlyValidation+@trackingOnlyDQM+postProcessorHLTtrackingSequence \
--filein file:DQM.root \
--scenario pp \
--filetype DQM \
--conditions auto:phase2_realistic_T33 \
--mc -n 100

mv DQM_V0001_R000000001__Global__CMSSW_X_Y_Z__RECO.root configName.root
makeTrackValidationPlots.py configName.root --extended
```

To make the `alpaka,trackingLST` configuration run without truncations, the `n_max_pixel_segments_per_module` is increased. To make the `alpaka,trackingLST,seedingLST` configuration run without truncations, the `n_max_pixel_track_candidates` and `n_max_nonpixel_track_candidates` are increased. Applying the object increases in the [Memory Usage sheet](https://docs.google.com/spreadsheets/d/1-tDK4nIPlrB-0SoeEbnJlf_lyt-xTZcIhmZGRnR-fnY/edit?gid=16484832#gid=16484832), I observe a 5% increase. Once we understand the usefulness of the configurations, we can revert some of those values back to the ones before this PR.

I think that the best way to move forward with this PR is to have the review here and make sure we are happy with everything we are implementing. Then, I can make it towards to cms-sw/master and, once we are done with that review, I can port it to whatever branch we will decide to be out development one. I would **not** merge this to our master.