### PR TITLE
Fix efficiency plots

### DIFF
--- a/RecoTracker/LSTCore/src/alpaka/Hit.h
+++ b/RecoTracker/LSTCore/src/alpaka/Hit.h
@@ -62,18 +62,16 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
             alpaka::math::acosh(
                 acc, alpaka::math::sqrt(acc, ihit_x * ihit_x + ihit_y * ihit_y + ihit_z * ihit_z) / hits.rts()[ihit]);
         auto found_pointer = alpaka_std::lower_bound(modules.mapdetId(), modules.mapdetId() + nModules, iDetId);
+        ALPAKA_ASSERT_ACC(found_pointer != modules.mapdetId() + nModules);
         int found_index = std::distance(modules.mapdetId(), found_pointer);
-        if (found_pointer == modules.mapdetId() + nModules)
-          found_index = -1;
         uint16_t lastModuleIndex = modules.mapIdx()[found_index];
 
         hits.moduleIndices()[ihit] = lastModuleIndex;
 
         if (modules.subdets()[lastModuleIndex] == Endcap && modules.moduleType()[lastModuleIndex] == TwoS) {
           found_pointer = alpaka_std::lower_bound(geoMapDetId, geoMapDetId + nEndCapMap, iDetId);
+          ALPAKA_ASSERT_ACC(found_pointer != geoMapDetId + nEndCapMap);
           found_index = std::distance(geoMapDetId, found_pointer);
-          if (found_pointer == geoMapDetId + nEndCapMap)
-            found_index = -1;
           float phi = geoMapPhi[found_index];
           float cos_phi = alpaka::math::cos(acc, phi);
           hits.highEdgeXs()[ihit] = ihit_x + 2.5f * cos_phi;

--- a/RecoTracker/LSTCore/src/alpaka/LSTEvent.dev.cc
+++ b/RecoTracker/LSTCore/src/alpaka/LSTEvent.dev.cc
@@ -1047,21 +1047,14 @@ void LSTEvent::addMiniDoubletsToEventExplicit() {
       cms::alpakatools::make_device_view(queue_, modules.layers(), nLowerModules_);  // only lower modules
   alpaka::memcpy(queue_, module_layers_buf, module_layers_view, nLowerModules_);
 
-  auto module_hitRanges_buf = cms::alpakatools::make_host_buffer<ArrayIx2[]>(queue_, nLowerModules_);
-  auto hits = hitsDC_->view<HitsRangesSoA>();
-  auto hitRanges_view =
-      cms::alpakatools::make_device_view(queue_, hits.hitRanges(), nLowerModules_);  // only lower modules
-  alpaka::memcpy(queue_, module_hitRanges_buf, hitRanges_view, nLowerModules_);
-
   alpaka::wait(queue_);  // wait for inputs before using them
 
   auto const* nMDsCPU = nMDsCPU_buf.data();
   auto const* module_subdets = module_subdets_buf.data();
   auto const* module_layers = module_layers_buf.data();
-  auto const* module_hitRanges = module_hitRanges_buf.data();
 
   for (unsigned int i = 0; i < nLowerModules_; i++) {
-    if (!(nMDsCPU[i] == 0 or module_hitRanges[i][0] == -1)) {
+    if (nMDsCPU[i] != 0) {
       if (module_subdets[i] == Barrel) {
         n_minidoublets_by_layer_barrel_[module_layers[i] - 1] += nMDsCPU[i];
       } else {

--- a/RecoTracker/LSTCore/standalone/code/core/lst_math.h
+++ b/RecoTracker/LSTCore/standalone/code/core/lst_math.h
@@ -74,7 +74,7 @@ namespace lst_math {
       center_.push_back(center_vec_z);
 
       // Lambda
-      lam_ = copysign(M_PI / 2. - 2. * atan(exp(-abs(eta))), eta);
+      lam_ = copysign(M_PI / 2. - 2. * atan(exp(-std::abs(eta))), eta);
     }
 
     const std::vector<float> center() { return center_; }

--- a/RecoTracker/LSTCore/standalone/code/core/trkCore.cc
+++ b/RecoTracker/LSTCore/standalone/code/core/trkCore.cc
@@ -475,7 +475,7 @@ int getDenomSimTrkType(int isimtrk) {
     return 1;  // sim
   const float &pt = trk.sim_pt()[isimtrk];
   const float &eta = trk.sim_eta()[isimtrk];
-  if (pt < 1 or abs(eta) > 2.4)
+  if (pt < 1 or std::abs(eta) > 2.4)
     return 2;  // sim and charged
   const int &bunch = trk.sim_bunchCrossing()[isimtrk];
   const int &event = trk.sim_event()[isimtrk];
@@ -486,7 +486,7 @@ int getDenomSimTrkType(int isimtrk) {
   const float &vtx_perp = sqrt(vtx_x * vtx_x + vtx_y * vtx_y);
   if (vtx_perp > 2.5)
     return 3;  // pt > 1 and abs(eta) < 2.4
-  if (abs(vtx_z) > 30)
+  if (std::abs(vtx_z) > 30)
     return 4;  // pt > 1 and abs(eta) < 2.4 and vtx < 2.5
   if (bunch != 0)
     return 5;  // pt > 1 and abs(eta) < 2.4 and vtx < 2.5 and vtx < 300
@@ -546,7 +546,7 @@ float drfracSimHitConsistentWithHelix(lst_math::Helix &helix, int isimhitidx) {
   auto [x, y, z, r] = helix.get_helix_point(t);
 
   // ( expected_r - simhit_r ) / expected_r
-  float drfrac = abs(helix.compare_radius(point)) / r;
+  float drfrac = std::abs(helix.compare_radius(point)) / r;
 
   return drfrac;
 }

--- a/RecoTracker/LSTCore/standalone/efficiency/src/performance.cc
+++ b/RecoTracker/LSTCore/standalone/efficiency/src/performance.cc
@@ -25,11 +25,13 @@ int main(int argc, char** argv) {
   };
   std::vector<std::function<bool(unsigned int)>> sels = {
       [&](unsigned int isim) { return 1.; },
-      [&](unsigned int isim) { return abs(lstEff.sim_eta().at(isim)) < 2.4; },
-      [&](unsigned int isim) { return abs(lstEff.sim_eta().at(isim)) > 1.1 and abs(lstEff.sim_eta().at(isim)) < 1.7; },
+      [&](unsigned int isim) { return std::abs(lstEff.sim_eta().at(isim)) < 2.4; },
       [&](unsigned int isim) {
-        return (abs(lstEff.sim_eta().at(isim)) < 1.1 or abs(lstEff.sim_eta().at(isim)) > 1.7) and
-               abs(lstEff.sim_eta().at(isim)) < 2.4;
+        return std::abs(lstEff.sim_eta().at(isim)) > 1.1 and std::abs(lstEff.sim_eta().at(isim)) < 1.7;
+      },
+      [&](unsigned int isim) {
+        return (std::abs(lstEff.sim_eta().at(isim)) < 1.1 or std::abs(lstEff.sim_eta().at(isim)) > 1.7) and
+               std::abs(lstEff.sim_eta().at(isim)) < 2.4;
       }};
   pdgids.insert(pdgids.end(), ana.pdgids.begin(), ana.pdgids.end());
 
@@ -584,7 +586,7 @@ void fillEfficiencySet(int isimtrk, SimTrackSetDefinition& effset) {
   bool sel = effset.sel(isimtrk);
 
   if (effset.pdgid != 0) {
-    if (abs(pdgidtrk) != abs(effset.pdgid))
+    if (std::abs(pdgidtrk) != std::abs(effset.pdgid))
       return;
   }
 
@@ -607,7 +609,7 @@ void fillEfficiencySet(int isimtrk, SimTrackSetDefinition& effset) {
   const float vtx_perp_thresh = 2.5;
 
   // N minus eta cut
-  if (pt > ana.pt_cut and abs(vtx_z) < vtx_z_thresh and abs(vtx_perp) < vtx_perp_thresh) {
+  if (pt > ana.pt_cut and std::abs(vtx_z) < vtx_z_thresh and std::abs(vtx_perp) < vtx_perp_thresh) {
     // vs. eta plot
     ana.tx.pushbackToBranch<float>(category_name + "_ef_denom_eta", eta);
     if (pass)
@@ -617,7 +619,7 @@ void fillEfficiencySet(int isimtrk, SimTrackSetDefinition& effset) {
   }
 
   // N minus pt cut
-  if (abs(eta) < ana.eta_cut and abs(vtx_z) < vtx_z_thresh and abs(vtx_perp) < vtx_perp_thresh) {
+  if (std::abs(eta) < ana.eta_cut and std::abs(vtx_z) < vtx_z_thresh and std::abs(vtx_perp) < vtx_perp_thresh) {
     // vs. pt plot
     ana.tx.pushbackToBranch<float>(category_name + "_ef_denom_pt", pt);
     if (pass)
@@ -627,7 +629,7 @@ void fillEfficiencySet(int isimtrk, SimTrackSetDefinition& effset) {
   }
 
   // N minus dxy cut
-  if (abs(eta) < ana.eta_cut and pt > ana.pt_cut and abs(vtx_z) < vtx_z_thresh) {
+  if (std::abs(eta) < ana.eta_cut and pt > ana.pt_cut and std::abs(vtx_z) < vtx_z_thresh) {
     // vs. dxy plot
     ana.tx.pushbackToBranch<float>(category_name + "_ef_denom_dxy", dxy);
     ana.tx.pushbackToBranch<float>(category_name + "_ef_denom_vxy", vtx_perp);
@@ -641,7 +643,7 @@ void fillEfficiencySet(int isimtrk, SimTrackSetDefinition& effset) {
   }
 
   // N minus dz cut
-  if (abs(eta) < ana.eta_cut and pt > ana.pt_cut and abs(vtx_perp) < vtx_perp_thresh) {
+  if (std::abs(eta) < ana.eta_cut and pt > ana.pt_cut and std::abs(vtx_perp) < vtx_perp_thresh) {
     // vs. dz plot
     ana.tx.pushbackToBranch<float>(category_name + "_ef_denom_dz", dz);
     if (pass)
@@ -651,7 +653,8 @@ void fillEfficiencySet(int isimtrk, SimTrackSetDefinition& effset) {
   }
 
   // All phase-space cuts
-  if (abs(eta) < ana.eta_cut and pt > ana.pt_cut and abs(vtx_z) < vtx_z_thresh and abs(vtx_perp) < vtx_perp_thresh) {
+  if (std::abs(eta) < ana.eta_cut and pt > ana.pt_cut and std::abs(vtx_z) < vtx_z_thresh and
+      std::abs(vtx_perp) < vtx_perp_thresh) {
     // vs. Phi plot
     ana.tx.pushbackToBranch<float>(category_name + "_ef_denom_phi", phi);
     if (pass)
@@ -687,12 +690,12 @@ void fillFakeRateSet(int itc, RecoTrackSetDefinition& FRset) {
     if (pass)
       ana.tx.pushbackToBranch<float>(category_name + "_fr_numer_eta", eta);
   }
-  if (abs(eta) < ana.eta_cut) {
+  if (std::abs(eta) < ana.eta_cut) {
     ana.tx.pushbackToBranch<float>(category_name + "_fr_denom_pt", pt);
     if (pass)
       ana.tx.pushbackToBranch<float>(category_name + "_fr_numer_pt", pt);
   }
-  if (abs(eta) < ana.eta_cut and pt > ana.pt_cut) {
+  if (std::abs(eta) < ana.eta_cut and pt > ana.pt_cut) {
     ana.tx.pushbackToBranch<float>(category_name + "_fr_denom_phi", phi);
     if (pass)
       ana.tx.pushbackToBranch<float>(category_name + "_fr_numer_phi", phi);
@@ -725,12 +728,12 @@ void fillDuplicateRateSet(int itc, RecoTrackSetDefinition& DRset) {
     if (pass)
       ana.tx.pushbackToBranch<float>(category_name + "_dr_numer_eta", eta);
   }
-  if (abs(eta) < ana.eta_cut) {
+  if (std::abs(eta) < ana.eta_cut) {
     ana.tx.pushbackToBranch<float>(category_name + "_dr_denom_pt", pt);
     if (pass)
       ana.tx.pushbackToBranch<float>(category_name + "_dr_numer_pt", pt);
   }
-  if (abs(eta) < ana.eta_cut and pt > ana.pt_cut) {
+  if (std::abs(eta) < ana.eta_cut and pt > ana.pt_cut) {
     ana.tx.pushbackToBranch<float>(category_name + "_dr_denom_phi", phi);
     if (pass)
       ana.tx.pushbackToBranch<float>(category_name + "_dr_numer_phi", phi);


### PR DESCRIPTION
This PR fixes the efficiency issue that @GNiendorf found. It turned out that it was that `abs` started truncating to integers, likely because of a change in some header. The actual data was fine, but the plots were being produced incorrectly.

I also came across some other weird bug while looking into this, which is what I mentioned during the meeting today. I'm not sure why, but `module_hitRanges[i][0] == -1` was randomly giving false positives. It doesn't make sense since the buffer on the device is initialized, and there is a wait for the memcpy. I should look more into this to see if there's a deeper issue, but either way, the check was redundant so I removed it and now it works fine.

I might take this as a chance to do a bit of minor refactoring. I'll spend a few hours on Monday looking into it.