### PR TITLE
Update Makefile with CMSSW_RELEASE_BASE too

### DIFF
--- a/RecoTracker/LSTCore/standalone/Makefile
+++ b/RecoTracker/LSTCore/standalone/Makefile
@@ -14,7 +14,7 @@ INCLUDEFLAGS= -ILST -I$(shell pwd) -Icode -Icode/core -I${ALPAKA_ROOT}/include -
 ifdef CMSSW_RELEASE_BASE
 INCLUDEFLAGS:= ${INCLUDEFLAGS} -I${CMSSW_RELEASE_BASE}/src
 endif
-LDFLAGS     = -g -O2 $(LSTLIB) -L${TRACKLOOPERDIR}/LST $(shell rooutil-config --libs) $(shell root-config --libs) -L${CMSSW_BASE}/lib/${SCRAM_ARCH} -lFWCoreMessageLogger
+LDFLAGS     = -g -O2 $(LSTLIB) -L${TRACKLOOPERDIR}/LST $(shell rooutil-config --libs) $(shell root-config --libs) -L${CMSSW_BASE}/lib/${SCRAM_ARCH} -L${CMSSW_RELEASE_BASE}/lib/${SCRAM_ARCH} -lFWCoreMessageLogger
 LDFLAGS_CUDA= -L${CUDA_HOME}/lib64 -lcudart
 LDFLAGS_ROCM= -L${ROCM_ROOT}/lib -lamdhip64
 ALPAKAFLAGS = -DALPAKA_DEBUG=0

--- a/RecoTracker/LSTCore/standalone/Makefile
+++ b/RecoTracker/LSTCore/standalone/Makefile
@@ -11,10 +11,7 @@ OBJECTS=$(OBJECTS_CPU) $(OBJECTS_CUDA) $(OBJECTS_ROCM)
 CXX         = g++
 CXXFLAGS    = -g -O2 -Wall -fPIC -Woverloaded-virtual -Wno-unused-function -fno-var-tracking -std=c++20
 INCLUDEFLAGS= -ILST -I$(shell pwd) -Icode -Icode/core -I${ALPAKA_ROOT}/include -I/${BOOST_ROOT}/include $(shell rooutil-config --include) -I$(shell root-config --incdir) -I${TRACKLOOPERDIR}/../../../ -I${CMSSW_BASE}/src -I${FMT_ROOT}/include -I../interface/ -I../interface/alpaka/ -I../src/ -I../src/alpaka/
-ifdef CMSSW_RELEASE_BASE
-INCLUDEFLAGS:= ${INCLUDEFLAGS} -I${CMSSW_RELEASE_BASE}/src
-endif
-LDFLAGS     = -g -O2 $(LSTLIB) -L${TRACKLOOPERDIR}/LST $(shell rooutil-config --libs) $(shell root-config --libs) -L${CMSSW_BASE}/lib/${SCRAM_ARCH} -L${CMSSW_RELEASE_BASE}/lib/${SCRAM_ARCH} -lFWCoreMessageLogger
+LDFLAGS     = -g -O2 $(LSTLIB) -L${TRACKLOOPERDIR}/LST $(shell rooutil-config --libs) $(shell root-config --libs)
 LDFLAGS_CUDA= -L${CUDA_HOME}/lib64 -lcudart
 LDFLAGS_ROCM= -L${ROCM_ROOT}/lib -lamdhip64
 ALPAKAFLAGS = -DALPAKA_DEBUG=0
@@ -27,6 +24,13 @@ EXTRAFLAGS  = -ITMultiDrawTreePlayer -Wunused-variable -lTMVA -lEG -lGenVector -
 DOQUINTUPLET =
 CUTVALUEFLAG =
 CUTVALUEFLAG_FLAGS = -DCUT_VALUE_DEBUG
+
+LDFLAGS += -L${CMSSW_BASE}/lib/${SCRAM_ARCH}
+ifdef CMSSW_RELEASE_BASE
+        INCLUDEFLAGS:= ${INCLUDEFLAGS} -I${CMSSW_RELEASE_BASE}/src
+        LDFLAGS += -L${CMSSW_RELEASE_BASE}/lib/${SCRAM_ARCH}
+endif
+LDFLAGS += -lFWCoreMessageLogger
 
 PRIMITIVEFLAG = 
 PRIMITIVEFLAG_FLAGS = -DPRIMITIVE_STUDY


### PR DESCRIPTION
Hi yall. I found an error while following the README instructions to compile standalone with `lst_make_tracklooper -m`:

```
/cvmfs/cms.cern.ch/el8_amd64_gcc12/external/gcc/12.3.1-
40d504be6370b5a30e3947a6e575ca28/bin/../lib/gcc/x86_64-
redhat-linux-gnu/12.3.1/../../../../x86_64-redhat-linux-
gnu/bin/ld: cannot find -lFWCoreMessageLogger: No such file or directory
collect2: error: ld returned 1 exit status
make: *** [Makefile:49: bin/lst_cpu] Error 1
```

I think there's an error because the Makefile has `LDFLAGS` which includes `CMSSW_BASE`, but I don't have `FWCoreMessageLogger` in my `CMSSW_BASE`. `FWCoreMessageLogger` exists in my `CMSSW_RELEASE_BASE` though.

Does this PR seem like an appropriate change? Thanks for your help.

Tagging @VourMa because he added `FWCoreMessageLogger` originally

---

My setup:

```bash
# ssh uaf-3.t2.ucsd.edu
source /cvmfs/cms.cern.ch/cmsset_default.sh
CMSSW_VERSION=CMSSW_15_0_0_pre3
cmsrel ${CMSSW_VERSION}
cd ${CMSSW_VERSION}/src/
cmsenv

git cms-init
git cms-addpkg RecoTracker/LST RecoTracker/LSTCore
scram b -j 12

cd RecoTracker/LSTCore/standalone
source setup.sh
lst_make_tracklooper -m
```

Error:

```bash
g++ -g -O2 -llst_cpu -L/ceph/users/atuna/CMSSW_15_0_0_pre3/src/RecoTracker/LSTCore/standalone/LST -L/ceph/users/atuna/CMSSW_15_0_0_pre3/src/RecoTracker/LSTCore/standalone/code/rooutil -lrooutil -L/cvmfs/cms.cern.ch/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_0_pre3/external/el8_amd64_gcc12/bin/../../../../../../../el8_amd64_gcc12/lcg/root/6.32.09-0a945d6e24dcaabe218b38fa8292785d/lib -lCore -lImt -lRIO -lNet -lHist -lGraf -lGraf3d -lGpad -lROOTVecOps -lTree -lTreePlayer -lRint -lPostscript -lMatrix -lPhysics -lMathCore -lThread -lMultiProc -lROOTDataFrame -Wl,-rpath,/cvmfs/cms.cern.ch/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_0_pre3/external/el8_amd64_gcc12/bin/../../../../../../../el8_amd64_gcc12/lcg/root/6.32.09-0a945d6e24dcaabe218b38fa8292785d/lib -pthread -lm -ldl -rdynamic -L/ceph/users/atuna/CMSSW_15_0_0_pre3/lib/el8_amd64_gcc12 -lFWCoreMessageLogger -ITMultiDrawTreePlayer -Wunused-variable -lTMVA -lEG -lGenVector -lXMLIO -lMLP -lTreePlayer -fopenmp -ILST -I/ceph/users/atuna/CMSSW_15_0_0_pre3/src/RecoTracker/LSTCore/standalone -Icode -Icode/core -I/cvmfs/cms.cern.ch/el8_amd64_gcc12/external/alpaka/1.2.0-b081818336b70095080b83065d50ff0d/include -I//cvmfs/cms.cern.ch/el8_amd64_gcc12/external/boost/1.80.0-96a02191111b66819e07de179cb25a0e/include -I/ceph/users/atuna/CMSSW_15_0_0_pre3/src/RecoTracker/LSTCore/standalone/code/rooutil -I/cvmfs/cms.cern.ch/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_0_pre3/external/el8_amd64_gcc12/bin/../../../../../../../el8_amd64_gcc12/lcg/root/6.32.09-0a945d6e24dcaabe218b38fa8292785d/include -I/ceph/users/atuna/CMSSW_15_0_0_pre3/src/RecoTracker/LSTCore/standalone/../../../ -I/ceph/users/atuna/CMSSW_15_0_0_pre3/src -I/cvmfs/cms.cern.ch/el8_amd64_gcc12/external/fmt/10.2.1-e35fd1db5eb3abc8ac0452e8ee427196/include -I../interface/ -I../interface/alpaka/ -I../src/ -I../src/alpaka/ -I/cvmfs/cms.cern.ch/el8_amd64_gcc12/cms/cmssw/CMSSW_15_0_0_pre3/src -DALPAKA_DEBUG=0 bin/lst_cpu.o code/core/AccessHelper_cpu.o code/core/AnalysisConfig_cpu.o code/core/Trktree_cpu.o code/core/trkCore_cpu.o code/core/write_lst_ntuple_cpu.o     -DALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED -DALPAKA_DISABLE_VENDOR_RNG -DALPAKA_DEFAULT_HOST_MEMORY_ALIGNMENT=128 -o bin/lst_cpu
/cvmfs/cms.cern.ch/el8_amd64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/bin/../lib/gcc/x86_64-redhat-linux-gnu/12.3.1/../../../../x86_64-redhat-linux-gnu/bin/ld: cannot find -lFWCoreMessageLogger: No such file or directory
collect2: error: ld returned 1 exit status
make: *** [Makefile:49: bin/lst_cpu] Error 1
make: *** Waiting for unfinished jobs....
ERROR: bin/lst_cpu failed to compile!
See /ceph/users/atuna/CMSSW_15_0_0_pre3/src/RecoTracker/LSTCore/standalone/.make.log.1740524731 file for more detail...
```

