### PR TITLE
Update README.md with FWCore/MessageLogger

### DIFF
--- a/RecoTracker/LSTCore/standalone/README.md
+++ b/RecoTracker/LSTCore/standalone/README.md
@@ -27,7 +27,7 @@ cmsenv
 git cms-init
 # If necessary, add the remote git@github.com:SegmentLinking/cmssw.git
 # and checkout a development/feature branch
-git cms-addpkg RecoTracker/LST RecoTracker/LSTCore
+git cms-addpkg RecoTracker/LST RecoTracker/LSTCore FWCore/MessageLogger
 # If modifying some dependencies, run `git cms-checkdeps -a -A`
 scram b -j 12
 cd RecoTracker/LSTCore/standalone


### PR DESCRIPTION
At the chat today, @slava77 wondered if it might be easier to include FWCore/MessageLogger in the local area, rather than adjust the Makefile (https://github.com/SegmentLinking/cmssw/pull/155).

This is a PR for the suggestion, and I do think it's easier. FWCore/MessageLogger is a relatively small repo (372K). And this approach avoids exposing LDFLAGS to the rest of CMSSW_RELEASE_BASE.

Do you have a preference @slava77 ?


---

Original problem:

Hi yall. I found an error while following the README instructions to compile standalone with `lst_make_tracklooper -m`:

```
/cvmfs/cms.cern.ch/el8_amd64_gcc12/external/gcc/12.3.1-
40d504be6370b5a30e3947a6e575ca28/bin/../lib/gcc/x86_64-
redhat-linux-gnu/12.3.1/../../../../x86_64-redhat-linux-
gnu/bin/ld: cannot find -lFWCoreMessageLogger: No such file or directory
collect2: error: ld returned 1 exit status
make: *** [Makefile:49: bin/lst_cpu] Error 1
```

I think there's an error because the Makefile has `LDFLAGS` which includes `CMSSW_BASE`, but I don't have `FWCoreMessageLogger` in my `CMSSW_BASE`.