### PR TITLE
Reset pixel segments collection at start

### DIFF
--- a/RecoTracker/LSTCore/src/alpaka/LSTEvent.dev.cc
+++ b/RecoTracker/LSTCore/src/alpaka/LSTEvent.dev.cc
@@ -57,6 +57,7 @@ void LSTEvent::resetEventSync() {
   miniDoubletsDC_.reset();
   rangesDC_.reset();
   segmentsDC_.reset();
+  pixelSegmentsDC_.reset();
   tripletsDC_.reset();
   quintupletsDC_.reset();
   trackCandidatesDC_.reset();
@@ -67,6 +68,7 @@ void LSTEvent::resetEventSync() {
   rangesHC_.reset();
   miniDoubletsHC_.reset();
   segmentsHC_.reset();
+  pixelSegmentsHC_.reset();
   tripletsHC_.reset();
   quintupletsHC_.reset();
   pixelTripletsHC_.reset();


### PR DESCRIPTION
The pixel segments collection was not being reset, so it was causing some issues. I'm surprised that it was only noticeable on GPU and not on CPU.

@GNiendorf could you verify that this fixes the issue?