### PR TITLE
 Introduce a single LST-seeded, CKF-building iteration based on Patatrack pixel tracks

### DIFF
--- a/Configuration/PyReleaseValidation/README.md
+++ b/Configuration/PyReleaseValidation/README.md
@@ -62,6 +62,7 @@ The offsets currently in use are:
 * 0.756 HLT phase-2 timing menu trimmed tracking
 * 0.7561 HLT phase-2 timing menu Alpaka, trimmed tracking
 * 0.7562 HLT phase-2 timing menu Alpaka, trimmed tracking, single tracking iteration variant
+* 0.757: HLT phase-2 timing menu Alpaka, single tracking iteration, LST seeding + CKF building variant
 * 0.777 New Phase 2 Standalone Muon seeding, streamlined L3 Tracker Muons reconstruction (Inside-Out first), HLT Muon NanoAOD
 * 0.778 New Phase 2 Standalone Muon seeding, streamlined L3 Tracker Muons reconstruction (Outside-In first), HLT Muon NanoAOD
 * 0.78: Complete L1 workflow

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -1907,6 +1907,19 @@ upgradeWFs['HLTTiming75e33AlpakaTrimmedTrackingSingleIter'].step2 = {
     '--eventcontent':'FEVTDEBUGHLT,DQMIO'
 }
 
+upgradeWFs['HLTTiming75e33AlpakaSingleIterLSTSeeding'] = deepcopy(upgradeWFs['HLTTiming75e33'])
+upgradeWFs['HLTTiming75e33AlpakaSingleIterLSTSeeding'].suffix = '_HLT75e33TimingAlpakaSingleIterLSTSeeding'
+upgradeWFs['HLTTiming75e33AlpakaSingleIterLSTSeeding'].offset = 0.757
+upgradeWFs['HLTTiming75e33AlpakaSingleIterLSTSeeding'].step2 = {
+    '-s':'DIGI:pdigi_valid,L1TrackTrigger,L1,L1P2GT,DIGI2RAW,HLT:75e33_timing,VALIDATION:@hltValidation',
+    '--procModifiers': 'alpaka,singleIterPatatrack,trackingLST,seedingLST',
+    '--datatier':'GEN-SIM-DIGI-RAW,DQMIO',
+    '--eventcontent':'FEVTDEBUGHLT,DQMIO'
+}
+upgradeWFs['HLTTiming75e33AlpakaSingleIterLSTSeeding'].step3 = {
+    '-s':'HARVESTING:@hltValidation'
+}
+
 class UpgradeWorkflow_HLTwDIGI75e33(UpgradeWorkflow):
     def setup_(self, step, stepName, stepDict, k, properties):
         if 'DigiTrigger' in step:

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltGeneralTracks_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltGeneralTracks_cfi.py
@@ -25,6 +25,10 @@ hltGeneralTracks = cms.EDProducer("TrackListMerger",
     writeOnlyTrkQuals = cms.bool(False)
 )
 
+from Configuration.ProcessModifiers.singleIterPatatrack_cff import singleIterPatatrack
+from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
+from Configuration.ProcessModifiers.seedingLST_cff import seedingLST
+
 _hltGeneralTracksSingleIterPatatrack = hltGeneralTracks.clone(
     TrackProducers = ["hltInitialStepTrackSelectionHighPurity"],
     hasSelector = [0],
@@ -36,8 +40,7 @@ _hltGeneralTracksSingleIterPatatrack = hltGeneralTracks.clone(
     )]
 )
 
-from Configuration.ProcessModifiers.singleIterPatatrack_cff import singleIterPatatrack
-singleIterPatatrack.toReplaceWith(hltGeneralTracks, _hltGeneralTracksSingleIterPatatrack)
+(singleIterPatatrack & ~trackingLST & ~seedingLST).toReplaceWith(hltGeneralTracks, _hltGeneralTracksSingleIterPatatrack)
 
 _hltGeneralTracksLST = hltGeneralTracks.clone(
     TrackProducers = ["hltInitialStepTrackSelectionHighPuritypTTCLST", "hltInitialStepTrackSelectionHighPuritypLSTCLST", "hltInitialStepTracksT5TCLST", "hltHighPtTripletStepTrackSelectionHighPurity"],
@@ -50,10 +53,9 @@ _hltGeneralTracksLST = hltGeneralTracks.clone(
     )]
 )
 
-from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
-trackingLST.toReplaceWith(hltGeneralTracks, _hltGeneralTracksLST)
+(~singleIterPatatrack & trackingLST & ~seedingLST).toReplaceWith(hltGeneralTracks, _hltGeneralTracksLST)
 
-_hltGeneralTracksLSTSingleIterPatatrack = hltGeneralTracks.clone(
+_hltGeneralTracksSingleIterPatatrackLST = hltGeneralTracks.clone(
     TrackProducers = ["hltInitialStepTrackSelectionHighPuritypTTCLST", "hltInitialStepTrackSelectionHighPuritypLSTCLST", "hltInitialStepTracksT5TCLST"],
     hasSelector = [0,0,0],
     indivShareFrac = [0.1,0.1,0.1],
@@ -64,7 +66,7 @@ _hltGeneralTracksLSTSingleIterPatatrack = hltGeneralTracks.clone(
     )]
 )
 
-(singleIterPatatrack & trackingLST).toReplaceWith(hltGeneralTracks, _hltGeneralTracksLSTSingleIterPatatrack)
+(singleIterPatatrack & trackingLST & ~seedingLST).toReplaceWith(hltGeneralTracks, _hltGeneralTracksSingleIterPatatrackLST)
 
 _hltGeneralTracksLSTSeeding = hltGeneralTracks.clone(
             TrackProducers = ["hltInitialStepTrackSelectionHighPuritypTTCLST", "hltInitialStepTracksT5TCLST", "hltHighPtTripletStepTrackSelectionHighPuritypLSTCLST"],
@@ -77,5 +79,6 @@ _hltGeneralTracksLSTSeeding = hltGeneralTracks.clone(
             )]
     )
 
-from Configuration.ProcessModifiers.seedingLST_cff import seedingLST
-(seedingLST & trackingLST).toReplaceWith(hltGeneralTracks, _hltGeneralTracksLSTSeeding)
+(~singleIterPatatrack & trackingLST & seedingLST).toReplaceWith(hltGeneralTracks, _hltGeneralTracksLSTSeeding)
+
+(singleIterPatatrack & trackingLST & seedingLST).toReplaceWith(hltGeneralTracks, _hltGeneralTracksSingleIterPatatrack)

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltGeneralTracks_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltGeneralTracks_cfi.py
@@ -81,4 +81,7 @@ _hltGeneralTracksLSTSeeding = hltGeneralTracks.clone(
 
 (~singleIterPatatrack & trackingLST & seedingLST).toReplaceWith(hltGeneralTracks, _hltGeneralTracksLSTSeeding)
 
+(singleIterPatatrack & trackingLST & seedingLST).toModify(_hltGeneralTracksSingleIterPatatrack,
+                                                          TrackProducers = ["hltInitialStepTracks"],
+                                                          selectedTrackQuals = ["hltInitialStepTracks"])
 (singleIterPatatrack & trackingLST & seedingLST).toReplaceWith(hltGeneralTracks, _hltGeneralTracksSingleIterPatatrack)

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrackCandidates_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrackCandidates_cfi.py
@@ -44,5 +44,11 @@ _hltInitialStepTrackCandidatesLST = cms.EDProducer('LSTOutputConverter',
     )
 )
 
+from Configuration.ProcessModifiers.singleIterPatatrack_cff import singleIterPatatrack
 from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
-trackingLST.toReplaceWith(hltInitialStepTrackCandidates, _hltInitialStepTrackCandidatesLST)
+from Configuration.ProcessModifiers.seedingLST_cff import seedingLST
+# All useful combinations added to make the code work as expected and for clarity
+(~singleIterPatatrack & trackingLST & ~seedingLST).toReplaceWith(hltInitialStepTrackCandidates, _hltInitialStepTrackCandidatesLST)
+(~singleIterPatatrack & trackingLST & seedingLST).toReplaceWith(hltInitialStepTrackCandidates, _hltInitialStepTrackCandidatesLST)
+(singleIterPatatrack & trackingLST & ~seedingLST).toReplaceWith(hltInitialStepTrackCandidates, _hltInitialStepTrackCandidatesLST)
+(singleIterPatatrack & trackingLST & seedingLST).toModify(hltInitialStepTrackCandidates, src = "hltInitialStepTrajectorySeedsLST") # All LST seeds

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrajectorySeedsLST_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrajectorySeedsLST_cfi.py
@@ -15,7 +15,7 @@ hltInitialStepTrajectorySeedsLST = cms.EDProducer('LSTOutputConverter',
         OriginTransverseErrorMultiplier = cms.double(1),
         MinOneOverPtError = cms.double(1),
         magneticField = cms.string(''),
-        TTRHBuilder = cms.string('WithTrackAngle'),
+        TTRHBuilder = cms.string('hltESPTTRHBuilderWithTrackAngle'),
         forceKinematicWithRegionDirection = cms.bool(False)
     )
 )

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrajectorySeedsLST_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltInitialStepTrajectorySeedsLST_cfi.py
@@ -1,0 +1,21 @@
+import FWCore.ParameterSet.Config as cms
+
+hltInitialStepTrajectorySeedsLST = cms.EDProducer('LSTOutputConverter',
+    lstOutput = cms.InputTag('hltLST'),
+    phase2OTHits = cms.InputTag('hltPhase2OTHitsInputLST'),
+    lstPixelSeeds = cms.InputTag('hltPixelSeedInputLST'),
+    includeT5s = cms.bool(True),
+    includeNonpLSTSs = cms.bool(True),
+    propagatorAlong = cms.ESInputTag('', 'PropagatorWithMaterial'),
+    propagatorOpposite = cms.ESInputTag('', 'PropagatorWithMaterialOpposite'),
+    SeedCreatorPSet = cms.PSet(
+        ComponentName = cms.string('SeedFromConsecutiveHitsCreator'),
+        propagator = cms.string('PropagatorWithMaterial'),
+        SeedMomentumForBOFF = cms.double(5),
+        OriginTransverseErrorMultiplier = cms.double(1),
+        MinOneOverPtError = cms.double(1),
+        magneticField = cms.string(''),
+        TTRHBuilder = cms.string('WithTrackAngle'),
+        forceKinematicWithRegionDirection = cms.bool(False)
+    )
+)

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltPhase2PixelTracksSoA_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltPhase2PixelTracksSoA_cfi.py
@@ -41,8 +41,3 @@ hltPhase2PixelTracksSoA = cms.EDProducer('CAHitNtupletAlpakaPhase2@alpaka',
     # autoselect the alpaka backend
     alpaka = cms.untracked.PSet(backend = cms.untracked.string(''))
 )
-
-_hltPhase2PixelTracksSoASingleIterPatatrack = hltPhase2PixelTracksSoA.clone( minHitsPerNtuplet = 3 )
-
-from Configuration.ProcessModifiers.singleIterPatatrack_cff import singleIterPatatrack
-singleIterPatatrack.toReplaceWith(hltPhase2PixelTracksSoA, _hltPhase2PixelTracksSoASingleIterPatatrack)

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTInitialStepSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTInitialStepSequence_cfi.py
@@ -62,8 +62,6 @@ _HLTInitialStepSequenceSingleIterPatatrackLSTSeeding = cms.Sequence(
     +hltInitialStepTrajectorySeedsLST
     +hltInitialStepTrackCandidates
     +hltInitialStepTracks
-    +hltInitialStepTrackCutClassifier
-    +hltInitialStepTrackSelectionHighPurity
 )
 
 (singleIterPatatrack & trackingLST & seedingLST).toReplaceWith(HLTInitialStepSequence, _HLTInitialStepSequenceSingleIterPatatrackLSTSeeding)

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTInitialStepSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTInitialStepSequence_cfi.py
@@ -41,11 +41,29 @@ _HLTInitialStepSequenceLST = cms.Sequence(
     +hltInitialStepTrackSelectionHighPuritypLSTCLST
 )
 
-from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
-trackingLST.toReplaceWith(HLTInitialStepSequence, _HLTInitialStepSequenceLST)
-
 from Configuration.ProcessModifiers.singleIterPatatrack_cff import singleIterPatatrack
-(singleIterPatatrack & trackingLST).toReplaceWith(HLTInitialStepSequence, HLTInitialStepSequence.copyAndExclude([HLTHighPtTripletStepSeedingSequence,hltHighPtTripletStepSeedTracksLST]))
-
+from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
 from Configuration.ProcessModifiers.seedingLST_cff import seedingLST
-(seedingLST & trackingLST).toReplaceWith(HLTInitialStepSequence, _HLTInitialStepSequenceLST.copyAndExclude([hltInitialStepTrackspLSTCLST,hltInitialStepTrackCutClassifierpLSTCLST,hltInitialStepTrackSelectionHighPuritypLSTCLST]))
+
+(~singleIterPatatrack & trackingLST & ~seedingLST).toReplaceWith(HLTInitialStepSequence, _HLTInitialStepSequenceLST)
+
+(singleIterPatatrack & trackingLST & ~seedingLST).toReplaceWith(HLTInitialStepSequence, _HLTInitialStepSequenceLST.copyAndExclude([HLTHighPtTripletStepSeedingSequence,hltHighPtTripletStepSeedTracksLST]))
+
+(~singleIterPatatrack & trackingLST & seedingLST).toReplaceWith(HLTInitialStepSequence, _HLTInitialStepSequenceLST.copyAndExclude([hltInitialStepTrackspLSTCLST,hltInitialStepTrackCutClassifierpLSTCLST,hltInitialStepTrackSelectionHighPuritypLSTCLST]))
+
+from ..modules.hltInitialStepTrajectorySeedsLST_cfi import *
+_HLTInitialStepSequenceSingleIterPatatrackLSTSeeding = cms.Sequence(
+     hltInitialStepSeeds
+    +hltInitialStepSeedTracksLST
+    +hltPixelSeedInputLST
+    +hltSiPhase2RecHits # Probably need to move elsewhere in the final setup
+    +hltPhase2OTHitsInputLST # Probably need to move elsewhere in the final setup
+    +hltLST
+    +hltInitialStepTrajectorySeedsLST
+    +hltInitialStepTrackCandidates
+    +hltInitialStepTracks
+    +hltInitialStepTrackCutClassifier
+    +hltInitialStepTrackSelectionHighPurity
+)
+
+(singleIterPatatrack & trackingLST & seedingLST).toReplaceWith(HLTInitialStepSequence, _HLTInitialStepSequenceSingleIterPatatrackLSTSeeding)


### PR DESCRIPTION
The title describes accurately what I am trying to do here. While doing that, I also went ahead and made the code a bit more robust/clear, writing out the full combination of procModifiers for each configuration. The main motivation for this is to facilitate mkFit studies and understand the benefits of extending the LST tracks.

I have run the physics validation for the different configurations. While doing so, I realized that Patatrack seeding + LST seeding + CKF building is plagued by the same low-barrel efficiency as Patatrack seeding + CKF building, something that is fixed for Patatrack seeding + LST building. My hypothesis is that that efficiency comes from T5s, which are displaced and hence killed by the highPurity ID. Relaxing that ID (in fact totally removing it) recovers the efficiency:
![image](https://github.com/user-attachments/assets/8efbf99d-dbf4-4359-b046-a9d1cc40fae4)
Full list of plots in [here](https://uaf-10.t2.ucsd.edu/~evourlio/SDL/singleIterLSTSeeding/plots_default_VS_alpakaSingleIter_VS_alpakaSingleIterLSTSeeding_VS_alpakaSingleIterLSTSeedingNoTRKID/plots_hlt.html).
This change is implemented in a separate commit: 34e1937fdf5d360a2661dc6c6cf0061916b5581f.
Ultimately, we need to think more carefully what we do with the tracking ID, and potentially work on the DNN one that is there for Run 3?

However, we are now suffering by huge fake+duplicate rate. To deal with that, and to be in line with the direction that the patatrack development is moving towards, I decided to try using only quads or longer Patatrack pixel tracks as seeds (essentially excluding Patatrack triplets). That comes with a huge reduction of fake+duplicate rate (as expected) and a moderate reduction in efficiency, mostly in the barrel:
![image](https://github.com/user-attachments/assets/ca00ebd3-8674-4cd3-9c18-7db3a3bbb895)
Full list of plots in [here](https://uaf-10.t2.ucsd.edu/~evourlio/SDL/singleIterLSTSeeding/plots_default_VS_alpakaSingleIter_VS_alpakaSingleIterQuadsOnly_VS_alpakaSingleIterQuadsOnlyLSTSeeding/plots_hlt.html).
Having written that, we expect improvements by the Patatrack people on this exact configuration, and it is already decent with the relaxation of the tracking ID:
![image](https://github.com/user-attachments/assets/a8843390-de43-4d8a-8a1b-fe779a92a6a4)
Full list of plots in [here](https://uaf-10.t2.ucsd.edu/~evourlio/SDL/singleIterLSTSeeding/plots_default_VS_alpakaSingleIterQuadsOnly_VS_alpakaSingleIterQuadsOnlyLSTSeeding_VS_alpakaSingleIterQuadsOnlyLSTSeedingNoTRKID/plots_hlt.html).
This change is implemented in a separate commit: e0f297b494868dac40557b0eb9df8410856ee386.

Finally, comparing Patatrack seeding + LST building with Patatrack seeding + LST seeding + CKF building, the advantages are not so clear in terms of efficiency and fake rate. CKF extends the track and/or finds hits on the same layer but it seems like it cannot extend the tracks inwards/in the inner tracker, hence I had to relax the tracking ID in the previous configuration:
![image](https://github.com/user-attachments/assets/b43f9325-2d37-482c-b7ae-ef96b0e108da)
![image](https://github.com/user-attachments/assets/676f5736-6ee4-4752-9e22-39757d5d983f)
Full list of plots in [here](https://uaf-10.t2.ucsd.edu/~evourlio/SDL/singleIterLSTSeeding/plots_default_VS_alpakaSingleIterLST_VS_alpakaSingleIterQuadsOnlyLST_VS_alpakaSingleIterQuadsOnlyLSTSeedingNoTRKID/plots_hlt.html).