### PR TITLE
add trackToTrack comparisons for GPU vs CPU tracking, populated for trackingLST

### DIFF
--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -545,7 +545,7 @@ upgradeWFs['lstOnCPUIters01TrackingOnly'].step3 = upgradeWFs['trackingOnly'].ste
 class UpgradeWorkflow_lstOnGPUIters01TrackingOnly(UpgradeWorkflowTracking):
     def setup__(self, step, stepName, stepDict, k, properties):
         if 'Reco' in step: stepDict[stepName][k] = merge([self.step3, stepDict[step][k]])
-        elif 'HARVEST' in step: stepDict[stepName][k] = merge([{'-s': 'HARVESTING:@trackingOnlyValidation+@trackingOnlyDQM'}, stepDict[step][k]])
+        elif 'HARVEST' in step: stepDict[stepName][k] = merge([{'-s': 'HARVESTING:@trackingOnlyValidation+@trackingOnlyDQM', '--procModifiers': 'trackingIters01,trackingLST'}, stepDict[step][k]])
         elif 'ALCA' in step: stepDict[stepName][k] = None
     def condition(self, fragment, stepList, key, hasHarvest):
         result = (fragment=="TTbar_14TeV") and hasHarvest and ('Run4' in key)

--- a/DQM/TrackingMonitorClient/python/TrackingClientConfig_Tier0_cff.py
+++ b/DQM/TrackingMonitorClient/python/TrackingClientConfig_Tier0_cff.py
@@ -92,7 +92,17 @@ TrackEffClient.AlgoName   = 'CKFTk'
 
 from DQM.TrackingMonitor.TrackFoldedOccupancyClient_cfi import *
 
-TrackingOfflineDQMClient = cms.Sequence(trackingQTester*trackingOfflineAnalyser*trackingEffFromHitPattern*voMonitoringClientSequence*primaryVertexResolutionClient*TrackEffClient*foldedMapClientSeq)
+from DQMOffline.Trigger.TrackingMonitoring_Client_cff import TrackToTrackEfficiencies as _t2t
+highPtTripletStepTrackToTrackSerialSyncAnalyzer = _t2t.clone(
+    subDirs = ["Tracking/TrackBuilding/ValidationWRTSerialSync/highPtTripletStep"])
+trackToTrackCPUAnalyzer = cms.Sequence()
+_trackToTrackCPUAnalyzer_trackingLST = cms.Sequence(highPtTripletStepTrackToTrackSerialSyncAnalyzer)
+from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU140
+from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
+(trackingPhase2PU140 & trackingLST).toReplaceWith(trackToTrackCPUAnalyzer, _trackToTrackCPUAnalyzer_trackingLST)
+
+
+TrackingOfflineDQMClient = cms.Sequence(trackingQTester*trackingOfflineAnalyser*trackingEffFromHitPattern*voMonitoringClientSequence*primaryVertexResolutionClient*TrackEffClient*foldedMapClientSeq*trackToTrackCPUAnalyzer)
 
 TrackingOfflineDQMClientZeroBias = cms.Sequence(trackingQTester*trackingOfflineAnalyser*trackingEffFromHitPatternZeroBias*voMonitoringClientSequence*primaryVertexResolutionClient*TrackEffClient*foldedMapClientSeq)
 

--- a/DQM/TrackingMonitorSource/python/TrackingSourceConfig_Tier0_cff.py
+++ b/DQM/TrackingMonitorSource/python/TrackingSourceConfig_Tier0_cff.py
@@ -403,6 +403,7 @@ trackingLST.toModify(locals()["TrackSeedMonhighPtTripletStep"],
 TrackingDQMSourceTier0 += TrackSeedMonSequence
 
 from DQM.TrackingMonitorSource.shortTrackResolution_cff import *
+from DQM.TrackingMonitorSource.trackToTrackCPU_cff import *
 
 # MessageLog
 for module in selectedModules :
@@ -412,6 +413,7 @@ TrackingDQMSourceTier0 += voMonitoringSequence
 TrackingDQMSourceTier0 += voWcutMonitoringSequence
 TrackingDQMSourceTier0 += primaryVertexResolution
 TrackingDQMSourceTier0 += shortTrackResolution3to8
+TrackingDQMSourceTier0 += trackToTrackCPUSequence
 TrackingDQMSourceTier0 += dqmInfoTracking
 
 

--- a/DQM/TrackingMonitorSource/python/trackToTrackCPU_cff.py
+++ b/DQM/TrackingMonitorSource/python/trackToTrackCPU_cff.py
@@ -1,0 +1,21 @@
+import FWCore.ParameterSet.Config as cms
+from RecoTracker.IterativeTracking.HighPtTripletStep_cff import HighPtTripletStepTaskSerialSync
+from .TrackToTrackComparisonHists_cfi import TrackToTrackComparisonHists as _t2t
+
+trackToTrackCPUSequence = cms.Sequence()
+
+highPtTripletStepTrackToTrackSerialSync = _t2t.clone(
+    requireValidHLTPaths = False,
+    monitoredTrack = "highPtTripletStepTracks",
+    referenceTrack = "highPtTripletStepTracksSerialSync",
+
+    monitoredBeamSpot = "offlineBeamSpot",
+    monitoredPrimaryVertices = "offlinePrimaryVertices",
+    topDirName = "Tracking/TrackBuilding/ValidationWRTSerialSync/highPtTripletStep"
+)
+_trackToTrackCPUTask_trackingLST = cms.Sequence(HighPtTripletStepTaskSerialSync)
+_trackToTrackCPUTask_trackingLST += highPtTripletStepTrackToTrackSerialSync
+
+from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU140
+from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
+(trackingPhase2PU140 & trackingLST).toReplaceWith(trackToTrackCPUSequence, _trackToTrackCPUTask_trackingLST)

--- a/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
@@ -433,6 +433,43 @@ _HighPtTripletStepTask_LST.add(siPhase2RecHits, lstInitialStepSeedTracks, lstHig
                                lstProducerTask, highPtTripletStepLSTpTracks, highPtTripletStepLSTT5Tracks, highPtTripletStepSelectorLSTT5)
 (trackingPhase2PU140 & trackingLST).toReplaceWith(HighPtTripletStepTask, _HighPtTripletStepTask_LST)
 
+lstInputProducerSerialSync = lstInputProducer.clone(
+    alpaka = dict(backend = "serial_sync")
+)
+lstProducerSerialSync = lstProducer.clone(
+    alpaka = dict(backend = "serial_sync"),
+    lstInput = "lstInputProducerSerialSync"
+)
+highPtTripletStepTrackCandidatesSerialSync = highPtTripletStepTrackCandidates.clone()
+(trackingPhase2PU140 & trackingLST).toModify(highPtTripletStepTrackCandidatesSerialSync,
+    lstOutput = "lstProducerSerialSync",
+    lstInput = "lstInputProducerSerialSync",
+    lstPixelSeeds = "lstInputProducerSerialSync"
+)
+highPtTripletStepLSTpTracksSerialSync = highPtTripletStepLSTpTracks.clone(
+    src    = 'highPtTripletStepTrackCandidatesSerialSync:pTCsLST')
+highPtTripletStepLSTT5TracksSerialSync = highPtTripletStepLSTT5Tracks.clone(
+    src    = 'highPtTripletStepTrackCandidatesSerialSync:t5TCsLST')
+highPtTripletStepSelectorSerialSync = highPtTripletStepSelector.clone()
+(trackingPhase2PU140 & trackingLST).toModify(highPtTripletStepSelectorSerialSync, src = "highPtTripletStepLSTpTracksSerialSync" )
+highPtTripletStepSelectorLSTT5SerialSync = highPtTripletStepSelectorLSTT5.clone(src = "highPtTripletStepLSTT5TracksSerialSync")
+highPtTripletStepTracksSerialSync = highPtTripletStepTracks.clone()
+(trackingPhase2PU140 & trackingLST).toModify(highPtTripletStepTracksSerialSync,
+    TrackProducers     = ['highPtTripletStepLSTpTracksSerialSync',
+                          'highPtTripletStepLSTT5TracksSerialSync'],
+    selectedTrackQuals = ['highPtTripletStepSelectorSerialSync:highPtTripletStep',
+                          'highPtTripletStepSelectorLSTT5SerialSync:highPtTripletStepLSTT5'],
+)
+_HighPtTripletStepTask_LSTSerialSync = HighPtTripletStepTask.copy()
+_HighPtTripletStepTask_LSTSerialSync.add(siPhase2RecHits, lstInitialStepSeedTracks, lstHighPtTripletStepSeedTracks, lstInputProducerSerialSync,
+                                         lstProducerSerialSync, highPtTripletStepTrackCandidatesSerialSync,
+                                         highPtTripletStepLSTpTracksSerialSync, highPtTripletStepLSTT5TracksSerialSync,
+                                         highPtTripletStepSelectorSerialSync, highPtTripletStepSelectorLSTT5SerialSync,
+                                         highPtTripletStepTracksSerialSync
+)
+HighPtTripletStepTaskSerialSync = cms.Task()
+(trackingPhase2PU140 & trackingLST).toReplaceWith(HighPtTripletStepTaskSerialSync, _HighPtTripletStepTask_LSTSerialSync)
+
 # fast tracking mask producer 
 from FastSimulation.Tracking.FastTrackerRecHitMaskProducer_cfi import maskProducerFromClusterRemover
 highPtTripletStepMasks = maskProducerFromClusterRemover(highPtTripletStepClusters)


### PR DESCRIPTION
the monitoring sequence is added in combination with `trackingLST` proc modifier.
This relies on running a clone of the regular LST tracking in `HighPtTripletStepTaskSerialSync`.
Tested with 29834.704 

<img width="819" alt="image" src="https://github.com/user-attachments/assets/b0a261e3-e140-4dd3-94b1-ac88a7965b97" />
<img width="801" alt="image" src="https://github.com/user-attachments/assets/fddd1530-0fe6-420e-98c0-4f366a3c6701" />

@VourMa please have a look

