### PR TITLE
Add plot of fake-or-duplicate rate 

### DIFF
--- a/RecoTracker/LSTCore/standalone/efficiency/python/lst_plot_performance.py
+++ b/RecoTracker/LSTCore/standalone/efficiency/python/lst_plot_performance.py
@@ -8,7 +8,7 @@ import sys
 from math import sqrt
 
 sel_choices = ["base", "loweta", "xtr", "vtr", "none"]
-metric_choices = ["eff", "fakerate", "duplrate"]
+metric_choices = ["eff", "fakerate", "duplrate", "fakeorduplrate"]
 variable_choices = ["pt", "ptmtv", "ptlow", "eta", "phi", "dxy", "dz", "vxy"]
 objecttype_choices = ["TC", "pT5", "T5", "pT3", "pLS", "pT5_lower", "pT3_lower", "T5_lower"]
 #lowerObjectType = ["pT5_lower", "pT3_lower", "T5_lower"]
@@ -235,6 +235,7 @@ def process_arguments_into_params(args):
     if params["metric"] == "eff": params["metricsuffix"] = "ef"
     if params["metric"] == "duplrate": params["metricsuffix"] = "dr"
     if params["metric"] == "fakerate": params["metricsuffix"] = "fr"
+    if params["metric"] == "fakeorduplrate": params["metricsuffix"] = "fdr"
 
     # If breakdown it must be object type of TC
     params["breakdown"] = args.breakdown
@@ -357,7 +358,9 @@ def draw_ratio(nums, dens, params):
 
 #______________________________________________________________________________________________________
 def parse_plot_name(output_name):
-    if "fake" in output_name:
+    if "fakeordupl" in output_name:
+        rtnstr = ["Fake-or-duplicate Rate of"]
+    elif "fake" in output_name:
         rtnstr = ["Fake Rate of"]
     elif "dup" in output_name:
         rtnstr = ["Duplicate Rate of"]
@@ -430,6 +433,8 @@ def set_label(eff, output_name, raw_number):
     eff.GetXaxis().SetTitle(title)
     if "fakerate" in output_name:
         eff.GetYaxis().SetTitle("Fake Rate")
+    elif "fakeorduplrate" in output_name:
+        eff.GetYaxis().SetTitle("Fake-or-duplicate Rate")
     elif "duplrate" in output_name:
         eff.GetYaxis().SetTitle("Duplicate Rate")
     elif "inefficiency" in output_name:
@@ -494,7 +499,7 @@ def draw_label(params):
         particleselection = ((", Particle:" + pdgidstr) if pdgidstr else "" ) + ((", Charge:" + chargestr) if chargestr else "" )
         fiducial_label += particleselection
     # If fake rate or duplicate rate plot follow the following fiducial label rule
-    elif "fakerate" in output_name or "duplrate" in output_name:
+    elif "fakerate" in output_name or "duplrate" in output_name or "fakeorduplrate" in output_name:
         if "_pt" in output_name:
             fiducial_label = "|#eta| < {eta}".format(eta=etacut)
         elif "_eta" in output_name:
@@ -579,6 +584,8 @@ def draw_plot(effs, nums, dens, params):
     else:
         if "fakerate" in output_name:
             effs[0].GetYaxis().SetRangeUser(0.0, yaxis_max * 1.1)
+        elif "fakeorduplrate" in output_name:
+            effs[0].GetYaxis().SetRangeUser(0.0, yaxis_max * 1.1)
         elif "duplrate" in output_name:
             effs[0].GetYaxis().SetRangeUser(0.0, yaxis_max * 1.1)
         else:
@@ -648,11 +655,13 @@ def plot_standard_performance_plots(args):
             "eff": ["pt", "ptlow", "ptmtv", "eta", "phi", "dxy", "dz", "vxy"],
             "fakerate": ["pt", "ptlow", "ptmtv", "eta", "phi"],
             "duplrate": ["pt", "ptlow", "ptmtv", "eta", "phi"],
+            "fakeorduplrate": ["pt", "ptlow", "ptmtv", "eta", "phi"],
             }
     sels = {
             "eff": ["base", "loweta"],
             "fakerate": ["none"],
             "duplrate": ["none"],
+            "fakeorduplrate": ["none"],
             }
     xcoarses = {
             "pt": [False],
@@ -696,16 +705,28 @@ def plot_standard_performance_plots(args):
                 "pT3_lower":[False],
                 "T5_lower":[False],
             },
+            "fakeorduplrate":{
+                "TC": [True, False],
+                "pT5": [False],
+                "pT3": [False],
+                "T5": [False],
+                "pLS": [False],
+                "pT5_lower":[False],
+                "pT3_lower":[False],
+                "T5_lower":[False],
+            },
     }
     pdgids = {
             "eff": [0, 11, 13, 211, 321],
             "fakerate": [0],
             "duplrate": [0],
+            "fakeorduplrate": [0],
             }
     charges = {
             "eff":[0, 1, -1],
             "fakerate":[0],
             "duplrate":[0],
+            "fakeorduplrate":[0],
             }
 
     if args.metric:
@@ -724,35 +745,41 @@ def plot_standard_performance_plots(args):
         pdgids["eff"] = [args.pdgid]
         pdgids["fakerate"] = [args.pdgid]
         pdgids["duplrate"] = [args.pdgid]
+        pdgids["fakeorduplrate"] = [args.pdgid]
 
     if args.charge != None:
         charges["eff"] = [args.charge]
         charges["fakerate"] = [args.charge]
         charges["duplrate"] = [args.charge]
+        charges["fakeorduplrate"] = [args.charge]
 
     if args.variable:
         # dxy and dz are only in efficiency
         if args.variable != "dxy" and args.variable != "dz" and args.variable != "vxy":
             variables["eff"] = [args.variable]
             variables["fakerate"] = [args.variable]
-            variables["suplrate"] = [args.variable]
+            variables["duplrate"] = [args.variable]
+            variables["fakeorduplrate"] = [args.variable]
         else:
             variables["eff"] = [args.variable]
             variables["fakerate"] = []
-            variables["suplrate"] = []
+            variables["duplrate"] = []
+            variables["fakeorduplrate"] = []
 
     if args.individual:
         # Only eff / TC matters here
         breakdowns = {"eff":{"TC":[False], "pT5_lower":[False], "pT3_lower":[False], "T5_lower":[False]},
                 "fakerate": {"TC":[False], "pT5_lower":[False], "pT3_lower":[False], "T5_lower":[False]},
-                "duplrate": {"TC":[False], "pT5_lower":[False], "pT3_lower":[False], "T5_lower":[False]}}
+                "duplrate": {"TC":[False], "pT5_lower":[False], "pT3_lower":[False], "T5_lower":[False]},
+                "fakeorduplrate": {"TC":[False], "pT5_lower":[False], "pT3_lower":[False], "T5_lower":[False]}}
 
 
     else:
         # Only eff / TC matters here
         breakdowns = {"eff":{"TC":[True], "pT5_lower":[False], "pT3_lower":[False], "T5_lower":[False]},
                 "fakerate": {"TC":[True], "pT5_lower":[False], "pT3_lower":[False], "T5_lower":[False]},
-                "duplrate": {"TC":[True], "pT5_lower":[False], "pT3_lower":[False], "T5_lower":[False]}}
+                "duplrate": {"TC":[True], "pT5_lower":[False], "pT3_lower":[False], "T5_lower":[False]},
+                "fakeorduplrate": {"TC":[True], "pT5_lower":[False], "pT3_lower":[False], "T5_lower":[False]}}
     if args.yzoom:
         args.yzooms = [args.yzoom]
 

--- a/RecoTracker/LSTCore/standalone/efficiency/src/performance.cc
+++ b/RecoTracker/LSTCore/standalone/efficiency/src/performance.cc
@@ -291,6 +291,95 @@ int main(int argc, char** argv) {
 
   bookDuplicateRateSets(list_DRSetDef);
 
+  // creating a set of fake-or-duplicate rate plots
+  std::vector<RecoTrackSetDefinition> list_FDRSetDef;
+  list_FDRSetDef.push_back(
+      RecoTrackSetDefinition(/* name  */
+                             "TC",
+                             /* pass  */
+                             [&](unsigned int itc) { return (lstEff.getVI("tc_isDuplicate").at(itc) > 0) or (lstEff.getVI("tc_isFake").at(itc) > 0); },
+                             /* sel   */ [&](unsigned int itc) { return 1; },
+                             /* pt    */ [&]() { return lstEff.getVF("tc_pt"); },
+                             /* eta   */ [&]() { return lstEff.getVF("tc_eta"); },
+                             /* phi   */ [&]() { return lstEff.getVF("tc_phi"); },
+                             /* type  */ [&]() { return lstEff.getVI("tc_type"); }));
+  list_FDRSetDef.push_back(
+      RecoTrackSetDefinition(/* name  */
+                             "pT5",
+                             /* pass  */
+                             [&](unsigned int itc) { return (lstEff.getVI("tc_isDuplicate").at(itc) > 0) or (lstEff.getVI("tc_isFake").at(itc) > 0); },
+                             /* sel   */
+                             [&](unsigned int itc) { return lstEff.getVI("tc_type").at(itc) == pT5; },
+                             /* pt    */ [&]() { return lstEff.getVF("tc_pt"); },
+                             /* eta   */ [&]() { return lstEff.getVF("tc_eta"); },
+                             /* phi   */ [&]() { return lstEff.getVF("tc_phi"); },
+                             /* type  */ [&]() { return lstEff.getVI("tc_type"); }));
+  list_FDRSetDef.push_back(
+      RecoTrackSetDefinition(/* name  */
+                             "pT3",
+                             /* pass  */
+                             [&](unsigned int itc) { return (lstEff.getVI("tc_isDuplicate").at(itc) > 0) or (lstEff.getVI("tc_isFake").at(itc) > 0); },
+                             /* sel   */
+                             [&](unsigned int itc) { return lstEff.getVI("tc_type").at(itc) == pT3; },
+                             /* pt    */ [&]() { return lstEff.getVF("tc_pt"); },
+                             /* eta   */ [&]() { return lstEff.getVF("tc_eta"); },
+                             /* phi   */ [&]() { return lstEff.getVF("tc_phi"); },
+                             /* type  */ [&]() { return lstEff.getVI("tc_type"); }));
+  list_FDRSetDef.push_back(
+      RecoTrackSetDefinition(/* name  */
+                             "T5",
+                             /* pass  */
+                             [&](unsigned int itc) { return (lstEff.getVI("tc_isDuplicate").at(itc) > 0) or (lstEff.getVI("tc_isFake").at(itc) > 0); },
+                             /* sel   */
+                             [&](unsigned int itc) { return lstEff.getVI("tc_type").at(itc) == T5; },
+                             /* pt    */ [&]() { return lstEff.getVF("tc_pt"); },
+                             /* eta   */ [&]() { return lstEff.getVF("tc_eta"); },
+                             /* phi   */ [&]() { return lstEff.getVF("tc_phi"); },
+                             /* type  */ [&]() { return lstEff.getVI("tc_type"); }));
+  list_FDRSetDef.push_back(
+      RecoTrackSetDefinition(/* name  */
+                             "pLS",
+                             /* pass  */
+                             [&](unsigned int itc) { return (lstEff.getVI("tc_isDuplicate").at(itc) > 0) or (lstEff.getVI("tc_isFake").at(itc) > 0); },
+                             /* sel   */
+                             [&](unsigned int itc) { return lstEff.getVI("tc_type").at(itc) == pLS; },
+                             /* pt    */ [&]() { return lstEff.getVF("tc_pt"); },
+                             /* eta   */ [&]() { return lstEff.getVF("tc_eta"); },
+                             /* phi   */ [&]() { return lstEff.getVF("tc_phi"); },
+                             /* type  */ [&]() { return lstEff.getVI("tc_type"); }));
+
+  if (ana.do_lower_level) {
+    list_FDRSetDef.push_back(RecoTrackSetDefinition(
+        /* name  */
+        "pT5_lower",
+        /* pass  */ [&](unsigned int ipT5) { return (lstEff.getVI("pT5_isDuplicate").at(ipT5) > 0) or (lstEff.getVI("pT5_isFake").at(ipT5) > 0); },
+        /* sel   */ [&](unsigned int ipT5) { return 1; },
+        /* pt    */ [&]() { return lstEff.getVF("pT5_pt"); },
+        /* eta   */ [&]() { return lstEff.getVF("pT5_eta"); },
+        /* phi   */ [&]() { return lstEff.getVF("pT5_phi"); },
+        /* type  */ [&]() { return std::vector<int>(lstEff.getVF("pT5_pt").size(), 1); }));
+    list_FDRSetDef.push_back(RecoTrackSetDefinition(
+        /* name  */
+        "T5_lower",
+        /* pass  */ [&](unsigned int it5) { return (lstEff.getVI("t5_isDuplicate").at(it5) > 0) or (lstEff.getVI("t5_isFake").at(it5) > 0); },
+        /* sel   */ [&](unsigned int it5) { return 1; },
+        /* pt    */ [&]() { return lstEff.getVF("t5_pt"); },
+        /* eta   */ [&]() { return lstEff.getVF("t5_eta"); },
+        /* phi   */ [&]() { return lstEff.getVF("t5_phi"); },
+        /* type  */ [&]() { return std::vector<int>(lstEff.getVF("t5_pt").size(), 1); }));
+    list_FDRSetDef.push_back(RecoTrackSetDefinition(
+        /* name  */
+        "pT3_lower",
+        /* pass  */ [&](unsigned int ipT3) { return (lstEff.getVI("pT3_isDuplicate").at(ipT3) > 0) or (lstEff.getVI("pT3_isFake").at(ipT3) > 0); },
+        /* sel   */ [&](unsigned int ipT3) { return 1; },
+        /* pt    */ [&]() { return lstEff.getVF("pT3_pt"); },
+        /* eta   */ [&]() { return lstEff.getVF("pT3_eta"); },
+        /* phi   */ [&]() { return lstEff.getVF("pT3_phi"); },
+        /* type  */ [&]() { return std::vector<int>(lstEff.getVF("pT3_pt").size(), 1); }));
+  }
+
+  bookFakeOrDuplicateRateSets(list_FDRSetDef);
+
   // Book Histograms
   ana.cutflow.bookHistograms(ana.histograms);  // if just want to book everywhere
 
@@ -311,6 +400,7 @@ int main(int argc, char** argv) {
     fillEfficiencySets(list_effSetDef);
     fillFakeRateSets(list_FRSetDef);
     fillDuplicateRateSets(list_DRSetDef);
+    fillFakeOrDuplicateRateSets(list_FDRSetDef);
 
     // Reset all temporary variables necessary for histogramming
     ana.cutflow.fill();
@@ -568,6 +658,60 @@ void bookFakeRateSet(RecoTrackSetDefinition& FRset) {
   });
 }
 
+//__________________________________________________________________________________________________________________________________________________________________________
+void bookFakeOrDuplicateRateSets(std::vector<RecoTrackSetDefinition>& FDRsets) {
+  for (auto& FDRset : FDRsets) {
+    bookFakeOrDuplicateRateSet(FDRset);
+  }
+}
+
+//__________________________________________________________________________________________________________________________________________________________________________
+void bookFakeOrDuplicateRateSet(RecoTrackSetDefinition& FDRset) {
+  TString category_name = FDRset.set_name;
+
+  // Denominator tracks' quantities
+  ana.tx.createBranch<std::vector<float>>(category_name + "_fdr_denom_pt");
+  ana.tx.createBranch<std::vector<float>>(category_name + "_fdr_denom_eta");
+  ana.tx.createBranch<std::vector<float>>(category_name + "_fdr_denom_phi");
+
+  // Numerator tracks' quantities
+  ana.tx.createBranch<std::vector<float>>(category_name + "_fdr_numer_pt");
+  ana.tx.createBranch<std::vector<float>>(category_name + "_fdr_numer_eta");
+  ana.tx.createBranch<std::vector<float>>(category_name + "_fdr_numer_phi");
+
+  // Histogram utility object that is used to define the histograms
+  ana.histograms.addVecHistogram(category_name + "_fdr_denom_pt", getPtBounds(0), [&, category_name]() {
+    return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_fdr_denom_pt");
+  });
+  ana.histograms.addVecHistogram(category_name + "_fdr_denom_ptlow", getPtBounds(4), [&, category_name]() {
+    return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_fdr_denom_pt");
+  });
+  ana.histograms.addVecHistogram(category_name + "_fdr_denom_ptmtv", getPtBounds(9), [&, category_name]() {
+    return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_fdr_denom_pt");
+  });
+  ana.histograms.addVecHistogram(category_name + "_fdr_denom_eta", 180, -4.5, 4.5, [&, category_name]() {
+    return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_fdr_denom_eta");
+  });
+  ana.histograms.addVecHistogram(category_name + "_fdr_numer_phi", 180, -M_PI, M_PI, [&, category_name]() {
+    return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_fdr_numer_phi");
+  });
+  ana.histograms.addVecHistogram(category_name + "_fdr_numer_pt", getPtBounds(0), [&, category_name]() {
+    return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_fdr_numer_pt");
+  });
+  ana.histograms.addVecHistogram(category_name + "_fdr_numer_ptlow", getPtBounds(4), [&, category_name]() {
+    return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_fdr_numer_pt");
+  });
+  ana.histograms.addVecHistogram(category_name + "_fdr_numer_ptmtv", getPtBounds(9), [&, category_name]() {
+    return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_fdr_numer_pt");
+  });
+  ana.histograms.addVecHistogram(category_name + "_fdr_numer_eta", 180, -4.5, 4.5, [&, category_name]() {
+    return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_fdr_numer_eta");
+  });
+  ana.histograms.addVecHistogram(category_name + "_fdr_denom_phi", 180, -M_PI, M_PI, [&, category_name]() {
+    return ana.tx.getBranchLazy<std::vector<float>>(category_name + "_fdr_denom_phi");
+  });
+}
+
 // ---------------------------------------------------------=============================================-------------------------------------------------------------------
 // ---------------------------------------------------------=============================================-------------------------------------------------------------------
 // ---------------------------------------------------------=============================================-------------------------------------------------------------------
@@ -784,5 +928,43 @@ void fillDuplicateRateSet(int itc, RecoTrackSetDefinition& DRset, float pt, floa
     ana.tx.pushbackToBranch<float>(category_name + "_dr_denom_phi", phi);
     if (pass)
       ana.tx.pushbackToBranch<float>(category_name + "_dr_numer_phi", phi);
+  }
+}
+
+//__________________________________________________________________________________________________________________________________________________________________________
+void fillFakeOrDuplicateRateSets(std::vector<RecoTrackSetDefinition>& FDRsets) {
+  for (auto& FDRset : FDRsets) {
+    std::vector<float> const& pt = FDRset.pt();
+    std::vector<float> const& eta = FDRset.eta();
+    std::vector<float> const& phi = FDRset.phi();
+    for (unsigned int itc = 0; itc < FDRset.pt().size(); ++itc) {
+      fillFakeOrDuplicateRateSet(itc, FDRset, pt.at(itc), eta.at(itc), phi.at(itc));
+    }
+  }
+}
+
+//__________________________________________________________________________________________________________________________________________________________________________
+void fillFakeOrDuplicateRateSet(int itc, RecoTrackSetDefinition& FDRset, float pt, float eta, float phi) {
+  TString category_name = FDRset.set_name;
+  bool pass = FDRset.pass(itc);
+  bool sel = FDRset.sel(itc);
+
+  if (not sel)
+    return;
+
+  if (pt > ana.pt_cut) {
+    ana.tx.pushbackToBranch<float>(category_name + "_fdr_denom_eta", eta);
+    if (pass)
+      ana.tx.pushbackToBranch<float>(category_name + "_fdr_numer_eta", eta);
+  }
+  if (std::abs(eta) < ana.eta_cut) {
+    ana.tx.pushbackToBranch<float>(category_name + "_fdr_denom_pt", pt);
+    if (pass)
+      ana.tx.pushbackToBranch<float>(category_name + "_fdr_numer_pt", pt);
+  }
+  if (std::abs(eta) < ana.eta_cut and pt > ana.pt_cut) {
+    ana.tx.pushbackToBranch<float>(category_name + "_fdr_denom_phi", phi);
+    if (pass)
+      ana.tx.pushbackToBranch<float>(category_name + "_fdr_numer_phi", phi);
   }
 }

--- a/RecoTracker/LSTCore/standalone/efficiency/src/performance.h
+++ b/RecoTracker/LSTCore/standalone/efficiency/src/performance.h
@@ -12,6 +12,8 @@ void bookFakeRateSets(std::vector<RecoTrackSetDefinition>& FRset);
 void bookFakeRateSet(RecoTrackSetDefinition& FRset);
 void bookDuplicateRateSets(std::vector<RecoTrackSetDefinition>& DRset);
 void bookDuplicateRateSet(RecoTrackSetDefinition& DRset);
+void bookFakeOrDuplicateRateSets(std::vector<RecoTrackSetDefinition>& FDRset);
+void bookFakeOrDuplicateRateSet(RecoTrackSetDefinition& FDRset);
 
 void fillEfficiencySets(std::vector<SimTrackSetDefinition>& effset);
 void fillEfficiencySet(int isimtrk,
@@ -30,5 +32,7 @@ void fillFakeRateSets(std::vector<RecoTrackSetDefinition>& FRset);
 void fillFakeRateSet(int isimtrk, RecoTrackSetDefinition& FRset, float pt, float eta, float phi);
 void fillDuplicateRateSets(std::vector<RecoTrackSetDefinition>& DRset);
 void fillDuplicateRateSet(int isimtrk, RecoTrackSetDefinition& DRset, float pt, float eta, float phi);
+void fillFakeOrDuplicateRateSets(std::vector<RecoTrackSetDefinition>& FDRset);
+void fillFakeOrDuplicateRateSet(int isimtrk, RecoTrackSetDefinition& FDRset, float pt, float eta, float phi);
 
 #endif


### PR DESCRIPTION
Hi yall. In my rabbit hole of understanding the relationship between fakes and duplicates, I think it would be helpful to have a plot of fake-or-duplicate rate. What do you think?

I attached a plot made with this. It looks similar to the fake rate and duplicate rate plots, as expected

[TC_fakeorduplrate_etacoarsezoom.pdf](https://github.com/user-attachments/files/21132913/TC_fakeorduplrate_etacoarsezoom.pdf)

Stupid question: should I rename `fakeordupl` to be `ford` (f-or-d)? It was nice how `fake` and `dupl` are both four characters, and I broke that niceness.