### PR TITLE
fix hit sorting in LSTOutputConverter.cc

### DIFF
--- a/RecoTracker/LST/plugins/LSTOutputConverter.cc
+++ b/RecoTracker/LST/plugins/LSTOutputConverter.cc
@@ -177,8 +177,8 @@ void LSTOutputConverter::produce(edm::Event& iEvent, const edm::EventSetup& iSet
         return true;
       } else if (GeomDetEnumerators::isOuterTracker(asub) && GeomDetEnumerators::isInnerTracker(bsub)) {
         return false;
-      } else if (asub != bsub) {
-        return asub < bsub;
+      } else if (asub != bsub) { // here: both are in the inner or both are in the outer
+        return GeomDetEnumerators::isBarrel(asub); // assumes only one subdet per barrel/endcap
       } else {
         const auto& apos = a.surface();
         const auto& bpos = b.surface();


### PR DESCRIPTION
subdets in the IT are barrel:1, endcap:2; in the OT barrel:5, endcap:4.
So, sorting by the subdet value is not reliable. I've changed to select barrel as smaller. This assumes only one subdet per detector type, which is currently the case in the tracker IDs.