### PR TITLE
Update Mixing.py to include 100_BX_25ns_m3p3

### DIFF
--- a/Configuration/StandardSequences/python/Mixing.py
+++ b/Configuration/StandardSequences/python/Mixing.py
@@ -172,6 +172,7 @@ addMixingScenario("AVE_90_BX_50ns",{'file': 'SimGeneral.MixingModule.mix_POISSON
 addMixingScenario("AVE_90_BX_25ns",{'file': 'SimGeneral.MixingModule.mix_POISSON_average_cfi','BX':25, 'B': (-12,3), 'N': 90})
 addMixingScenario("AVE_100_BX_50ns",{'file': 'SimGeneral.MixingModule.mix_POISSON_average_cfi','BX':50, 'B': (-12,3), 'N': 100})
 addMixingScenario("AVE_100_BX_25ns",{'file': 'SimGeneral.MixingModule.mix_POISSON_average_cfi','BX':25, 'B': (-12,3), 'N': 100})
+addMixingScenario("AVE_100_BX_25ns_m3p3",{'file': 'SimGeneral.MixingModule.mix_POISSON_average_cfi','BX':25, 'B': (-3,3), 'N': 100})
 addMixingScenario("AVE_120_BX_50ns",{'file': 'SimGeneral.MixingModule.mix_POISSON_average_cfi','BX':50, 'B': (-12,3), 'N': 120})
 addMixingScenario("AVE_120_BX_25ns",{'file': 'SimGeneral.MixingModule.mix_POISSON_average_cfi','BX':25, 'B': (-12,3), 'N': 120})
 addMixingScenario("AVE_125_BX_50ns",{'file': 'SimGeneral.MixingModule.mix_POISSON_average_cfi','BX':50, 'B': (-12,3), 'N': 125})


### PR DESCRIPTION
Hi @slava77 , any objection to me adding this mixing scenario? I used it when making a ntuple for Evgueni, for fair comparison with PU50 and PU200 scenarios