### PR TITLE
revive support for HLT in the tracking ntuple

### DIFF
--- a/Validation/RecoTrack/plugins/TrackingNtuple.cc
+++ b/Validation/RecoTrack/plugins/TrackingNtuple.cc
@@ -688,6 +688,9 @@ private:
 
   std::string builderName_;
   const bool includeSeeds_;
+  const bool seedUniqueCheck_;
+  const bool seedAlgoDetect_;
+  std::vector<unsigned int> seedAlgos_;
   const bool includeTrackCandidates_;
   const bool addSeedCurvCov_;
   const bool includeAllHits_;
@@ -1369,8 +1372,10 @@ private:
   std::vector<unsigned int> see_algo;
   std::vector<unsigned short> see_stopReason;
   std::vector<unsigned short> see_nCands;
-  std::vector<int> see_trkIdx;
-  std::vector<int> see_tcandIdx;
+  std::vector<unsigned int> see_nTrk;
+  std::vector<unsigned int> see_nTCand;
+  std::vector<std::vector<unsigned int>> see_trkIdx;
+  std::vector<std::vector<unsigned int>> see_tcandIdx;
   std::vector<short> see_isTrue;
   std::vector<int> see_bestSimTrkIdx;
   std::vector<float> see_bestSimTrkShareFrac;
@@ -1454,6 +1459,10 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig)
       tpNStripStereoLayersToken_(consumes<edm::ValueMap<unsigned int>>(
           iConfig.getUntrackedParameter<edm::InputTag>("trackingParticleNstripstereolayers"))),
       includeSeeds_(iConfig.getUntrackedParameter<bool>("includeSeeds")),
+      seedUniqueCheck_(includeSeeds_ && iConfig.getUntrackedParameter<bool>("seedUniqueCheck")),
+      seedAlgoDetect_(includeSeeds_ && iConfig.getUntrackedParameter<bool>("seedAlgoDetect")),
+      seedAlgos_(seedAlgoDetect_ ? std::vector<unsigned int>()
+                                 : iConfig.getUntrackedParameter<std::vector<unsigned int>>("seedAlgos")),
       includeTrackCandidates_(iConfig.getUntrackedParameter<bool>("includeTrackCandidates")),
       addSeedCurvCov_(iConfig.getUntrackedParameter<bool>("addSeedCurvCov")),
       includeAllHits_(iConfig.getUntrackedParameter<bool>("includeAllHits")),
@@ -1475,6 +1484,37 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig)
     if (seedTokens_.size() != seedStopInfoTokens_.size()) {
       throw cms::Exception("Configuration") << "Got " << seedTokens_.size() << " seed collections, but "
                                             << seedStopInfoTokens_.size() << " track candidate collections";
+    }
+    if (seedAlgoDetect_) {
+      for (auto const& token : seedStopInfoTokens_) {
+        edm::EDConsumerBase::Labels labels;
+        labelsForToken(token, labels);
+
+        TString label = labels.module;
+        //format label to match algoName
+        label.ReplaceAll("seedTracks", "");
+        label.ReplaceAll("Seeds", "");
+        label.ReplaceAll("TrackCandidates", "");
+        label.ReplaceAll("muonSeeded", "muonSeededStep");
+        //for HLT seeds
+        label.ReplaceAll("FromPixelTracks", "");
+        label.ReplaceAll("PFLowPixel", "");
+        label.ReplaceAll("PFlowPixel", "");
+        label.ReplaceAll("hltIni", "ini");
+        label.ReplaceAll("hltHigh", "high");
+        label.ReplaceAll("hltDoubletRecovery", "pixelPairStep");
+        label.ReplaceAll("hltInputLST", "hltPixel");
+
+        int algo = reco::TrackBase::algoByName(label.Data());
+        if (algo == 0)
+          throw cms::Exception("LogicError") << "Failed to detect seed algo for collection " << labels.module << ":"
+                                             << labels.productInstance << " last transform is " << label;
+        seedAlgos_.push_back(algo);
+      }
+    } else {
+      if (seedAlgos_.size() != seedTokens_.size())
+        throw cms::Exception("Configuration")
+            << "Got " << seedTokens_.size() << " seed collections, but " << seedAlgos_.size() << " algo overrides";
     }
   }
   if (includeTrackCandidates_)
@@ -1964,9 +2004,12 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig)
     t->Branch("see_algo", &see_algo);
     t->Branch("see_stopReason", &see_stopReason);
     t->Branch("see_nCands", &see_nCands);
+    t->Branch("see_nTrk", &see_nTrk);
     t->Branch("see_trkIdx", &see_trkIdx);
-    if (includeTrackCandidates_)
+    if (includeTrackCandidates_) {
+      t->Branch("see_nTCand", &see_nTCand);
       t->Branch("see_tcandIdx", &see_tcandIdx);
+    }
     if (includeTrackingParticles_) {
       t->Branch("see_simTrkIdx", &see_simTrkIdx);
       t->Branch("see_simTrkShareFrac", &see_simTrkShareFrac);
@@ -2380,6 +2423,8 @@ void TrackingNtuple::clearVariables() {
   see_algo.clear();
   see_stopReason.clear();
   see_nCands.clear();
+  see_nTrk.clear();
+  see_nTCand.clear();
   see_trkIdx.clear();
   see_tcandIdx.clear();
   see_isTrue.clear();
@@ -3429,6 +3474,7 @@ void TrackingNtuple::fillSeeds(const edm::Event& iEvent,
   TSCBLBuilderNoMaterial tscblBuilder;
   for (size_t iColl = 0; iColl < seedTokens_.size(); ++iColl) {
     const auto& seedToken = seedTokens_[iColl];
+    const auto algo = seedAlgos_[iColl];
 
     edm::Handle<edm::View<reco::Track>> seedTracksHandle;
     iEvent.getByToken(seedToken, seedTracksHandle);
@@ -3469,28 +3515,17 @@ void TrackingNtuple::fillSeeds(const edm::Event& iEvent,
     reco::RecoToSimCollection recSimColl = associatorByHits.associateRecoToSim(seedTrackRefs, tpCollection);
     reco::SimToRecoCollection simRecColl = associatorByHits.associateSimToReco(seedTrackRefs, tpCollection);
 
-    TString label = labels.module;
-    //format label to match algoName
-    label.ReplaceAll("seedTracks", "");
-    label.ReplaceAll("Seeds", "");
-    label.ReplaceAll("muonSeeded", "muonSeededStep");
-    //for HLT seeds
-    label.ReplaceAll("FromPixelTracks", "");
-    label.ReplaceAll("PFLowPixel", "");
-    label.ReplaceAll("hltDoubletRecovery", "pixelPairStep");  //random choice
-    int algo = reco::TrackBase::algoByName(label.Data());
-
     edm::ProductID id = seedTracks[0].seedRef().id();
     const auto offset = see_fitok.size();
     auto inserted = seedCollToOffset.emplace(id, offset);
     if (!inserted.second)
       throw cms::Exception("Configuration")
           << "Trying to add seeds with ProductID " << id << " for a second time from collection " << labels.module
-          << ", seed algo " << label << ". Typically this is caused by a configuration problem.";
+          << ", seed algo " << algo << ". Typically this is caused by a configuration problem.";
     see_offset.push_back(offset);
 
-    LogTrace("TrackingNtuple") << "NEW SEED LABEL: " << label << " size: " << seedTracks.size() << " algo=" << algo
-                               << " ProductID " << id;
+    LogTrace("TrackingNtuple") << "NEW SEED LABEL: for " << labels.module << " size: " << seedTracks.size()
+                               << " algo=" << algo << " ProductID " << id;
 
     for (size_t iSeed = 0; iSeed < seedTrackRefs.size(); ++iSeed) {
       const auto& seedTrackRef = seedTrackRefs[iSeed];
@@ -3592,8 +3627,12 @@ void TrackingNtuple::fillSeeds(const edm::Event& iEvent,
         see_stateCurvCov.push_back(std::move(cov));
       }
 
-      see_trkIdx.push_back(-1);    // to be set correctly in fillTracks
-      see_tcandIdx.push_back(-1);  // to be set correctly in fillCandidates
+      // to be set correctly in fillTracks
+      see_nTrk.push_back(0);
+      see_nTCand.push_back(0);
+      see_trkIdx.push_back({});
+      see_tcandIdx.push_back({});
+
       if (includeTrackingParticles_) {
         see_simTrkIdx.push_back(tpIdx);
         see_simTrkShareFrac.push_back(sharedFraction);
@@ -3967,11 +4006,12 @@ void TrackingNtuple::fillTracks(const edm::RefToBaseVector<reco::Track>& tracks,
 
       const auto seedIndex = offset->second + itTrack->seedRef().key();
       trk_seedIdx.push_back(seedIndex);
-      if (see_trkIdx[seedIndex] != -1) {
+      if (seedUniqueCheck_ && see_nTrk[seedIndex] > 0) {
         throw cms::Exception("LogicError") << "Track index has already been set for seed " << seedIndex << " to "
-                                           << see_trkIdx[seedIndex] << "; was trying to set it to " << iTrack;
+                                           << see_trkIdx[seedIndex][0] << "; was trying to set it to " << iTrack;
       }
-      see_trkIdx[seedIndex] = iTrack;
+      see_nTrk[seedIndex]++;
+      see_trkIdx[seedIndex].push_back(iTrack);
     }
     trk_vtxIdx.push_back(-1);  // to be set correctly in fillVertices
     if (includeTrackingParticles_) {
@@ -4260,12 +4300,13 @@ void TrackingNtuple::fillCandidates(const edm::Handle<TrackCandidateCollection>&
 
       const auto seedIndex = offset->second + aCand.seedRef().key();
       tcand_seedIdx.push_back(seedIndex);
-      if (see_tcandIdx[seedIndex] != -1) {
+      if (seedUniqueCheck_ && see_nTCand[seedIndex] > 0) {
         throw cms::Exception("LogicError")
-            << "Track cand index has already been set for seed " << seedIndex << " to " << see_tcandIdx[seedIndex]
+            << "Track cand index has already been set for seed " << seedIndex << " to " << see_tcandIdx[seedIndex][0]
             << "; was trying to set it to " << iglobCand << " current " << iCand;
       }
-      see_tcandIdx[seedIndex] = iglobCand;
+      see_nTCand[seedIndex]++;
+      see_tcandIdx[seedIndex].push_back(iglobCand);
     }
     tcand_vtxIdx.push_back(-1);  // to be set correctly in fillVertices
     if (includeTrackingParticles_) {
@@ -4667,6 +4708,9 @@ void TrackingNtuple::fillDescriptions(edm::ConfigurationDescriptions& descriptio
   desc.addUntracked<std::string>("TTRHBuilder", "WithTrackAngle")
       ->setComment("currently not used: keep for possible future use");
   desc.addUntracked<bool>("includeSeeds", false);
+  desc.addOptionalUntracked<bool>("seedUniqueCheck", true);
+  desc.addOptionalUntracked<bool>("seedAlgoDetect", true);
+  desc.addOptionalUntracked<std::vector<unsigned int>>("seedAlgos");
   desc.addUntracked<bool>("includeTrackCandidates", false);
   desc.addUntracked<bool>("addSeedCurvCov", false);
   desc.addUntracked<bool>("includeAllHits", false);

--- a/Validation/RecoTrack/python/TrackValidation_cff.py
+++ b/Validation/RecoTrack/python/TrackValidation_cff.py
@@ -135,7 +135,7 @@ def _addSeedToTrackProducers(seedProducers,modDict):
     names = []
     task = cms.Task()
     for seed in seedProducers:
-        modName = "seedTracks"+seed
+        modName = ("seedTracks"+seed).replace(":", "MI")
         if modName not in modDict:
             mod = _trajectorySeedTracks.clone(src=seed)
             modDict[modName] = mod

--- a/Validation/RecoTrack/python/trackingNtuple_cff.py
+++ b/Validation/RecoTrack/python/trackingNtuple_cff.py
@@ -1,12 +1,10 @@
 import FWCore.ParameterSet.Config as cms
 
-from RecoLocalTracker.Configuration.RecoLocalTracker_cff import *
 from SimGeneral.TrackingAnalysis.simHitTPAssociation_cfi import *
 from SimTracker.TrackerHitAssociation.tpClusterProducer_cfi import *
 from SimTracker.TrackAssociatorProducers.quickTrackAssociatorByHits_cfi import *
 from RecoTracker.TransientTrackingRecHit.TTRHBuilders_cff import *
 from RecoLocalTracker.SiPixelRecHits.PixelCPEGeneric_cfi import *
-from RecoLocalTracker.Phase2TrackerRecHits.Phase2TrackerRecHits_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerTopology_cfi import *
 
 from Validation.RecoTrack.trackingNtuple_cfi import *
@@ -43,6 +41,9 @@ trackingNtuple.includeAllHits = _includeHits
 trackingNtuple.includeSeeds = _includeSeeds
 trackingNtuple.includeMVA = _includeMVA
 trackingNtuple.includeTrackingParticles = _includeTrackingParticles
+
+from Configuration.ProcessModifiers.trackingLST_cff import trackingLST
+trackingLST.toModify(trackingNtuple, seedUniqueCheck = False)
 
 def _filterForNtuple(lst):
     ret = []
@@ -86,6 +87,8 @@ trackingPhase2PU140.toModify(trackingNtuple, trackCandidates=[_seedProdToTrackCa
 trackingNtupleTask = cms.Task()
 # reproduce hits because they're not stored in RECO
 if _includeHits:
+    from RecoLocalTracker.Configuration.RecoLocalTracker_cff import siPixelRecHits,siStripMatchedRecHits
+    from RecoLocalTracker.Phase2TrackerRecHits.Phase2TrackerRecHits_cfi import siPhase2RecHits
     trackingNtupleTask.add(siPixelRecHits, siStripMatchedRecHits)
     _phase2_trackingNtupleTask = trackingNtupleTask.copy()
     _phase2_trackingNtupleTask.remove(siStripMatchedRecHits)


### PR DESCRIPTION
refresh/enable support for tracking ntuple with HLT
- this can be enabled on a corresponding (re)HLT workflow with `VALIDATION:@hltValidation` step present by adding `--customise Validation/RecoTrack/customiseTrackingNtuple.customiseTrackingNtupleHLT,Validation/RecoTrack/customiseTrackingNtuple.extendedContent`
- tested configurations (I checked they run on a PU input with 10 events and looked at the first and last variant cursorily):
    - Run-3 with tracking-only from `hltGetConfiguration --cff --mc --type GRun --paths HLTriggerFirstPath,MC_ReducedIterativeTracking_v25,HLTriggerFinalPath --unprescale --globaltag auto:phase1_2025_realistic /dev/CMSSW_15_0_0/GRun/V96` and then run `-s HLT:ReducedIterativeTracking,VALIDATION:@hltValidation`
    - `alpaka`
    - `alpaka,trackingLST`
    - `alpaka,trackingLST,seedingLST`
    - `alpaka,singleIterPatatrack,trackingLST`
    - `alpaka,singleIterPatatrack,trackingLST,seedingLST`

related updates in the ntuple:
- `see_{trk,tcand}Idx` are now vectors per seed allowing multiple tracks/cands per seed; `see_nTrk` and `see_nTCand` are added equal to the size of these vectors (useful in `TTree::Draw`, which has issues with vectors of vectors)
- rework `see_algo` setting: a few more patterns for auto-detection and an option to override manually per collection

related changes in LST:
- fill seedRef in the candidates
- fill stop infos per candidate collection (still dummy)

