### PR TITLE
[Test] Use T5 DNN Score for Duplicate Removal

### DIFF
--- a/RecoTracker/LSTCore/interface/QuintupletsSoA.h
+++ b/RecoTracker/LSTCore/interface/QuintupletsSoA.h
@@ -24,6 +24,7 @@ namespace lst {
                       SOA_COLUMN(char, isDup),         // duplicate flag
                       SOA_COLUMN(bool, tightCutFlag),  // tight pass to be a TC
                       SOA_COLUMN(bool, partOfPT5),
+                      SOA_COLUMN(float, dnnScore),
                       SOA_COLUMN(float, regressionRadius),
                       SOA_COLUMN(float, regressionCenterX),
                       SOA_COLUMN(float, regressionCenterY),

--- a/RecoTracker/LSTCore/interface/alpaka/Common.h
+++ b/RecoTracker/LSTCore/interface/alpaka/Common.h
@@ -59,7 +59,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
 
     // Common constants for both DNNs
     HOST_DEVICE_CONSTANT float kPhi_norm = kPi;
-    HOST_DEVICE_CONSTANT float kEtaSize = 0.25f;  // Bin size in eta.
+    HOST_DEVICE_CONSTANT float kEtaSize = 0.25f;         // Bin size in eta.
+    HOST_DEVICE_CONSTANT float kHighPtThreshold = 5.0f;  // 5 GeV
+    HOST_DEVICE_CONSTANT float kMaxEtaLimit = 2.5f;      // Last eta bin.
     constexpr unsigned int kPtBins = 2;
     constexpr unsigned int kEtaBins = 10;
 


### PR DESCRIPTION
Opening this to see if using the DNN score over chi-square sum gives an appreciable benefit in the CMSSW plots.

Benefit on standalone plots is small but noticeable:
<img width="400" height="400" alt="TC_base_0_0_eff_vxycoarse" src="https://github.com/user-attachments/assets/9b7bda96-caa9-47f8-94d0-ebfe7d56d9ae" />

Seems like there might be a small benefit?
<img width="333" height="415" alt="Screenshot 2025-09-08 at 2 30 55 PM" src="https://github.com/user-attachments/assets/36f36020-0f46-41f2-98f7-0f298fdef929" />

edit: Gonna close this for now, may re-open it in the future.