### PR TITLE
set T5 occupancy threshold at 100K

### DIFF
--- a/RecoTracker/LSTCore/interface/alpaka/Common.h
+++ b/RecoTracker/LSTCore/interface/alpaka/Common.h
@@ -44,6 +44,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
   HOST_DEVICE_CONSTANT float kWidthPS = 0.01;
   HOST_DEVICE_CONSTANT float kPt_betaMax = 7.0;
   HOST_DEVICE_CONSTANT int kNTripletThreshold = 1000;
+  HOST_DEVICE_CONSTANT int kNQuintupletThreshold = 100000;
   HOST_DEVICE_CONSTANT int kLogicalOTLayers = 11;  // logical OT layers are 1..11
   HOST_DEVICE_CONSTANT auto kMaxPLSHitBitsInHitsSoA = ::lst::kMaxPLSHitBitsInHitsSoA;
 

--- a/RecoTracker/LSTCore/src/alpaka/Quintuplet.h
+++ b/RecoTracker/LSTCore/src/alpaka/Quintuplet.h
@@ -2153,6 +2153,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
 
         if (dynamic_count == 0)
           continue;
+        if (dynamic_count > kNQuintupletThreshold)
+          dynamic_count = kNQuintupletThreshold;
 
         int nEligibleT5Modules = alpaka::atomicAdd(acc, &nEligibleT5Modulesx, 1, alpaka::hierarchy::Threads{});
         int nTotQ = alpaka::atomicAdd(acc, &nTotalQuintupletsx, dynamic_count, alpaka::hierarchy::Threads{});

--- a/RecoTracker/LSTCore/src/alpaka/Quintuplet.h
+++ b/RecoTracker/LSTCore/src/alpaka/Quintuplet.h
@@ -1871,6 +1871,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
 
             // Match inner Sg and Outer Sg
             int mIdx = alpaka::atomicAdd(acc, &matchCount, 1, alpaka::hierarchy::Threads{});
+            if (mIdx >= ranges.quintupletModuleOccupancy()[lowerModule1])
+              continue;
             unsigned int quintupletIndex = ranges.quintupletModuleIndices()[lowerModule1] + mIdx;
 
 #ifdef WARNINGS
@@ -1900,7 +1902,10 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
         }
 
         // Step 2: Parallel processing of triplet pairs
-        for (int i = flatThreadIdxXY; i < matchCount; i += flatThreadExtent) {
+        const int stage2Bound = matchCount < ranges.quintupletModuleOccupancy()[lowerModule1]
+                                    ? matchCount
+                                    : ranges.quintupletModuleOccupancy()[lowerModule1];
+        for (int i = flatThreadIdxXY; i < stage2Bound; i += flatThreadExtent) {
           unsigned int quintupletIndex = ranges.quintupletModuleIndices()[lowerModule1] + i;
           int innerTripletIndex = quintuplets.preAllocatedTripletIndices()[quintupletIndex][0];
           int outerTripletIndex = quintuplets.preAllocatedTripletIndices()[quintupletIndex][1];


### PR DESCRIPTION
somewhat rounded upper limit.

- Not seen in 200 ttbar PU events.
- happens in about 3% of QCD 2 TeV dijet events (Using Mario's sample originally from 16_1_X)