### PR TITLE
Switch compute capability from 7.0 to 8.0

### DIFF
--- a/RecoTracker/LSTCore/standalone/LST/Makefile
+++ b/RecoTracker/LSTCore/standalone/LST/Makefile
@@ -41,7 +41,7 @@ LIBS=$(LIB_CPU) $(LIB_CUDA) $(LIB_ROCM)
 #
 
 # Different architectures to optimize for
-GENCODE_CUDA := -gencode arch=compute_70,code=[sm_70,compute_70] -gencode arch=compute_89,code=[sm_89,compute_89]
+GENCODE_CUDA := -gencode arch=compute_80,code=[sm_80,compute_80] -gencode arch=compute_89,code=[sm_89,compute_89] -gencode arch=compute_90,code=[sm_90,compute_90]
 
 CXX                  = g++
 CXXFLAGS_CPU         = -march=native -mtune=native -Ofast -fno-reciprocal-math -fopenmp-simd -g -Wall -Woverloaded-virtual -fPIC -fopenmp -I..


### PR DESCRIPTION
CMSSW moved to CUDA 13, which drops support for compute capability 7.0. I switched it to 8.0, since cgpu-1 has a card with that compute capability (the A30).