### PR TITLE
speedup ExtendT5FromDupT5: fast skip for kT5DuplicateMinSharedHits == 8, refactor loops

### DIFF
--- a/RecoTracker/LSTCore/src/alpaka/Kernels.h
+++ b/RecoTracker/LSTCore/src/alpaka/Kernels.h
@@ -310,7 +310,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
 
       const float baseEta = __H2F(quintuplets.eta()[refT5Index]);
       const float basePhi = __H2F(quintuplets.phi()[refT5Index]);
-      const uint8_t baseStartLogicalLayer = quintuplets.logicalLayers()[refT5Index][0];
+      const uint8_t refStartLogicalLayer = quintuplets.logicalLayers()[refT5Index][0];
 
       // Hoist ref data once: hit indices and embedding read every candidate iteration otherwise.
       float refEmbed[Params_T5::kEmbed];
@@ -323,45 +323,69 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
       CMS_UNROLL_LOOP
       for (unsigned int h = 0; h < kRefHits; ++h)
         refHits[h] = quintuplets.hitIndices()[refT5Index][h];
+      auto refModuleIndex1 = quintuplets.lowerModuleIndices()[refT5Index][1];
 
       const int threadIndexFlat = alpaka::getIdx<alpaka::Block, alpaka::Threads>(acc)[0u];
       const int blockDimFlat = alpaka::getWorkDiv<alpaka::Block, alpaka::Threads>(acc)[0u];
 
       // Ref-starts-at-layer-1 special case: only ref's slot-1 module can host a valid candidate.
-      const bool restrictToRefSlot1 = (baseStartLogicalLayer == 1);
+      const bool restrictToRefSlot1 = (refStartLogicalLayer == 1);
       const uint16_t nEligibleT5Modules = ranges.nEligibleT5Modules();
       const int loopCount = restrictToRefSlot1 ? 1 : static_cast<int>(nEligibleT5Modules);
 
       for (int idx = threadIndexFlat; idx < loopCount; idx += blockDimFlat) {
-        const uint16_t lowerModuleIndex = restrictToRefSlot1 ? quintuplets.lowerModuleIndices()[refT5Index][1]
-                                                             : ranges.indicesOfEligibleT5Modules()[idx];
+        const uint16_t testModuleIndex =
+            restrictToRefSlot1 ? refModuleIndex1 : ranges.indicesOfEligibleT5Modules()[idx];
 
+        const short modSubdet = modules.subdets()[testModuleIndex];
+        const int testStartLogicalLayer =
+            static_cast<int>(modules.layers()[testModuleIndex]) + (modSubdet == Endcap ? 6 : 0);
         if (!restrictToRefSlot1) {
           // Skip same-starting-layer modules (logical = physical + 6 for endcap, see Triplet.h).
-          const short modSubdet = modules.subdets()[lowerModuleIndex];
-          const int moduleLogicalLayer =
-              static_cast<int>(modules.layers()[lowerModuleIndex]) + (modSubdet == Endcap ? 6 : 0);
-          if (moduleLogicalLayer == static_cast<int>(baseStartLogicalLayer))
+          if (testStartLogicalLayer == static_cast<int>(refStartLogicalLayer))
             continue;
-
+          if constexpr (kT5DuplicateMinSharedHits == 8) {
+            if (testStartLogicalLayer > refStartLogicalLayer && testModuleIndex != refModuleIndex1)
+              continue;
+          }
           // Module-level eta/phi pre-cut; margin covers per-T5 window plus T5-vs-module spread.
-          if (alpaka::math::abs(acc, baseEta - modules.eta()[lowerModuleIndex]) > 0.3f)
+          if (alpaka::math::abs(acc, baseEta - modules.eta()[testModuleIndex]) > 0.3f)
             continue;
-          if (alpaka::math::abs(acc, cms::alpakatools::deltaPhi(acc, basePhi, modules.phi()[lowerModuleIndex])) > 0.5f)
+          if (alpaka::math::abs(acc, cms::alpakatools::deltaPhi(acc, basePhi, modules.phi()[testModuleIndex])) > 0.5f)
             continue;
         }
 
-        const int firstQuintupletInModule = ranges.quintupletModuleIndices()[lowerModuleIndex];
+        const int firstQuintupletInModule = ranges.quintupletModuleIndices()[testModuleIndex];
         if (firstQuintupletInModule == -1)
           continue;
 
-        const unsigned int nQuintupletsInModule = quintupletsOccupancy.nQuintuplets()[lowerModuleIndex];
+        const unsigned int nQuintupletsInModule = quintupletsOccupancy.nQuintuplets()[testModuleIndex];
 
         for (unsigned int quintupletOffset = 0; quintupletOffset < nQuintupletsInModule; ++quintupletOffset) {
           const unsigned int testT5Index = firstQuintupletInModule + quintupletOffset;
           if (testT5Index == refT5Index)
             continue;
 
+          if constexpr (kT5DuplicateMinSharedHits == 8) {
+            // most frequent (leave the rare case for the full check)
+            if (refHits[kRefHits - 1] != quintuplets.hitIndices()[testT5Index][kRefHits - 1]) {
+              bool hitMiss = false;
+              int refOffset = 2;
+              int testOffset = 0;
+              if (testStartLogicalLayer < refStartLogicalLayer) {
+                refOffset = 0;
+                testOffset = 2;
+              }
+              for (unsigned int h = 0; h < kRefHits - 2; ++h) {
+                if (refHits[h + refOffset] != quintuplets.hitIndices()[testT5Index][h + testOffset]) {
+                  hitMiss = true;
+                  break;
+                }
+              }
+              if (hitMiss)
+                continue;
+            }
+          }
           // Per-T5 eta/phi window.
           const float candidateEta = __H2F(quintuplets.eta()[testT5Index]);
           if (alpaka::math::abs(acc, baseEta - candidateEta) > 0.1f)

--- a/RecoTracker/LSTCore/src/alpaka/Kernels.h
+++ b/RecoTracker/LSTCore/src/alpaka/Kernels.h
@@ -284,6 +284,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
     static constexpr unsigned int kPackedIndexMask = 0xFFFFFFF;
     static constexpr unsigned int kPackedSlotMask = 0xF;
     static constexpr int kT5DuplicateMinSharedHits = 8;
+    static constexpr unsigned int kMaxCompatModules = 40;
 
     ALPAKA_FN_ACC void operator()(Acc1D const& acc,
                                   ModulesConst modules,
@@ -292,6 +293,10 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
                                   QuintupletsOccupancyConst quintupletsOccupancy) const {
       // Best candidate per OT logical layer (1..11), packed score|index|slot.
       uint64_t* sharedBestPacked = alpaka::declareSharedVar<uint64_t[lst::kLogicalOTLayers], __COUNTER__>(acc);
+      unsigned int* testModuleStart = alpaka::declareSharedVar<unsigned int[kMaxCompatModules], __COUNTER__>(acc);
+      unsigned int* testModuleLength = alpaka::declareSharedVar<unsigned int[kMaxCompatModules], __COUNTER__>(acc);
+      unsigned int& testModules = alpaka::declareSharedVar<unsigned int, __COUNTER__>(acc);
+      uint8_t* testModuleLogicalLayer = alpaka::declareSharedVar<uint8_t[kMaxCompatModules], __COUNTER__>(acc);
 
       // One block per T5 in 1D; block index = ref T5 index.
       const unsigned int refT5Index = alpaka::getIdx<alpaka::Grid, alpaka::Blocks>(acc)[0u];
@@ -305,6 +310,11 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
         for (int logicalLayerBin = 0; logicalLayerBin < lst::kLogicalOTLayers; ++logicalLayerBin) {
           sharedBestPacked[logicalLayerBin] = 0;
         }
+        for (unsigned int iM = 0; iM < kMaxCompatModules; ++iM) {
+          testModuleStart[iM] = 0;
+          testModuleLength[iM] = 0;
+        }
+        testModules = 0;
       }
       alpaka::syncBlockThreads(acc);
 
@@ -325,24 +335,24 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
         refHits[h] = quintuplets.hitIndices()[refT5Index][h];
       auto refModuleIndex1 = quintuplets.lowerModuleIndices()[refT5Index][1];
 
-      const int threadIndexFlat = alpaka::getIdx<alpaka::Block, alpaka::Threads>(acc)[0u];
-      const int blockDimFlat = alpaka::getWorkDiv<alpaka::Block, alpaka::Threads>(acc)[0u];
+      const auto threadIndexFlat = alpaka::getIdx<alpaka::Block, alpaka::Threads>(acc)[0u];
+      const auto blockDimFlat = alpaka::getWorkDiv<alpaka::Block, alpaka::Threads>(acc)[0u];
 
       // Ref-starts-at-layer-1 special case: only ref's slot-1 module can host a valid candidate.
       const bool restrictToRefSlot1 = (refStartLogicalLayer == 1);
       const uint16_t nEligibleT5Modules = ranges.nEligibleT5Modules();
-      const int loopCount = restrictToRefSlot1 ? 1 : static_cast<int>(nEligibleT5Modules);
+      const unsigned int loopCount = restrictToRefSlot1 ? 1 : nEligibleT5Modules;
 
-      for (int idx = threadIndexFlat; idx < loopCount; idx += blockDimFlat) {
+      for (auto idx = threadIndexFlat; idx < loopCount; idx += blockDimFlat) {
         const uint16_t testModuleIndex =
             restrictToRefSlot1 ? refModuleIndex1 : ranges.indicesOfEligibleT5Modules()[idx];
 
         const short modSubdet = modules.subdets()[testModuleIndex];
-        const int testStartLogicalLayer =
-            static_cast<int>(modules.layers()[testModuleIndex]) + (modSubdet == Endcap ? 6 : 0);
+        const uint8_t testStartLogicalLayer =
+            static_cast<uint8_t>(modules.layers()[testModuleIndex]) + (modSubdet == Endcap ? 6 : 0);
         if (!restrictToRefSlot1) {
           // Skip same-starting-layer modules (logical = physical + 6 for endcap, see Triplet.h).
-          if (testStartLogicalLayer == static_cast<int>(refStartLogicalLayer))
+          if (testStartLogicalLayer == refStartLogicalLayer)
             continue;
           if constexpr (kT5DuplicateMinSharedHits == 8) {
             if (testStartLogicalLayer > refStartLogicalLayer && testModuleIndex != refModuleIndex1)
@@ -360,9 +370,24 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
           continue;
 
         const unsigned int nQuintupletsInModule = quintupletsOccupancy.nQuintuplets()[testModuleIndex];
-
-        for (unsigned int quintupletOffset = 0; quintupletOffset < nQuintupletsInModule; ++quintupletOffset) {
-          const unsigned int testT5Index = firstQuintupletInModule + quintupletOffset;
+        unsigned int iTestModule = alpaka::atomicAdd(acc, &testModules, 1u, alpaka::hierarchy::Threads{});
+        if (iTestModule >= kMaxCompatModules) {
+#ifdef WARNINGS
+          printf("ERROR! Compatible module excess in ExtendT5FromDupT5: now at %d\n", iTestModule);
+#endif
+        } else {
+          testModuleStart[iTestModule] = firstQuintupletInModule;
+          testModuleLength[iTestModule] = nQuintupletsInModule;
+          testModuleLogicalLayer[iTestModule] = testStartLogicalLayer;
+        }
+      }
+      alpaka::syncBlockThreads(acc);
+      auto const tModuleMax = testModules < kMaxCompatModules ? testModules : kMaxCompatModules;
+      for (unsigned int tModule = 0; tModule < tModuleMax; ++tModule) {
+        auto const testT5Min = testModuleStart[tModule] + threadIndexFlat;
+        auto const testT5Max = testModuleStart[tModule] + testModuleLength[tModule];
+        auto const testModuleLayer = testModuleLogicalLayer[tModule];
+        for (auto testT5Index = testT5Min; testT5Index < testT5Max; testT5Index += blockDimFlat) {
           if (testT5Index == refT5Index)
             continue;
 
@@ -372,7 +397,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::lst {
               bool hitMiss = false;
               int refOffset = 2;
               int testOffset = 0;
-              if (testStartLogicalLayer < refStartLogicalLayer) {
+              if (testModuleLayer < refStartLogicalLayer) {
                 refOffset = 0;
                 testOffset = 2;
               }


### PR DESCRIPTION
in the 17.0.0pre2 relval GEN-SIM c78d2621-e964-4ec4-baf0-31eb50b6e2bd.root LS:190 had some slow events (4th:5404 7th:5407); a large fraction of time was in the `ExtendT5FromDupT5` kernel

For the case with `kT5DuplicateMinSharedHits == 8` there is apparently a shortcut in the logic where a large fraction of modules or T5s can be skipped early.

CPU backend, baseline -> this PR: 5404:{37 s -> 4 s}, 5407:{550 s -> 63 s}.
I checked in printouts of `tryExtendT5` arguments that the same calls are made in both cases (using just the 1st event of the slow set in LS:190).

Additionally, I noticed that the thread use for cases with modules with many events is suboptimal (parallelizes only over modules; as a result only one thread per warp does any work in majority of cases). This part was refactored to collect compatible modules first and then parallelize the loop over T5s rather than the modules.

Performance measurements:
comparing baseline/1700pre2+#260 -> [b2c0404](https://github.com/SegmentLinking/cmssw/pull/262/commits/b2c0404f3cfed1f37784b5a1a5721103297f503d) -> [9810ef4](https://github.com/SegmentLinking/cmssw/pull/262/commits/9810ef47bb3b541b520835ccd927d9334de553e1)
CPU side (using igprof):
- 10 events from the slow relval 2TeV job (per event): 56.6 s -> 7.0 s -> 6.9 s
- ttbar PU200 benchmark (per event, over 100 evts): 7.70 ms -> 6.60 ms -> 7.2 ms

GPU side is less impressive (times via nsys):
- 10 events from the slow relval 2TeV job (per event): 3.83 s -> 2.45 s -> 0.228 s
    - the slowest event: 33.8 s -> 21.6 s -> 2.12 s
- ttbar PU200 benchmark (per event, over 100 evts): 0.179 ms -> 0.198 ms -> 0.130 ms

So, overall, the ttbar PU200 is a bit faster now both CPU and GPU and the 2TeV is about 10 times faster for both CPU and GPU.